### PR TITLE
Harden Robinhood session: Redis persistence, device token fix, throttled alerts

### DIFF
--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -138,8 +138,16 @@ class RobinhoodTrader:
         }
         if mfa_code:
             kwargs["mfa_code"] = mfa_code
+
+        # Patch generate_device_token to return a fixed token so Robinhood
+        # sees the same device across logins. Without this, robin-stocks
+        # generates a random UUID each call → new device → needs approval.
+        _orig_gen = None
         if self.device_token:
-            kwargs["device_token"] = self.device_token
+            import robin_stocks.robinhood.authentication as _rh_auth
+            _orig_gen = _rh_auth.generate_device_token
+            _rh_auth.generate_device_token = lambda: self.device_token
+            log.info("Using fixed device token for login")
 
         global _last_slack_alert
         try:
@@ -182,6 +190,10 @@ class RobinhoodTrader:
                     f"Robinhood login FAILED for {self.email}: {e}"
                 )
             raise
+        finally:
+            if _orig_gen is not None:
+                import robin_stocks.robinhood.authentication as _rh_auth
+                _rh_auth.generate_device_token = _orig_gen
 
     def _ensure_auth(self):
         """Re-authenticate if session has expired.


### PR DESCRIPTION
## Summary
- **Throttle Slack alerts** to once per 10 minutes on repeated login failures (prevents notification spam every 60s)
- **Persist Robinhood session in Redis** across Render deploys — saves/restores the robin-stocks pickle file so re-auth isn't needed on redeploy
- **Reduce API calls** — only probe Robinhood session health every 5 minutes instead of every tick
- **Fix device token** — monkey-patch `generate_device_token` in robin-stocks to use fixed `RH_DEVICE_TOKEN` (robin-stocks generates a random UUID each call, causing device approval loops)

## Setup required on Render
- `RH_DEVICE_TOKEN` — set to a fixed UUID (one-time device approval needed on first deploy)
- `REDIS_HOST` and `REDIS_PASSWORD` — for session persistence

## Test plan
- [ ] Deploy to Render with `RH_DEVICE_TOKEN` set
- [ ] Approve device on first login via Robinhood app
- [ ] Verify subsequent ticks reuse cached session (no re-auth)
- [ ] Trigger a redeploy and confirm session is restored from Redis without new device approval
- [ ] Verify Slack alerts are throttled on repeated failures