### PR TITLE
Simplify Robinhood login: remove device_token

### DIFF
--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -26,7 +26,6 @@ def get_broker(name: str) -> BrokerClient:
             email=config["RH_USER"],
             password=config["RH_PASS"],
             totp_secret=config.get("RH_TOTP_SECRET", ""),
-            device_token=config.get("RH_DEVICE_TOKEN", ""),
             pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
         )
     else:

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -31,13 +31,11 @@ class RobinhoodTrader:
         email: str,
         password: str,
         totp_secret: str = "",
-        device_token: str = "",
         pickle_name: str = "taipei_session",
     ):
         self.email = email
         self.password = password
         self.totp_secret = totp_secret
-        self.device_token = device_token
         self.pickle_name = pickle_name
         self._authenticated = False
         try:
@@ -52,15 +50,14 @@ class RobinhoodTrader:
             totp = pyotp.TOTP(self.totp_secret)
             mfa_code = totp.now()
 
-        kwargs = {
-            "store_session": True,
-            "pickle_name": self.pickle_name,
-        }
-        if mfa_code:
-            kwargs["mfa_code"] = mfa_code
-
         try:
-            result = rh.login(self.email, self.password, **kwargs)
+            result = rh.login(
+                self.email,
+                self.password,
+                mfa_code=mfa_code,
+                store_session=True,
+                pickle_name=self.pickle_name,
+            )
             if result:
                 self._authenticated = True
                 log.info("Robinhood login successful for %s", self.email)


### PR DESCRIPTION
Remove the unused device_token parameter from RobinhoodTrader and simplify the login call by using explicit named parameters instead of building a kwargs dict.

This makes the rh.login() requirements more explicit and removes a parameter that was never actually used by the Robinhood API.