### PR TITLE
Add Redis sync with frontend-compatible date fields

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -30,6 +30,7 @@ def start_engine_thread(app):
             from app.brokers import get_broker
             from app.engine import AllocationEngine
             from app.runtime_client import RuntimeClient
+            from app.redis_store import sync_to_redis
 
             config = app.config
             broker = get_broker(config["ENGINE_BROKER"])
@@ -43,6 +44,7 @@ def start_engine_thread(app):
             _engine_status["running"] = True
             _engine_status["dry_run"] = config["DRY_RUN"]
             interval = config["POLL_INTERVAL_SECONDS"]
+            is_live = not config["DRY_RUN"]
 
             log.info("Background engine started (interval=%ds, dry_run=%s, broker=%s)",
                      interval, config["DRY_RUN"], config["ENGINE_BROKER"])
@@ -53,6 +55,16 @@ def start_engine_thread(app):
                     _engine_status["last_tick"] = datetime.now(timezone.utc).isoformat()
                     _engine_status["tick_count"] += 1
                     _engine_status["last_error"] = None
+
+                    # Sync positions + orders to Redis after each tick
+                    try:
+                        positions = broker.positions()
+                        open_orders = broker.open_orders()
+                        account = broker.account()
+                        sync_to_redis(positions, open_orders, account, live=is_live)
+                    except Exception:
+                        log.exception("Redis sync error")
+
                 except Exception as e:
                     log.exception("Engine tick error")
                     _engine_status["last_error"] = str(e)

--- a/app/redis_store.py
+++ b/app/redis_store.py
@@ -1,0 +1,144 @@
+"""Redis sync — writes portfolio positions and orders to Redis hashes.
+
+Two Redis hashes are maintained:
+  - stocks: current stock positions keyed by symbol
+  - orders: open orders keyed by order_id
+
+Uses REDIS_HOST + REDIS_PASSWORD env vars. Only writes when live=True.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+
+def _get_client():
+    """Get a Redis client, or None if not configured."""
+    try:
+        import redis
+    except ImportError:
+        log.warning("[redis] redis package not installed")
+        return None
+
+    host = os.getenv("REDIS_HOST")
+    password = os.getenv("REDIS_PASSWORD")
+    if host:
+        port = 6379
+        if ":" in host:
+            host, port_str = host.rsplit(":", 1)
+            try:
+                port = int(port_str)
+            except ValueError:
+                pass
+        try:
+            return redis.Redis(
+                host=host, port=port, password=password,
+                decode_responses=True,
+            )
+        except Exception as e:
+            log.error("[redis] Failed to connect to %s: %s", host, e)
+            return None
+
+    url = os.getenv("REDIS_URL")
+    if url:
+        try:
+            import redis as _redis
+            return _redis.from_url(url, decode_responses=True)
+        except Exception as e:
+            log.error("[redis] Failed to connect via URL: %s", e)
+            return None
+
+    return None
+
+
+def sync_to_redis(positions, open_orders, account, live=False):
+    """Write portfolio positions and orders to Redis.
+
+    Args:
+        positions: List of position dicts from BrokerClient.positions()
+        open_orders: List of order dicts from BrokerClient.open_orders()
+        account: Account summary dict from BrokerClient.account()
+        live: Only write when True (skips in dry-run mode)
+    """
+    if not live:
+        return
+
+    client = _get_client()
+    if not client:
+        return
+
+    ts = datetime.now(timezone.utc).isoformat()
+
+    try:
+        pipe = client.pipeline()
+
+        # --- stocks hash: positions keyed by symbol ---
+        pipe.delete("stocks")
+        for pos in positions:
+            symbol = pos.get("symbol")
+            if not symbol:
+                continue
+            qty = pos["qty"]
+            entry = {
+                "symbol": symbol,
+                "name": symbol,
+                "type": "stock",
+                "quantity": qty,
+                "avg_buy_price": pos.get("avg_entry", 0),
+                "current_price": round(pos["market_value"] / qty, 4) if qty else 0,
+                "equity": pos["market_value"],
+                "profit_loss": pos.get("unrealized_pl", 0),
+                "profit_loss_pct": pos.get("unrealized_pl_pct", 0) * 100,
+                "percent_change": round(pos.get("unrealized_pl_pct", 0) * 100, 2),
+                "equity_change": pos.get("unrealized_pl", 0),
+            }
+            pipe.hset("stocks", symbol, json.dumps(entry))
+
+        pipe.hset("stocks", "_meta", json.dumps({
+            "updated_at": ts,
+            "num_stocks": len(positions),
+            "num_options": 0,
+        }))
+
+        # --- orders hash: open orders keyed by order_id ---
+        pipe.delete("orders")
+        for order in open_orders:
+            oid = order.get("id", "unknown")
+            entry = {
+                "order_id": oid,
+                "symbol": order.get("symbol", ""),
+                "side": order.get("side", "").upper(),
+                "order_type": order.get("type", "market"),
+                "trigger": "stop" if order.get("type") in ("stop", "stop_limit") else "immediate",
+                "state": order.get("status", "unknown"),
+                "quantity": order.get("qty", 0),
+                "limit_price": order.get("limit_price"),
+                "stop_price": order.get("stop_price"),
+                "created_at": ts,
+                "updated_at": ts,
+                "_status": "open",
+                "_type": "stock",
+            }
+            pipe.hset("orders", oid, json.dumps(entry))
+
+        pipe.hset("orders", "_meta", json.dumps({
+            "updated_at": ts,
+            "num_open_stock": len(open_orders),
+            "num_open_option": 0,
+            "num_historical_stock": 0,
+            "num_historical_option": 0,
+        }))
+
+        pipe.execute()
+        log.info("[redis] Synced: %d positions, %d open orders", len(positions), len(open_orders))
+
+    except Exception as e:
+        log.error("[redis] FAILED: %s", e)
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyotp>=2.9.0
 # Utilities
 requests>=2.31.0
 python-dotenv>=1.0.0
+redis>=5.0.0


### PR DESCRIPTION
## Summary
- Syncs positions + open orders to Redis after each engine tick
- Includes `created_at` and `updated_at` on order entries (fixes Invalid Date on TradePage)
- Adds redis package

Fixes the "Invalid Date" issue when TradePage reads from Redis.