### PR TITLE
Fix: remove invalid device_token kwarg from rh.login()

### DIFF
--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -58,8 +58,6 @@ class RobinhoodTrader:
         }
         if mfa_code:
             kwargs["mfa_code"] = mfa_code
-        if self.device_token:
-            kwargs["device_token"] = self.device_token
 
         try:
             result = rh.login(self.email, self.password, **kwargs)


### PR DESCRIPTION
## Summary
- `robin_stocks.robinhood.login()` does NOT accept a `device_token` parameter
- Passing it as a kwarg caused login to silently return empty
- This was the root cause of the repeated "Robinhood login empty" errors

## Root cause
```python
# rh.login() signature:
(username, password, expiresIn, scope, store_session, mfa_code, pickle_path, pickle_name)

# We were passing:
kwargs["device_token"] = self.device_token  # ← not a valid param
```

## Test plan
- [ ] Deploy to Render and confirm login succeeds without device approval
- [ ] Verify portfolio logging and Redis sync resume