### PR TITLE
Add options data pipeline for IWN/CRWD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,16 @@ ALPACA_PAPER=true
 # === Runtime Service ===
 RUNTIME_SERVICE_URL=https://route-runtime-service.netlify.app/api
 
+# === Market Data Service (Scala) ===
+POLL_INTERVAL_MS=3000
+SYMBOLS=BTC
+CRYPTO_SYMBOLS=BTC/USD
+HISTORY_MAX_SIZE=10000
+
+# === Options Pipeline ===
+OPTIONS_SYMBOLS=IWN,CRWD
+OPTIONS_POLL_INTERVAL_MS=30000
+
 # === Engine ===
 POLL_INTERVAL_SECONDS=30
 DRY_RUN=true

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/Main.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/Main.scala
@@ -2,6 +2,7 @@ package com.helsinki.marketdata
 
 import com.helsinki.marketdata.config.AppConfig
 import com.helsinki.marketdata.poller.QuotePoller
+import com.helsinki.marketdata.options.OptionsPoller
 
 @main def run(): Unit =
   println("[market-data] Initializing Alpaca -> Redis market data service")
@@ -11,11 +12,23 @@ import com.helsinki.marketdata.poller.QuotePoller
     System.err.println("[market-data] FATAL: ALPACA_API_KEY must be set")
     sys.exit(1)
 
-  val poller = QuotePoller(config)
+  val quotePoller = QuotePoller(config)
+
+  // Start options poller on a separate thread if options symbols are configured
+  val optionsPoller = if config.optionsSymbols.nonEmpty then
+    val op = OptionsPoller(config)
+    val thread = new Thread(() => op.start(), "options-poller")
+    thread.setDaemon(true)
+    thread.start()
+    println(s"[market-data] Options poller started for: ${config.optionsSymbols.mkString(", ")}")
+    Some(op)
+  else
+    None
 
   Runtime.getRuntime.addShutdownHook(new Thread(() => {
     println("\n[market-data] Shutting down...")
-    poller.stop()
+    quotePoller.stop()
+    optionsPoller.foreach(_.stop())
   }))
 
-  poller.start()
+  quotePoller.start()

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/config/AppConfig.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/config/AppConfig.scala
@@ -9,7 +9,9 @@ case class AppConfig(
   pollIntervalMs: Long,
   symbols: Seq[String],
   cryptoSymbols: Seq[String],
-  historyMaxSize: Int
+  historyMaxSize: Int,
+  optionsSymbols: Seq[String],
+  optionsPollIntervalMs: Long
 )
 
 object AppConfig:
@@ -32,5 +34,7 @@ object AppConfig:
       pollIntervalMs = sys.env.getOrElse("POLL_INTERVAL_MS", "3000").toLong,
       symbols = sys.env.getOrElse("SYMBOLS", "BTC").split(",").map(_.trim).toSeq,
       cryptoSymbols = sys.env.getOrElse("CRYPTO_SYMBOLS", "BTC/USD").split(",").map(_.trim).toSeq,
-      historyMaxSize = sys.env.getOrElse("HISTORY_MAX_SIZE", "10000").toInt
+      historyMaxSize = sys.env.getOrElse("HISTORY_MAX_SIZE", "10000").toInt,
+      optionsSymbols = sys.env.getOrElse("OPTIONS_SYMBOLS", "IWN,CRWD").split(",").map(_.trim).toSeq,
+      optionsPollIntervalMs = sys.env.getOrElse("OPTIONS_POLL_INTERVAL_MS", "30000").toLong
     )

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsClient.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsClient.scala
@@ -1,0 +1,212 @@
+package com.helsinki.marketdata.options
+
+import com.helsinki.marketdata.config.AppConfig
+import io.circe.parser.*
+import io.circe.*
+import sttp.client3.*
+import java.time.{Instant, LocalDate}
+import java.time.format.DateTimeFormatter
+
+class OptionsClient(config: AppConfig):
+  private val backend = HttpClientSyncBackend()
+  private val optionsBaseUrl = "https://data.alpaca.markets/v1beta1/options"
+
+  /** Fetch the full options chain (snapshots) for an underlying symbol.
+    * Returns contract snapshots with latest trade, latest quote, and greeks.
+    */
+  def fetchOptionChain(
+    underlying: String,
+    feed: String = "indicative",
+    optionType: Option[String] = None,
+    expirationGte: Option[String] = None,
+    expirationLte: Option[String] = None,
+    strikePriceGte: Option[Double] = None,
+    strikePriceLte: Option[Double] = None,
+    limit: Int = 100
+  ): Seq[OptionSnapshot] =
+    try
+      var url = uri"$optionsBaseUrl/snapshots/$underlying?feed=$feed&limit=$limit"
+
+      // Build query params manually since sttp uri interpolation handles it
+      val params = Seq(
+        optionType.map(t => s"type=$t"),
+        expirationGte.map(d => s"expiration_date_gte=$d"),
+        expirationLte.map(d => s"expiration_date_lte=$d"),
+        strikePriceGte.map(p => s"strike_price_gte=$p"),
+        strikePriceLte.map(p => s"strike_price_lte=$p")
+      ).flatten
+
+      val fullUrl = if params.nonEmpty then
+        val baseStr = s"$optionsBaseUrl/snapshots/$underlying?feed=$feed&limit=$limit&${params.mkString("&")}"
+        uri"$baseStr"
+      else
+        uri"$optionsBaseUrl/snapshots/$underlying?feed=$feed&limit=$limit"
+
+      val response = basicRequest
+        .get(fullUrl)
+        .header("APCA-API-KEY-ID", config.alpacaApiKey)
+        .header("APCA-API-SECRET-KEY", config.alpacaSecretKey)
+        .send(backend)
+
+      response.body match
+        case Right(body) => parseOptionChain(body, underlying)
+        case Left(err) =>
+          println(s"[options] Chain error for $underlying: $err")
+          Seq.empty
+    catch
+      case e: Exception =>
+        println(s"[options] Chain exception for $underlying: ${e.getMessage}")
+        Seq.empty
+
+  /** Fetch minute-level bars for specific option contract symbols. */
+  def fetchOptionBars(
+    contractSymbols: Seq[String],
+    timeframe: String = "1Min",
+    start: Option[String] = None,
+    end: Option[String] = None,
+    limit: Int = 1000
+  ): Map[String, Seq[OptionBar]] =
+    if contractSymbols.isEmpty then return Map.empty
+
+    try
+      // Alpaca limits to 100 symbols per request; batch if needed
+      val batches = contractSymbols.grouped(100).toSeq
+      val allBars = scala.collection.mutable.Map[String, Seq[OptionBar]]()
+
+      for batch <- batches do
+        val symbolsParam = batch.mkString(",")
+        val startParam = start.getOrElse(LocalDate.now().atStartOfDay().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "Z")
+        val endParam = end.getOrElse(Instant.now().toString)
+
+        val response = basicRequest
+          .get(uri"$optionsBaseUrl/bars?symbols=$symbolsParam&timeframe=$timeframe&start=$startParam&end=$endParam&limit=$limit&sort=desc")
+          .header("APCA-API-KEY-ID", config.alpacaApiKey)
+          .header("APCA-API-SECRET-KEY", config.alpacaSecretKey)
+          .send(backend)
+
+        response.body match
+          case Right(body) =>
+            val parsed = parseOptionBars(body)
+            for (sym, bars) <- parsed do
+              allBars(sym) = allBars.getOrElse(sym, Seq.empty) ++ bars
+          case Left(err) =>
+            println(s"[options] Bars error for batch: $err")
+
+      allBars.toMap
+    catch
+      case e: Exception =>
+        println(s"[options] Bars exception: ${e.getMessage}")
+        Map.empty
+
+  /** Fetch latest snapshots for specific contract symbols. */
+  def fetchOptionSnapshots(
+    contractSymbols: Seq[String],
+    feed: String = "indicative"
+  ): Seq[OptionSnapshot] =
+    if contractSymbols.isEmpty then return Seq.empty
+
+    try
+      val symbolsParam = contractSymbols.take(100).mkString(",")
+      val response = basicRequest
+        .get(uri"$optionsBaseUrl/snapshots?symbols=$symbolsParam&feed=$feed")
+        .header("APCA-API-KEY-ID", config.alpacaApiKey)
+        .header("APCA-API-SECRET-KEY", config.alpacaSecretKey)
+        .send(backend)
+
+      response.body match
+        case Right(body) => parseSnapshots(body)
+        case Left(err) =>
+          println(s"[options] Snapshots error: $err")
+          Seq.empty
+    catch
+      case e: Exception =>
+        println(s"[options] Snapshots exception: ${e.getMessage}")
+        Seq.empty
+
+  // --- Parsers ---
+
+  private def parseOptionChain(body: String, underlying: String): Seq[OptionSnapshot] =
+    parse(body).toOption match
+      case Some(json) =>
+        val snapshots = json.hcursor.downField("snapshots")
+        snapshots.keys.getOrElse(Nil).toSeq.flatMap { contractSymbol =>
+          val c = snapshots.downField(contractSymbol)
+          Some(parseOneSnapshot(c, contractSymbol))
+        }
+      case None =>
+        println(s"[options] Failed to parse chain JSON for $underlying")
+        Seq.empty
+
+  private def parseSnapshots(body: String): Seq[OptionSnapshot] =
+    parse(body).toOption match
+      case Some(json) =>
+        val snapshots = json.hcursor.downField("snapshots")
+        snapshots.keys.getOrElse(Nil).toSeq.flatMap { contractSymbol =>
+          val c = snapshots.downField(contractSymbol)
+          Some(parseOneSnapshot(c, contractSymbol))
+        }
+      case None =>
+        println(s"[options] Failed to parse snapshots JSON")
+        Seq.empty
+
+  private def parseOneSnapshot(c: ACursor, contractSymbol: String): OptionSnapshot =
+    val trade = for
+      price <- c.downField("latestTrade").get[Double]("p").toOption
+      size  <- c.downField("latestTrade").get[Int]("s").toOption
+      ts    <- c.downField("latestTrade").get[String]("t").toOption
+    yield OptionTrade(price, size, ts)
+
+    val quote = for
+      bp <- c.downField("latestQuote").get[Double]("bp").toOption
+      ap <- c.downField("latestQuote").get[Double]("ap").toOption
+      bs <- c.downField("latestQuote").get[Int]("bs").toOption
+      as_ <- c.downField("latestQuote").get[Int]("as").toOption
+      ts <- c.downField("latestQuote").get[String]("t").toOption
+    yield OptionQuote(bp, ap, bs, as_, ts)
+
+    val greeks = {
+      val g = c.downField("greeks")
+      val delta = g.get[Double]("delta").toOption
+      val gamma = g.get[Double]("gamma").toOption
+      val theta = g.get[Double]("theta").toOption
+      val vega  = g.get[Double]("vega").toOption
+      val rho   = g.get[Double]("rho").toOption
+      if delta.isDefined || gamma.isDefined then Some(OptionGreeks(delta, gamma, theta, vega, rho))
+      else None
+    }
+
+    val iv = c.downField("impliedVolatility").as[Double].toOption
+      .orElse(c.downField("greeks").downField("implied_volatility").as[Double].toOption)
+
+    OptionSnapshot(contractSymbol, trade, quote, greeks, iv)
+
+  private def parseOptionBars(body: String): Map[String, Seq[OptionBar]] =
+    parse(body).toOption match
+      case Some(json) =>
+        val barsObj = json.hcursor.downField("bars")
+        barsObj.keys.getOrElse(Nil).toSeq.map { symbol =>
+          val barArray = barsObj.downField(symbol).focus
+            .flatMap(_.asArray)
+            .getOrElse(Vector.empty)
+
+          val bars = barArray.flatMap { barJson =>
+            val c = barJson.hcursor
+            for
+              t <- c.get[String]("t").toOption
+              o <- c.get[Double]("o").toOption
+              h <- c.get[Double]("h").toOption
+              l <- c.get[Double]("l").toOption
+              cl <- c.get[Double]("c").toOption
+              v <- c.get[Long]("v").toOption.orElse(c.get[Int]("v").toOption.map(_.toLong))
+            yield
+              val n = c.get[Int]("n").toOption.getOrElse(0)
+              val vw = c.get[Double]("vw").toOption.getOrElse(0.0)
+              OptionBar(t, o, h, l, cl, v, n, vw)
+          }
+          symbol -> bars.toSeq
+        }.toMap
+      case None =>
+        println(s"[options] Failed to parse bars JSON")
+        Map.empty
+
+  def close(): Unit = backend.close()

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsModels.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsModels.scala
@@ -1,0 +1,113 @@
+package com.helsinki.marketdata.options
+
+import io.circe.*
+import io.circe.syntax.*
+
+case class OptionGreeks(
+  delta: Option[Double],
+  gamma: Option[Double],
+  theta: Option[Double],
+  vega: Option[Double],
+  rho: Option[Double]
+)
+
+case class OptionTrade(
+  price: Double,
+  size: Int,
+  timestamp: String
+)
+
+case class OptionQuote(
+  bid: Double,
+  ask: Double,
+  bidSize: Int,
+  askSize: Int,
+  timestamp: String
+)
+
+case class OptionSnapshot(
+  symbol: String,
+  latestTrade: Option[OptionTrade],
+  latestQuote: Option[OptionQuote],
+  greeks: Option[OptionGreeks],
+  impliedVolatility: Option[Double]
+)
+
+case class OptionBar(
+  timestamp: String,
+  open: Double,
+  high: Double,
+  low: Double,
+  close: Double,
+  volume: Long,
+  tradeCount: Int,
+  vwap: Double
+)
+
+case class OptionChainEntry(
+  contractSymbol: String,
+  underlying: String,
+  snapshot: OptionSnapshot,
+  bars: Seq[OptionBar]
+)
+
+object OptionsEncoders:
+  given Encoder[OptionGreeks] = Encoder.instance { g =>
+    Json.obj(
+      "delta" -> g.delta.fold(Json.Null)(Json.fromDoubleOrNull),
+      "gamma" -> g.gamma.fold(Json.Null)(Json.fromDoubleOrNull),
+      "theta" -> g.theta.fold(Json.Null)(Json.fromDoubleOrNull),
+      "vega"  -> g.vega.fold(Json.Null)(Json.fromDoubleOrNull),
+      "rho"   -> g.rho.fold(Json.Null)(Json.fromDoubleOrNull)
+    )
+  }
+
+  given Encoder[OptionTrade] = Encoder.instance { t =>
+    Json.obj(
+      "price"     -> Json.fromDoubleOrNull(t.price),
+      "size"      -> Json.fromInt(t.size),
+      "timestamp" -> Json.fromString(t.timestamp)
+    )
+  }
+
+  given Encoder[OptionQuote] = Encoder.instance { q =>
+    Json.obj(
+      "bid"       -> Json.fromDoubleOrNull(q.bid),
+      "ask"       -> Json.fromDoubleOrNull(q.ask),
+      "bid_size"  -> Json.fromInt(q.bidSize),
+      "ask_size"  -> Json.fromInt(q.askSize),
+      "timestamp" -> Json.fromString(q.timestamp)
+    )
+  }
+
+  given Encoder[OptionBar] = Encoder.instance { b =>
+    Json.obj(
+      "timestamp"   -> Json.fromString(b.timestamp),
+      "open"        -> Json.fromDoubleOrNull(b.open),
+      "high"        -> Json.fromDoubleOrNull(b.high),
+      "low"         -> Json.fromDoubleOrNull(b.low),
+      "close"       -> Json.fromDoubleOrNull(b.close),
+      "volume"      -> Json.fromLong(b.volume),
+      "trade_count" -> Json.fromInt(b.tradeCount),
+      "vwap"        -> Json.fromDoubleOrNull(b.vwap)
+    )
+  }
+
+  given Encoder[OptionSnapshot] = Encoder.instance { s =>
+    Json.obj(
+      "symbol"             -> Json.fromString(s.symbol),
+      "latest_trade"       -> s.latestTrade.fold(Json.Null)(_.asJson),
+      "latest_quote"       -> s.latestQuote.fold(Json.Null)(_.asJson),
+      "greeks"             -> s.greeks.fold(Json.Null)(_.asJson),
+      "implied_volatility" -> s.impliedVolatility.fold(Json.Null)(Json.fromDoubleOrNull)
+    )
+  }
+
+  given Encoder[OptionChainEntry] = Encoder.instance { e =>
+    Json.obj(
+      "contract_symbol" -> Json.fromString(e.contractSymbol),
+      "underlying"      -> Json.fromString(e.underlying),
+      "snapshot"        -> e.snapshot.asJson,
+      "bars"            -> Json.fromValues(e.bars.map(_.asJson))
+    )
+  }

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsPoller.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsPoller.scala
@@ -1,0 +1,102 @@
+package com.helsinki.marketdata.options
+
+import com.helsinki.marketdata.config.AppConfig
+import java.time.{Instant, LocalDate}
+import java.time.format.DateTimeFormatter
+
+class OptionsPoller(config: AppConfig):
+  private val client = OptionsClient(config)
+  private val redis  = OptionsRedisWriter(config)
+  @volatile private var running = true
+
+  // How many top contracts (by volume) to fetch minute bars for
+  private val TopContractsForBars = 20
+
+  def start(): Unit =
+    println(s"[options] Starting options poller")
+    println(s"  underlyings: ${config.optionsSymbols.mkString(", ")}")
+    println(s"  interval:    ${config.optionsPollIntervalMs}ms")
+    println(s"  bars limit:  top $TopContractsForBars contracts per underlying")
+
+    // Verify Redis
+    try
+      if redis.ping() then
+        println("[options] Redis connection OK")
+      else
+        println("[options] WARNING: Redis ping failed — will retry on writes")
+    catch
+      case e: Exception =>
+        println(s"[options] WARNING: Redis ping error: ${e.getMessage}")
+
+    while running do
+      try
+        for underlying <- config.optionsSymbols do
+          pollUnderlying(underlying)
+
+        Thread.sleep(config.optionsPollIntervalMs)
+      catch
+        case _: InterruptedException => running = false
+        case e: Exception =>
+          println(s"[options] ERROR: ${e.getMessage}")
+          Thread.sleep(config.optionsPollIntervalMs)
+
+  private def pollUnderlying(underlying: String): Unit =
+    // 1. Fetch option chain snapshots (near-term expirations)
+    val today = LocalDate.now()
+    val nearTermEnd = today.plusDays(45).format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+    val chain = client.fetchOptionChain(
+      underlying = underlying,
+      feed = "indicative",
+      expirationGte = Some(today.format(DateTimeFormatter.ISO_LOCAL_DATE)),
+      expirationLte = Some(nearTermEnd),
+      limit = 100
+    )
+
+    if chain.nonEmpty then
+      println(s"[options] $underlying: ${chain.size} contracts in chain")
+
+      // Write chain to Redis
+      try
+        redis.writeChain(underlying, chain)
+        println(s"[options] $underlying: chain written to Redis")
+      catch
+        case e: Exception =>
+          println(s"[options] $underlying: Redis chain write failed: ${e.getMessage}")
+
+      // 2. Pick top contracts by trade volume for minute bars
+      val topContracts = chain
+        .filter(_.latestTrade.isDefined)
+        .sortBy(s => -s.latestTrade.map(_.size).getOrElse(0))
+        .take(TopContractsForBars)
+        .map(_.symbol)
+
+      if topContracts.nonEmpty then
+        val bars = client.fetchOptionBars(
+          contractSymbols = topContracts,
+          timeframe = "1Min",
+          limit = 390  // Full trading day of minute bars
+        )
+
+        if bars.nonEmpty then
+          val totalBars = bars.values.map(_.size).sum
+          println(s"[options] $underlying: $totalBars minute bars across ${bars.size} contracts")
+
+          try
+            redis.writeBars(underlying, bars)
+            println(s"[options] $underlying: bars written to Redis")
+          catch
+            case e: Exception =>
+              println(s"[options] $underlying: Redis bars write failed: ${e.getMessage}")
+        else
+          println(s"[options] $underlying: no minute bars returned")
+      else
+        println(s"[options] $underlying: no traded contracts for bar fetching")
+    else
+      println(s"[options] $underlying: empty chain (market may be closed)")
+
+  def stop(): Unit =
+    running = false
+    client.close()
+    redis.close()
+    println("[options] Stopped")

--- a/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsRedisWriter.scala
+++ b/market-data-service/src/main/scala/com/helsinki/marketdata/options/OptionsRedisWriter.scala
@@ -1,0 +1,99 @@
+package com.helsinki.marketdata.options
+
+import com.helsinki.marketdata.config.AppConfig
+import com.helsinki.marketdata.options.OptionsEncoders.given
+import io.circe.Json
+import io.circe.syntax.*
+import redis.clients.jedis.{JedisPool, JedisPoolConfig}
+
+class OptionsRedisWriter(config: AppConfig):
+  private val ChainHashKey   = "options-chain"
+  private val BarsHashKey    = "options-bars"
+  private val HistoryKey     = "options-chain:history"
+
+  private val poolConfig = new JedisPoolConfig()
+  poolConfig.setMaxTotal(4)
+  poolConfig.setMaxIdle(2)
+
+  private val pool = new JedisPool(
+    poolConfig,
+    config.redisHost,
+    config.redisPort,
+    5000,
+    if config.redisPassword.nonEmpty then config.redisPassword else null
+  )
+
+  /** Write option chain snapshots for an underlying symbol to Redis. */
+  def writeChain(underlying: String, snapshots: Seq[OptionSnapshot]): Unit =
+    val jedis = pool.getResource
+    try
+      val pipe = jedis.pipelined()
+
+      // Write each contract snapshot under options-chain:{UNDERLYING}
+      val chainKey = s"$ChainHashKey:$underlying"
+      for s <- snapshots do
+        pipe.hset(chainKey, s.symbol, s.asJson.noSpaces)
+
+      // Write chain summary metadata
+      val meta = Json.obj(
+        "underlying"   -> Json.fromString(underlying),
+        "updated_at"   -> Json.fromString(java.time.Instant.now.toString),
+        "num_contracts" -> Json.fromInt(snapshots.size),
+        "contracts"    -> Json.fromValues(snapshots.map(s => Json.fromString(s.symbol)))
+      )
+      pipe.hset(chainKey, "_meta", meta.noSpaces)
+
+      // Also track which underlyings have chains in the top-level hash
+      pipe.hset(ChainHashKey, underlying, meta.noSpaces)
+
+      // Push chain snapshot into history
+      val historyEntry = Json.obj(
+        "timestamp"  -> Json.fromString(java.time.Instant.now.toString),
+        "underlying" -> Json.fromString(underlying),
+        "num_contracts" -> Json.fromInt(snapshots.size),
+        "snapshots"  -> Json.fromValues(snapshots.map(_.asJson))
+      )
+      pipe.lpush(s"$HistoryKey:$underlying", historyEntry.noSpaces)
+      pipe.ltrim(s"$HistoryKey:$underlying", 0, config.historyMaxSize - 1)
+
+      pipe.sync()
+    finally
+      jedis.close()
+
+  /** Write minute-level bars for option contracts to Redis. */
+  def writeBars(underlying: String, barsMap: Map[String, Seq[OptionBar]]): Unit =
+    if barsMap.isEmpty then return
+
+    val jedis = pool.getResource
+    try
+      val pipe = jedis.pipelined()
+      val barsKey = s"$BarsHashKey:$underlying"
+
+      for (contractSymbol, bars) <- barsMap do
+        val barsJson = Json.fromValues(bars.map(_.asJson))
+        pipe.hset(barsKey, contractSymbol, barsJson.noSpaces)
+
+      // Write bars metadata
+      val meta = Json.obj(
+        "underlying"    -> Json.fromString(underlying),
+        "updated_at"    -> Json.fromString(java.time.Instant.now.toString),
+        "num_contracts" -> Json.fromInt(barsMap.size),
+        "total_bars"    -> Json.fromInt(barsMap.values.map(_.size).sum)
+      )
+      pipe.hset(barsKey, "_meta", meta.noSpaces)
+      pipe.hset(BarsHashKey, underlying, meta.noSpaces)
+
+      pipe.sync()
+    finally
+      jedis.close()
+
+  def ping(): Boolean =
+    val jedis = pool.getResource
+    try
+      jedis.ping() == "PONG"
+    catch
+      case _: Exception => false
+    finally
+      jedis.close()
+
+  def close(): Unit = pool.close()

--- a/render.yaml
+++ b/render.yaml
@@ -61,3 +61,7 @@ services:
         value: BTC/USD
       - key: HISTORY_MAX_SIZE
         value: "10000"
+      - key: OPTIONS_SYMBOLS
+        value: "IWN,CRWD"
+      - key: OPTIONS_POLL_INTERVAL_MS
+        value: "30000"


### PR DESCRIPTION
## Summary
- Adds Scala options pipeline to market-data-service for **IWN** and **CRWD**
- Fetches option chain snapshots (greeks, IV, bid/ask, trade) from Alpaca `/v1beta1/options/snapshots/{underlying}`
- Pulls **1-minute OHLCV bars** for top 20 most-traded contracts via `/v1beta1/options/bars`
- Writes to Redis: `options-chain:{symbol}`, `options-bars:{symbol}`, with history tracking
- Runs on a daemon thread alongside existing quote poller (30s interval)

## New files
- `OptionsModels.scala` — data models + Circe encoders
- `OptionsClient.scala` — Alpaca options API client
- `OptionsPoller.scala` — polling loop
- `OptionsRedisWriter.scala` — Redis persistence

## Config
- `OPTIONS_SYMBOLS=IWN,CRWD` (env var)
- `OPTIONS_POLL_INTERVAL_MS=30000` (env var)