### PR TITLE
Convert to Flask WSGI service with Robinhood support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,29 @@
-# Alpaca credentials (from 5thstreetcapital app)
+# === Broker Selection ===
+ENABLED_BROKERS=robinhood,alpaca
+DEFAULT_BROKER=robinhood
+
+# === Robinhood ===
+RH_USER=your_email@example.com
+RH_PASS=your_password
+RH_TOTP_SECRET=              # Base32 secret from authenticator app setup
+RH_DEVICE_TOKEN=             # Optional: fixed device UUID
+RH_PICKLE_NAME=taipei_session
+
+# === Alpaca (from 5thstreetcapital app) ===
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=
 ALPACA_PAPER=true
 
-# Allocation Runtime Service
+# === Runtime Service ===
 RUNTIME_SERVICE_URL=https://route-runtime-service.netlify.app/api
 
-# Engine settings
+# === Engine ===
 POLL_INTERVAL_SECONDS=30
 DRY_RUN=true
+ENGINE_ENABLED=true
+ENGINE_BROKER=alpaca
+
+# === Flask ===
+FLASK_DEBUG=false
+SECRET_KEY=change-me-in-production
+PORT=10000

--- a/README.md
+++ b/README.md
@@ -1,60 +1,99 @@
 # Allocation Engine 2.0
 
-Trade execution engine backed by **Alpaca** that reads desired orders from the [allocation-runtime-service](https://github.com/IamJasonBian/allocation-runtime-service) and reconciles them against live broker state.
+Flask API service for portfolio monitoring and trade execution across **Robinhood** and **Alpaca** brokers. Deploys on Render via gunicorn.
 
 ## How it works
 
 1. **Read** — Fetches desired orders from the runtime service (`/api/orders`)
-2. **Reconcile** — Diffs desired state against Alpaca open orders & positions
-3. **Execute** — Cancels stale orders and submits new ones via Alpaca API
+2. **Reconcile** — Diffs desired state against broker open orders & positions
+3. **Execute** — Cancels stale orders and submits new ones
+
+The background engine loop runs alongside the Flask API in a daemon thread.
 
 ## Setup
 
 ```bash
 pip install -r requirements.txt
 cp .env.example .env
-# Fill in Alpaca keys from the 5thstreetcapital app
+# Fill in broker credentials
 ```
 
 ## Usage
 
+### Production (Render / gunicorn)
+
 ```bash
-# Check account status + desired vs actual orders
-python main.py status
-
-# Run a single reconciliation tick
-python main.py once
-
-# Run continuous loop (polls every POLL_INTERVAL_SECONDS)
-python main.py run
+gunicorn app.wsgi:application
 ```
 
-## Environment variables
+### Local development
+
+```bash
+# Flask dev server
+python main.py serve
+
+# CLI: check account status
+python main.py --broker robinhood status
+python main.py --broker alpaca status
+
+# CLI: single reconciliation tick
+python main.py --broker alpaca once
+
+# CLI: continuous loop
+python main.py --broker alpaca run
+```
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/health` | Service status + config |
+| GET | `/api/account[/<broker>]` | Account summary (equity, cash, buying power) |
+| GET | `/api/positions[/<broker>]` | Open positions with P&L |
+| GET | `/api/orders[/<broker>]` | Open orders |
+| GET | `/api/portfolio[/<broker>]` | Account + positions combined |
+| GET | `/api/engine/status` | Background engine loop status |
+| POST | `/api/engine/tick` | Manually trigger reconciliation |
+
+Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca` or `/robinhood` to target a specific broker.
+
+## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ALPACA_API_KEY` | Alpaca API key (from 5thstreetcapital) | required |
-| `ALPACA_SECRET_KEY` | Alpaca secret key | required |
-| `ALPACA_PAPER` | Use paper trading | `true` |
+| `ENABLED_BROKERS` | Comma-separated broker list | `robinhood` |
+| `DEFAULT_BROKER` | Default broker for API | `robinhood` |
+| `RH_USER` | Robinhood email | required for RH |
+| `RH_PASS` | Robinhood password | required for RH |
+| `RH_TOTP_SECRET` | Base32 TOTP secret for automated MFA | required for RH |
+| `ALPACA_API_KEY` | Alpaca API key | required for Alpaca |
+| `ALPACA_SECRET_KEY` | Alpaca secret key | required for Alpaca |
+| `ALPACA_PAPER` | Use Alpaca paper trading | `true` |
 | `RUNTIME_SERVICE_URL` | Runtime service base URL | `https://route-runtime-service.netlify.app/api` |
-| `POLL_INTERVAL_SECONDS` | Loop interval | `30` |
+| `POLL_INTERVAL_SECONDS` | Engine loop interval | `30` |
 | `DRY_RUN` | Log orders without submitting | `true` |
+| `ENGINE_ENABLED` | Run background engine loop | `true` |
+| `ENGINE_BROKER` | Broker for engine reconciliation | `alpaca` |
+| `PORT` | Server port | `10000` |
 
 ## Architecture
 
 ```
 allocation-runtime-service (read-only API)
         │
-        │  GET /api/orders  (desired order set)
+        │  GET /api/orders
         ▼
-┌─────────────────────┐
-│  allocation-engine   │
-│  2.0                 │
-│                      │
-│  reconcile desired   │
-│  vs Alpaca state     │
-└────────┬────────────┘
-         │  submit / cancel
-         ▼
-    Alpaca Trading API
+┌────────────────────────┐
+│  allocation-engine 2.0 │
+│  (Flask + gunicorn)    │
+│                        │
+│  ┌──────────────────┐  │   GET /api/positions/robinhood
+│  │ Background Engine │  │   GET /api/account/alpaca
+│  │ (daemon thread)   │  │   ...
+│  └──────────────────┘  │
+│                        │
+│  ┌─────────┐ ┌──────┐ │
+│  │Robinhood│ │Alpaca│ │
+│  └─────────┘ └──────┘ │
+└────────────────────────┘
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,29 @@
+"""Flask app factory for Allocation Engine 2.0."""
+
+import logging
+from flask import Flask
+from flask_cors import CORS
+
+from app.config import Config
+from app.background import start_engine_thread
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s  %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
+def create_app(config_class=Config):
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    CORS(app)
+
+    from app.api import register_blueprints
+    register_blueprints(app)
+
+    if app.config.get("ENGINE_ENABLED", True):
+        start_engine_thread(app)
+
+    return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,11 @@
+def register_blueprints(app):
+    from app.api.health import bp as health_bp
+    from app.api.account import bp as account_bp
+    from app.api.positions import bp as positions_bp
+    from app.api.orders import bp as orders_bp
+    from app.api.portfolio import bp as portfolio_bp
+    from app.api.engine_api import bp as engine_bp
+
+    for blueprint in [health_bp, account_bp, positions_bp, orders_bp,
+                      portfolio_bp, engine_bp]:
+        app.register_blueprint(blueprint, url_prefix="/api")

--- a/app/api/account.py
+++ b/app/api/account.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, jsonify, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("account", __name__)
+
+
+@bp.route("/account")
+@bp.route("/account/<broker_name>")
+def account(broker_name=None):
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        data = broker.account()
+        return jsonify({"broker": broker_name, **data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/engine_api.py
+++ b/app/api/engine_api.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, jsonify
+from app.background import get_engine_status, trigger_tick
+
+bp = Blueprint("engine", __name__)
+
+
+@bp.route("/engine/status")
+def engine_status():
+    return jsonify(get_engine_status())
+
+
+@bp.route("/engine/tick", methods=["POST"])
+def engine_tick():
+    result = trigger_tick()
+    return jsonify(result)

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+from flask import Blueprint, jsonify, current_app
+
+bp = Blueprint("health", __name__)
+
+
+@bp.route("/health")
+def health():
+    config = current_app.config
+    return jsonify({
+        "status": "ok",
+        "service": "allocation-engine-2.0",
+        "version": "2.0.0",
+        "enabled_brokers": config["ENABLED_BROKERS"],
+        "default_broker": config["DEFAULT_BROKER"],
+        "engine_enabled": config["ENGINE_ENABLED"],
+        "dry_run": config["DRY_RUN"],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })

--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, jsonify, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("orders", __name__)
+
+
+@bp.route("/orders")
+@bp.route("/orders/<broker_name>")
+def orders(broker_name=None):
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        data = broker.open_orders()
+        return jsonify({"broker": broker_name, "count": len(data), "orders": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, jsonify, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("portfolio", __name__)
+
+
+@bp.route("/portfolio")
+@bp.route("/portfolio/<broker_name>")
+def portfolio(broker_name=None):
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        acct = broker.account()
+        pos = broker.positions()
+        return jsonify({
+            "broker": broker_name,
+            "equity": acct.get("equity"),
+            "cash": acct.get("cash"),
+            "buying_power": acct.get("buying_power"),
+            "portfolio_value": acct.get("portfolio_value"),
+            "positions": pos,
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/positions.py
+++ b/app/api/positions.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, jsonify, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("positions", __name__)
+
+
+@bp.route("/positions")
+@bp.route("/positions/<broker_name>")
+def positions(broker_name=None):
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        data = broker.positions()
+        return jsonify({"broker": broker_name, "count": len(data), "positions": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/background.py
+++ b/app/background.py
@@ -1,0 +1,75 @@
+"""Background engine thread — runs reconciliation loop alongside Flask."""
+
+import threading
+import time
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+_engine_thread = None
+_engine_status = {
+    "running": False,
+    "last_tick": None,
+    "tick_count": 0,
+    "last_error": None,
+    "dry_run": True,
+}
+_tick_event = threading.Event()
+
+
+def start_engine_thread(app):
+    """Start the background reconciliation loop in a daemon thread."""
+    global _engine_thread
+
+    if _engine_thread and _engine_thread.is_alive():
+        return
+
+    def _loop():
+        with app.app_context():
+            from app.brokers import get_broker
+            from app.engine import AllocationEngine
+            from app.runtime_client import RuntimeClient
+
+            config = app.config
+            broker = get_broker(config["ENGINE_BROKER"])
+            runtime = RuntimeClient(config["RUNTIME_SERVICE_URL"])
+            engine = AllocationEngine(
+                trader=broker,
+                runtime=runtime,
+                dry_run=config["DRY_RUN"],
+            )
+
+            _engine_status["running"] = True
+            _engine_status["dry_run"] = config["DRY_RUN"]
+            interval = config["POLL_INTERVAL_SECONDS"]
+
+            log.info("Background engine started (interval=%ds, dry_run=%s, broker=%s)",
+                     interval, config["DRY_RUN"], config["ENGINE_BROKER"])
+
+            while True:
+                try:
+                    engine.tick()
+                    _engine_status["last_tick"] = datetime.now(timezone.utc).isoformat()
+                    _engine_status["tick_count"] += 1
+                    _engine_status["last_error"] = None
+                except Exception as e:
+                    log.exception("Engine tick error")
+                    _engine_status["last_error"] = str(e)
+
+                # Wait for interval, but wake early if manual tick requested
+                _tick_event.wait(timeout=interval)
+                _tick_event.clear()
+
+    _engine_thread = threading.Thread(target=_loop, daemon=True, name="engine-loop")
+    _engine_thread.start()
+
+
+def get_engine_status() -> dict:
+    return dict(_engine_status)
+
+
+def trigger_tick() -> dict:
+    """Wake the engine thread to run an immediate tick."""
+    _tick_event.set()
+    return {"triggered": True, "status": get_engine_status()}

--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -1,0 +1,36 @@
+"""Broker registry — lazy-creates and caches broker clients by name."""
+
+from app.brokers.base import BrokerClient
+
+_broker_cache: dict[str, BrokerClient] = {}
+
+
+def get_broker(name: str) -> BrokerClient:
+    """Get or create a broker client by name ('alpaca' or 'robinhood')."""
+    if name in _broker_cache:
+        return _broker_cache[name]
+
+    from flask import current_app
+    config = current_app.config
+
+    if name == "alpaca":
+        from app.brokers.alpaca_client import AlpacaTrader
+        client = AlpacaTrader(
+            api_key=config["ALPACA_API_KEY"],
+            secret_key=config["ALPACA_SECRET_KEY"],
+            paper=config["ALPACA_PAPER"],
+        )
+    elif name == "robinhood":
+        from app.brokers.robinhood_client import RobinhoodTrader
+        client = RobinhoodTrader(
+            email=config["RH_USER"],
+            password=config["RH_PASS"],
+            totp_secret=config.get("RH_TOTP_SECRET", ""),
+            device_token=config.get("RH_DEVICE_TOKEN", ""),
+            pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
+        )
+    else:
+        raise ValueError(f"Unknown broker: {name}")
+
+    _broker_cache[name] = client
+    return client

--- a/app/brokers/alpaca_client.py
+++ b/app/brokers/alpaca_client.py
@@ -1,0 +1,123 @@
+"""Alpaca trading client — wraps alpaca-py for order submission and account info."""
+
+import logging
+from alpaca.trading.client import TradingClient
+from alpaca.trading.requests import (
+    LimitOrderRequest,
+    MarketOrderRequest,
+    StopLimitOrderRequest,
+    StopOrderRequest,
+)
+from alpaca.trading.enums import OrderSide, TimeInForce
+from alpaca.common.exceptions import APIError
+
+log = logging.getLogger(__name__)
+
+SYMBOL_MAP = {
+    "BTC": "BTC/USD",
+    "ETH": "ETH/USD",
+}
+
+
+def _map_symbol(symbol: str) -> str:
+    return SYMBOL_MAP.get(symbol, symbol)
+
+
+class AlpacaTrader:
+    def __init__(self, api_key: str, secret_key: str, paper: bool = True):
+        self.client = TradingClient(api_key, secret_key, paper=paper)
+
+    # -- account / positions ------------------------------------------------
+
+    def account(self) -> dict:
+        acct = self.client.get_account()
+        return {
+            "equity": float(acct.equity),
+            "cash": float(acct.cash),
+            "buying_power": float(acct.buying_power),
+            "portfolio_value": float(acct.portfolio_value),
+        }
+
+    def positions(self) -> list[dict]:
+        return [
+            {
+                "symbol": p.symbol,
+                "qty": float(p.qty),
+                "side": p.side,
+                "market_value": float(p.market_value),
+                "avg_entry": float(p.avg_entry_price),
+                "unrealized_pl": float(p.unrealized_pl),
+                "unrealized_pl_pct": float(p.unrealized_plpc),
+            }
+            for p in self.client.get_all_positions()
+        ]
+
+    def open_orders(self) -> list[dict]:
+        return [
+            {
+                "id": str(o.id),
+                "symbol": o.symbol,
+                "side": o.side.value,
+                "qty": float(o.qty) if o.qty else None,
+                "type": o.type.value,
+                "limit_price": float(o.limit_price) if o.limit_price else None,
+                "stop_price": float(o.stop_price) if o.stop_price else None,
+                "status": o.status.value,
+            }
+            for o in self.client.get_orders()
+        ]
+
+    # -- order submission ---------------------------------------------------
+
+    def submit_order(self, order: dict) -> dict | None:
+        symbol = _map_symbol(order["symbol"])
+        side = OrderSide.BUY if order["side"] == "BUY" else OrderSide.SELL
+        qty = float(order["quantity"])
+        otype = order.get("order_type", "market").lower()
+        limit_px = order.get("limit_price")
+        stop_px = order.get("stop_price")
+
+        try:
+            if otype == "limit" and limit_px is not None:
+                req = LimitOrderRequest(
+                    symbol=symbol, qty=qty, side=side,
+                    limit_price=float(limit_px), time_in_force=TimeInForce.GTC,
+                )
+            elif otype == "stop" and stop_px is not None:
+                req = StopOrderRequest(
+                    symbol=symbol, qty=qty, side=side,
+                    stop_price=float(stop_px), time_in_force=TimeInForce.GTC,
+                )
+            elif otype == "stop_limit" and limit_px and stop_px:
+                req = StopLimitOrderRequest(
+                    symbol=symbol, qty=qty, side=side,
+                    limit_price=float(limit_px), stop_price=float(stop_px),
+                    time_in_force=TimeInForce.GTC,
+                )
+            else:
+                req = MarketOrderRequest(
+                    symbol=symbol, qty=qty, side=side,
+                    time_in_force=TimeInForce.GTC,
+                )
+
+            result = self.client.submit_order(req)
+            log.info("Order submitted: %s %s %s @ %s -> %s",
+                     side.value, qty, symbol, limit_px or "MKT", result.id)
+            return {
+                "id": str(result.id),
+                "symbol": result.symbol,
+                "status": result.status.value,
+            }
+
+        except APIError as e:
+            log.error("Alpaca API error submitting %s %s %s: %s",
+                      side.value, qty, symbol, e)
+            return None
+
+    def cancel_all(self):
+        self.client.cancel_orders()
+        log.info("All open orders cancelled")
+
+    def cancel_order(self, order_id: str):
+        self.client.cancel_order_by_id(order_id)
+        log.info("Cancelled order %s", order_id)

--- a/app/brokers/base.py
+++ b/app/brokers/base.py
@@ -1,0 +1,36 @@
+"""Abstract broker interface — all broker implementations must satisfy this protocol."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BrokerClient(Protocol):
+    """Interface that all broker implementations must satisfy."""
+
+    def account(self) -> dict:
+        """Return account summary: equity, cash, buying_power, portfolio_value."""
+        ...
+
+    def positions(self) -> list[dict]:
+        """Return list of position dicts with standardized keys:
+        symbol, qty, side, market_value, avg_entry, unrealized_pl, unrealized_pl_pct
+        """
+        ...
+
+    def open_orders(self) -> list[dict]:
+        """Return list of open order dicts with standardized keys:
+        id, symbol, side, qty, type, limit_price, stop_price, status
+        """
+        ...
+
+    def submit_order(self, order: dict) -> dict | None:
+        """Submit an order. Returns order confirmation dict or None on failure."""
+        ...
+
+    def cancel_order(self, order_id: str) -> None:
+        """Cancel a specific order by ID."""
+        ...
+
+    def cancel_all(self) -> None:
+        """Cancel all open orders."""
+        ...

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -1,0 +1,192 @@
+"""Robinhood trading client — wraps robin-stocks with server-side TOTP auth."""
+
+import logging
+import robin_stocks.robinhood as rh
+import pyotp
+
+log = logging.getLogger(__name__)
+
+# Cache instrument URL -> symbol to avoid repeated API calls
+_instrument_cache: dict[str, str] = {}
+
+
+def _symbol_from_instrument(instrument_url: str) -> str:
+    """Resolve an instrument URL to a ticker symbol, with caching."""
+    if instrument_url in _instrument_cache:
+        return _instrument_cache[instrument_url]
+    try:
+        data = rh.stocks.get_instrument_by_url(instrument_url)
+        symbol = data.get("symbol", "UNKNOWN") if data else "UNKNOWN"
+    except Exception:
+        symbol = "UNKNOWN"
+    _instrument_cache[instrument_url] = symbol
+    return symbol
+
+
+class RobinhoodTrader:
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        totp_secret: str = "",
+        device_token: str = "",
+        pickle_name: str = "taipei_session",
+    ):
+        self.email = email
+        self.password = password
+        self.totp_secret = totp_secret
+        self.device_token = device_token
+        self.pickle_name = pickle_name
+        self._authenticated = False
+        self._login()
+
+    def _login(self):
+        """Authenticate with Robinhood using stored session or fresh TOTP login."""
+        mfa_code = None
+        if self.totp_secret:
+            totp = pyotp.TOTP(self.totp_secret)
+            mfa_code = totp.now()
+
+        kwargs = {
+            "store_session": True,
+            "pickle_name": self.pickle_name,
+        }
+        if mfa_code:
+            kwargs["mfa_code"] = mfa_code
+        if self.device_token:
+            kwargs["device_token"] = self.device_token
+
+        try:
+            result = rh.login(self.email, self.password, **kwargs)
+            if result:
+                self._authenticated = True
+                log.info("Robinhood login successful for %s", self.email)
+            else:
+                log.error("Robinhood login returned empty result")
+        except Exception as e:
+            log.error("Robinhood login failed: %s", e)
+            raise
+
+    def _ensure_auth(self):
+        """Re-authenticate if session has expired."""
+        if not self._authenticated:
+            self._login()
+            return
+        try:
+            rh.profiles.load_account_profile()
+        except Exception:
+            log.warning("Robinhood session expired, re-authenticating...")
+            self._authenticated = False
+            self._login()
+
+    # -- account / positions ------------------------------------------------
+
+    def account(self) -> dict:
+        self._ensure_auth()
+        profile = rh.profiles.load_account_profile()
+        portfolio = rh.profiles.load_portfolio_profile()
+        return {
+            "equity": float(portfolio.get("equity", 0)),
+            "cash": float(profile.get("cash", 0)),
+            "buying_power": float(profile.get("buying_power", 0)),
+            "portfolio_value": float(portfolio.get("market_value", 0)),
+        }
+
+    def positions(self) -> list[dict]:
+        self._ensure_auth()
+        raw = rh.account.get_all_positions()
+        result = []
+        for pos in raw:
+            qty = float(pos.get("quantity", 0))
+            if qty == 0:
+                continue
+
+            symbol = _symbol_from_instrument(pos.get("instrument", ""))
+            avg_buy = float(pos.get("average_buy_price", 0))
+
+            try:
+                quote = rh.stocks.get_latest_price(symbol)
+                current_price = float(quote[0]) if quote and quote[0] else avg_buy
+            except Exception:
+                current_price = avg_buy
+
+            market_value = qty * current_price
+            cost_basis = qty * avg_buy
+            unrealized_pl = market_value - cost_basis
+            unrealized_pl_pct = unrealized_pl / cost_basis if cost_basis > 0 else 0.0
+
+            result.append({
+                "symbol": symbol,
+                "qty": qty,
+                "side": "long",
+                "market_value": round(market_value, 2),
+                "avg_entry": avg_buy,
+                "unrealized_pl": round(unrealized_pl, 2),
+                "unrealized_pl_pct": round(unrealized_pl_pct, 4),
+            })
+        return result
+
+    def open_orders(self) -> list[dict]:
+        self._ensure_auth()
+        raw = rh.orders.get_all_open_stock_orders()
+        result = []
+        for o in raw:
+            symbol = _symbol_from_instrument(o.get("instrument", ""))
+            result.append({
+                "id": o.get("id"),
+                "symbol": symbol,
+                "side": o.get("side", "").upper(),
+                "qty": float(o.get("quantity", 0)),
+                "type": o.get("type", "market"),
+                "limit_price": float(o["price"]) if o.get("price") else None,
+                "stop_price": float(o["stop_price"]) if o.get("stop_price") else None,
+                "status": o.get("state", "unknown"),
+            })
+        return result
+
+    # -- order submission ---------------------------------------------------
+
+    def submit_order(self, order: dict) -> dict | None:
+        self._ensure_auth()
+        symbol = order["symbol"]
+        side = order["side"].lower()
+        qty = float(order["quantity"])
+        otype = order.get("order_type", "market").lower()
+        limit_px = order.get("limit_price")
+
+        try:
+            if otype == "limit" and limit_px:
+                result = rh.orders.order(
+                    symbol, qty, side,
+                    limitPrice=float(limit_px),
+                    timeInForce="gtc", jsonify=True,
+                )
+            else:
+                result = rh.orders.order(
+                    symbol, qty, side,
+                    timeInForce="gtc", jsonify=True,
+                )
+
+            if result and result.get("id"):
+                log.info("RH order submitted: %s %s %s @ %s -> %s",
+                         side, qty, symbol, limit_px or "MKT", result["id"])
+                return {
+                    "id": result["id"],
+                    "symbol": symbol,
+                    "status": result.get("state"),
+                }
+            return None
+
+        except Exception as e:
+            log.error("Robinhood order error for %s %s %s: %s", side, qty, symbol, e)
+            return None
+
+    def cancel_order(self, order_id: str):
+        self._ensure_auth()
+        rh.orders.cancel_stock_order(order_id)
+        log.info("Cancelled RH order %s", order_id)
+
+    def cancel_all(self):
+        self._ensure_auth()
+        rh.orders.cancel_all_stock_orders()
+        log.info("All RH stock orders cancelled")

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,40 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    # -- Flask --
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-change-me")
+    DEBUG = os.getenv("FLASK_DEBUG", "false").lower() == "true"
+
+    # -- Broker selection --
+    ENABLED_BROKERS = [
+        b.strip() for b in os.getenv("ENABLED_BROKERS", "robinhood").split(",")
+    ]
+    DEFAULT_BROKER = os.getenv("DEFAULT_BROKER", "robinhood")
+
+    # -- Alpaca --
+    ALPACA_API_KEY = os.getenv("ALPACA_API_KEY", "")
+    ALPACA_SECRET_KEY = os.getenv("ALPACA_SECRET_KEY", "")
+    ALPACA_PAPER = os.getenv("ALPACA_PAPER", "true").lower() == "true"
+
+    # -- Robinhood --
+    RH_USER = os.getenv("RH_USER", "")
+    RH_PASS = os.getenv("RH_PASS", "")
+    RH_TOTP_SECRET = os.getenv("RH_TOTP_SECRET", "")
+    RH_DEVICE_TOKEN = os.getenv("RH_DEVICE_TOKEN", "")
+    RH_PICKLE_NAME = os.getenv("RH_PICKLE_NAME", "taipei_session")
+
+    # -- Runtime service --
+    RUNTIME_SERVICE_URL = os.getenv(
+        "RUNTIME_SERVICE_URL",
+        "https://route-runtime-service.netlify.app/api",
+    )
+
+    # -- Engine --
+    POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "30"))
+    DRY_RUN = os.getenv("DRY_RUN", "true").lower() == "true"
+    ENGINE_ENABLED = os.getenv("ENGINE_ENABLED", "true").lower() == "true"
+    ENGINE_BROKER = os.getenv("ENGINE_BROKER", "alpaca")

--- a/app/engine.py
+++ b/app/engine.py
@@ -1,0 +1,116 @@
+"""Core allocation engine — reads desired state from the runtime service,
+reconciles against broker positions/orders, and submits the delta."""
+
+import logging
+
+from app.brokers.base import BrokerClient
+from app.runtime_client import RuntimeClient
+
+log = logging.getLogger(__name__)
+
+
+class AllocationEngine:
+    def __init__(self, trader: BrokerClient, runtime: RuntimeClient, dry_run: bool = True):
+        self.trader = trader
+        self.runtime = runtime
+        self.dry_run = dry_run
+        self._last_snapshot_key: str | None = None
+
+    # -- public -------------------------------------------------------------
+
+    def tick(self):
+        """Single reconciliation cycle: read desired state -> diff -> execute."""
+        state = self.runtime.state()
+        snapshot_key = state.get("snapshot_key")
+
+        if snapshot_key == self._last_snapshot_key:
+            log.debug("No new snapshot (still %s), skipping", snapshot_key)
+            return
+
+        log.info("Processing snapshot %s", snapshot_key)
+        self._last_snapshot_key = snapshot_key
+
+        desired_orders = self._desired_orders()
+        current_orders = self.trader.open_orders()
+        current_positions = self.trader.positions()
+
+        new_orders, stale_order_ids = self._reconcile(
+            desired_orders, current_orders, current_positions
+        )
+
+        self._execute(new_orders, stale_order_ids)
+
+    # -- internals ----------------------------------------------------------
+
+    def _desired_orders(self) -> list[dict]:
+        """Fetch the target order set from the runtime service."""
+        data = self.runtime.orders()
+        return data.get("stock_orders", [])
+
+    def _reconcile(
+        self,
+        desired: list[dict],
+        current_orders: list[dict],
+        current_positions: list[dict],
+    ) -> tuple[list[dict], list[str]]:
+        """Compare desired orders against broker state.
+
+        Returns (orders_to_submit, order_ids_to_cancel).
+        """
+        def _order_key(o: dict) -> tuple:
+            return (
+                o.get("symbol"),
+                o.get("side"),
+                o.get("quantity") or o.get("qty"),
+                o.get("limit_price"),
+            )
+
+        desired_keys = {_order_key(o) for o in desired}
+
+        current_map: dict[tuple, dict] = {}
+        for o in current_orders:
+            key = (o["symbol"], o["side"], o["qty"], o["limit_price"])
+            current_map[key] = o
+
+        stale_ids = [
+            o["id"] for key, o in current_map.items() if key not in desired_keys
+        ]
+
+        position_symbols = {p["symbol"] for p in current_positions}
+
+        to_submit = []
+        for o in desired:
+            key = _order_key(o)
+            if key in current_map:
+                continue
+            if o["symbol"] in position_symbols and o["side"] == "BUY":
+                log.info("Skipping %s BUY — already holding position", o["symbol"])
+                continue
+            to_submit.append(o)
+
+        log.info(
+            "Reconciliation: %d desired, %d already open, %d stale, %d to submit",
+            len(desired), len(current_map) - len(stale_ids),
+            len(stale_ids), len(to_submit),
+        )
+        return to_submit, stale_ids
+
+    def _execute(self, orders: list[dict], cancel_ids: list[str]):
+        """Cancel stale orders and submit new ones."""
+        for oid in cancel_ids:
+            if self.dry_run:
+                log.info("[DRY RUN] Would cancel order %s", oid)
+            else:
+                self.trader.cancel_order(oid)
+
+        results = []
+        for order in orders:
+            if self.dry_run:
+                log.info("[DRY RUN] Would submit: %s %s %s @ %s",
+                         order["side"], order["quantity"],
+                         order["symbol"], order.get("limit_price", "MKT"))
+            else:
+                result = self.trader.submit_order(order)
+                results.append(result)
+
+        return results

--- a/app/runtime_client.py
+++ b/app/runtime_client.py
@@ -1,0 +1,40 @@
+"""Client for the allocation-runtime-service read-only API."""
+
+import requests
+
+
+class RuntimeClient:
+    def __init__(self, base_url: str):
+        self.base = base_url.rstrip("/")
+
+    def _get(self, path: str):
+        resp = requests.get(f"{self.base}{path}", timeout=15)
+        resp.raise_for_status()
+        return resp.json()
+
+    def health(self) -> dict:
+        return self._get("/health")
+
+    def state(self) -> dict:
+        """Latest trading state (tickers, drift metrics, strategy state)."""
+        return self._get("/state")
+
+    def orders(self) -> dict:
+        """Open stock orders + options positions from latest snapshot."""
+        return self._get("/orders")
+
+    def portfolio(self) -> dict:
+        """Portfolio holdings from latest snapshot."""
+        return self._get("/portfolio")
+
+    def market_data(self) -> dict:
+        """Ticker-level metrics and drift analysis."""
+        return self._get("/market-data")
+
+    def snapshots(self) -> dict:
+        """List most recent 50 snapshot keys."""
+        return self._get("/snapshots")
+
+    def snapshot(self, key: str) -> dict:
+        """Full data for a specific snapshot."""
+        return self._get(f"/snapshots/{key}")

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,0 +1,5 @@
+"""WSGI entry point — run with: gunicorn app.wsgi:application"""
+
+from app import create_app
+
+application = create_app()

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,10 @@
+import os
+
+bind = "0.0.0.0:" + os.getenv("PORT", "10000")
+workers = 1           # Single worker — engine thread must be singleton
+threads = 4           # Handle concurrent API requests
+timeout = 120         # Robinhood API calls can be slow
+preload_app = True    # Load app before forking (ensures single engine thread)
+accesslog = "-"       # Log to stdout
+errorlog = "-"
+loglevel = "info"

--- a/main.py
+++ b/main.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""Allocation Engine 2.0 — Alpaca-backed trade execution.
+"""Allocation Engine 2.0 — CLI entry point for local development.
 
-Reads desired orders from the allocation-runtime-service, reconciles
-against live Alpaca state, and submits the delta.
+For production, use: gunicorn app.wsgi:application
 """
 
 import argparse
@@ -10,8 +9,11 @@ import logging
 import sys
 import time
 
-from config import POLL_INTERVAL_SECONDS, DRY_RUN
-from engine import AllocationEngine
+from app import create_app
+from app.config import Config
+from app.engine import AllocationEngine
+from app.brokers import get_broker
+from app.runtime_client import RuntimeClient
 
 logging.basicConfig(
     level=logging.INFO,
@@ -35,25 +37,26 @@ def run_loop(engine: AllocationEngine, interval: int):
         time.sleep(interval)
 
 
-def status(engine: AllocationEngine):
-    """Print current Alpaca account + runtime service state."""
+def status(engine: AllocationEngine, broker_name: str):
+    """Print broker account + runtime service state."""
     acct = engine.trader.account()
     positions = engine.trader.positions()
-    alpaca_orders = engine.trader.open_orders()
+    broker_orders = engine.trader.open_orders()
     runtime_orders = engine.runtime.orders()
 
-    print("\n=== Alpaca Account ===")
+    print(f"\n=== {broker_name.title()} Account ===")
     for k, v in acct.items():
         print(f"  {k}: {v}")
 
-    print(f"\n=== Alpaca Positions ({len(positions)}) ===")
+    print(f"\n=== {broker_name.title()} Positions ({len(positions)}) ===")
     for p in positions:
         print(f"  {p['symbol']}: {p['qty']} shares, MV=${p['market_value']:.2f}, "
               f"PnL=${p['unrealized_pl']:.2f} ({p['unrealized_pl_pct']:.2%})")
 
-    print(f"\n=== Alpaca Open Orders ({len(alpaca_orders)}) ===")
-    for o in alpaca_orders:
-        print(f"  {o['id'][:8]}  {o['side']} {o['qty']} {o['symbol']} "
+    print(f"\n=== {broker_name.title()} Open Orders ({len(broker_orders)}) ===")
+    for o in broker_orders:
+        oid = o['id'][:8] if o.get('id') else '?'
+        print(f"  {oid}  {o['side']} {o['qty']} {o['symbol']} "
               f"{o['type']} @ {o['limit_price'] or 'MKT'}")
 
     rt_stock = runtime_orders.get("stock_orders", [])
@@ -63,26 +66,48 @@ def status(engine: AllocationEngine):
               f"{o.get('order_type', 'market')} @ {o.get('limit_price', 'MKT')}")
 
 
+def serve():
+    """Run the Flask development server (use gunicorn for production)."""
+    import os
+    app = create_app()
+    port = int(os.getenv("PORT", "10000"))
+    app.run(host="0.0.0.0", port=port, debug=Config.DEBUG)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Allocation Engine 2.0")
+    parser.add_argument("--broker", default=Config.ENGINE_BROKER,
+                        choices=["alpaca", "robinhood"],
+                        help="Broker to use (default: ENGINE_BROKER env var)")
     sub = parser.add_subparsers(dest="command")
 
     sub.add_parser("run", help="Run continuous reconciliation loop")
     sub.add_parser("once", help="Run a single reconciliation tick")
-    sub.add_parser("status", help="Print Alpaca + runtime service status")
+    sub.add_parser("status", help="Print broker + runtime service status")
+    sub.add_parser("serve", help="Run Flask dev server (use gunicorn for prod)")
 
     args = parser.parse_args()
-    engine = AllocationEngine(dry_run=DRY_RUN)
 
-    if args.command == "run":
-        run_loop(engine, POLL_INTERVAL_SECONDS)
-    elif args.command == "once":
-        run_once(engine)
-    elif args.command == "status":
-        status(engine)
-    else:
-        parser.print_help()
-        sys.exit(1)
+    if args.command == "serve":
+        serve()
+        return
+
+    # For CLI commands, create app context to initialize brokers
+    app = create_app()
+    with app.app_context():
+        broker = get_broker(args.broker)
+        runtime = RuntimeClient(Config.RUNTIME_SERVICE_URL)
+        engine = AllocationEngine(trader=broker, runtime=runtime, dry_run=Config.DRY_RUN)
+
+        if args.command == "run":
+            run_loop(engine, Config.POLL_INTERVAL_SECONDS)
+        elif args.command == "once":
+            run_once(engine)
+        elif args.command == "status":
+            status(engine, args.broker)
+        else:
+            parser.print_help()
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,38 @@
+services:
+  - type: web
+    name: allocation-engine
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app.wsgi:application
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.12"
+      - key: ENABLED_BROKERS
+        sync: false
+      - key: DEFAULT_BROKER
+        sync: false
+      - key: RH_USER
+        sync: false
+      - key: RH_PASS
+        sync: false
+      - key: RH_TOTP_SECRET
+        sync: false
+      - key: RH_DEVICE_TOKEN
+        sync: false
+      - key: ALPACA_API_KEY
+        sync: false
+      - key: ALPACA_SECRET_KEY
+        sync: false
+      - key: ALPACA_PAPER
+        sync: false
+      - key: RUNTIME_SERVICE_URL
+        sync: false
+      - key: DRY_RUN
+        value: "true"
+      - key: ENGINE_ENABLED
+        value: "true"
+      - key: ENGINE_BROKER
+        value: "alpaca"
+      - key: POLL_INTERVAL_SECONDS
+        value: "60"
+    healthCheckPath: /api/health

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,13 @@
+# Web framework
+flask>=3.0.0
+gunicorn>=21.2.0
+flask-cors>=4.0.0
+
+# Brokers
 alpaca-py>=0.31.0
+robin-stocks>=3.0.0
+pyotp>=2.9.0
+
+# Utilities
 requests>=2.31.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

Restructure the CLI allocation engine into a Flask WSGI web service deployable on Render.com. The service provides REST API endpoints for portfolio monitoring across Robinhood (primary) and Alpaca brokers, while maintaining a background reconciliation loop.

## Changes

- **Package refactor**: Introduced `app/` package with Flask factory pattern, WSGI entry point, and broker abstraction layer (BrokerClient Protocol)
- **Robinhood broker**: Full robin-stocks client with server-side TOTP auth using pyotp (no interactive MFA needed on Render)
- **API endpoints**: `/api/health`, `/api/account`, `/api/positions`, `/api/orders`, `/api/portfolio` with per-broker targeting
- **Background engine**: Daemon thread running reconciliation loop alongside Flask server (workers=1 for singleton guarantee)
- **Deployment config**: `render.yaml` for Render.com, `gunicorn.conf.py` with optimized settings, updated `.env.example`
- **CLI preserved**: Local development support with `--broker` flag for selecting Robinhood or Alpaca

## Testing

- Flask app factory verified working
- Health endpoint tested: returns service status and configuration
- Gunicorn WSGI loading confirmed
- All dependencies installed successfully

## Deployment

Ready to push to Render. Set environment variables (RH_USER, RH_PASS, RH_TOTP_SECRET, ALPACA_API_KEY, etc.) in Render dashboard. Service deploys via `gunicorn app.wsgi:application` on configurable port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)