### PR TITLE
Expand blob snapshots with order history and options data

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -89,7 +89,24 @@ def start_engine_thread(app):
                     now_mono = time.monotonic()
                     if is_live and (now_mono - last_blob_sync) >= blob_interval:
                         try:
-                            sync_to_blob(positions, open_orders, account)
+                            # Fetch extended data for blob snapshot
+                            recent = broker.recent_orders(limit=50)
+                            option_pos = broker.option_positions()
+                            option_orders = broker.recent_option_orders(limit=20)
+
+                            log.info("[blob] Preparing snapshot: %d positions, %d open orders, "
+                                     "%d recent orders, %d option positions, %d option orders",
+                                     len(positions), len(open_orders), len(recent),
+                                     len(option_pos), len(option_orders))
+
+                            sync_to_blob(
+                                positions=positions,
+                                open_orders=open_orders,
+                                account=account,
+                                recent_orders=recent,
+                                option_positions=option_pos,
+                                option_orders=option_orders,
+                            )
                             last_blob_sync = now_mono
                         except Exception:
                             log.exception("Blob sync error")

--- a/app/blob_store.py
+++ b/app/blob_store.py
@@ -17,7 +17,14 @@ BLOBS_URL = "https://api.netlify.com/api/v1/blobs"
 STORE_NAME = "order-book"
 
 
-def sync_to_blob(positions, open_orders, account):
+def sync_to_blob(
+    positions,
+    open_orders,
+    account,
+    recent_orders=None,
+    option_positions=None,
+    option_orders=None,
+):
     """Upload current portfolio state to Netlify Blobs.
 
     Writes two keys:
@@ -29,6 +36,10 @@ def sync_to_blob(positions, open_orders, account):
     if not token or not site_id:
         log.debug("[blob] NETLIFY_API_TOKEN or NETLIFY_SITE_ID not set, skipping")
         return
+
+    recent_orders = recent_orders or []
+    option_positions = option_positions or []
+    option_orders = option_orders or []
 
     now = datetime.now(timezone.utc)
     ts = now.isoformat()
@@ -47,8 +58,8 @@ def sync_to_blob(positions, open_orders, account):
         for p in positions
     ]
 
-    # Map orders to the frontend SnapshotOrder schema
-    snap_orders = [
+    # Map open orders to the frontend SnapshotOrder schema
+    snap_open_orders = [
         {
             "order_id": o.id,
             "symbol": o.symbol,
@@ -65,6 +76,99 @@ def sync_to_blob(positions, open_orders, account):
         for o in open_orders
     ]
 
+    # Map recent filled/cancelled orders to SnapshotOrder schema
+    snap_recent_orders = [
+        {
+            "order_id": o.id,
+            "symbol": o.symbol,
+            "side": o.side.upper(),
+            "order_type": o.order_type,
+            "trigger": "immediate",
+            "state": o.status,
+            "quantity": o.qty,
+            "limit_price": o.limit_price or 0,
+            "stop_price": o.stop_price,
+            "average_price": o.average_price,
+            "filled_quantity": o.filled_qty,
+            "created_at": o.created_at,
+            "updated_at": o.updated_at,
+        }
+        for o in recent_orders
+    ]
+
+    # Map option positions to the frontend OptionPosition schema
+    snap_options = [
+        {
+            "chain_symbol": op.chain_symbol,
+            "option_type": op.option_type,
+            "strike": op.strike,
+            "expiration": op.expiration,
+            "dte": _days_until(op.expiration),
+            "quantity": op.quantity,
+            "position_type": op.position_type,
+            "avg_price": op.avg_price,
+            "mark_price": op.mark_price,
+            "multiplier": op.multiplier,
+            "cost_basis": op.cost_basis,
+            "current_value": op.current_value,
+            "unrealized_pl": op.unrealized_pl,
+            "unrealized_pl_pct": op.unrealized_pl_pct,
+            "underlying_price": op.underlying_price,
+            "break_even": op.break_even,
+            "greeks": {
+                "delta": op.delta,
+                "gamma": op.gamma,
+                "theta": op.theta,
+                "vega": op.vega,
+                "rho": op.rho,
+                "iv": op.iv,
+            },
+            "expected_pl": {
+                "-5%": round(op.delta * op.underlying_price * -0.05 * op.multiplier * op.quantity, 2) if op.underlying_price else 0,
+                "-1%": round(op.delta * op.underlying_price * -0.01 * op.multiplier * op.quantity, 2) if op.underlying_price else 0,
+                "+1%": round(op.delta * op.underlying_price * 0.01 * op.multiplier * op.quantity, 2) if op.underlying_price else 0,
+                "+5%": round(op.delta * op.underlying_price * 0.05 * op.multiplier * op.quantity, 2) if op.underlying_price else 0,
+                "theta_daily": round(op.theta * op.multiplier * op.quantity, 2),
+            },
+            "chance_of_profit": op.chance_of_profit,
+            "recommended_action": {"action": "hold", "reasons": []},
+            "btc_correlation": 0.0,
+        }
+        for op in option_positions
+    ]
+
+    # Map option orders to the frontend SnapshotOptionOrder schema
+    snap_option_orders = [
+        {
+            "order_id": oo.id,
+            "state": oo.state,
+            "quantity": oo.quantity,
+            "price": oo.price,
+            "premium": oo.premium,
+            "processed_premium": oo.premium,
+            "direction": oo.direction,
+            "order_type": oo.order_type,
+            "trigger": oo.trigger,
+            "time_in_force": oo.time_in_force,
+            "opening_strategy": oo.opening_strategy,
+            "created_at": oo.created_at,
+            "updated_at": oo.updated_at,
+            "legs": [
+                {
+                    "side": leg.get("side", ""),
+                    "position_effect": leg.get("position_effect", ""),
+                    "quantity": leg.get("quantity", 0),
+                    "strike": leg.get("strike", 0),
+                    "expiration": leg.get("expiration", ""),
+                    "option_type": leg.get("option_type", ""),
+                    "chain_symbol": leg.get("chain_symbol", ""),
+                }
+                for leg in oo.legs
+            ],
+        }
+        for oo in option_orders
+    ]
+
     snapshot = {
         "timestamp": ts,
         "portfolio": {
@@ -77,11 +181,13 @@ def sync_to_blob(positions, open_orders, account):
             "equity": account.equity,
             "market_value": account.portfolio_value,
             "positions": snap_positions,
-            "open_orders": snap_orders,
+            "open_orders": snap_open_orders,
+            "options": snap_options,
+            "open_option_orders": snap_option_orders,
         },
-        "order_book": snap_orders,
-        "recent_orders": [],
-        "recent_option_orders": [],
+        "order_book": snap_open_orders,
+        "recent_orders": snap_recent_orders,
+        "recent_option_orders": snap_option_orders,
     }
 
     headers = {
@@ -99,3 +205,14 @@ def sync_to_blob(positions, open_orders, account):
                      STORE_NAME, blob_key, resp.status_code, len(payload))
         except Exception:
             log.exception("[blob] Failed to upload %s/%s", STORE_NAME, blob_key)
+
+
+def _days_until(date_str: str) -> int:
+    """Calculate days until expiration from a YYYY-MM-DD string."""
+    if not date_str:
+        return 0
+    try:
+        exp = datetime.strptime(date_str, "%Y-%m-%d").date()
+        return max(0, (exp - datetime.now(timezone.utc).date()).days)
+    except ValueError:
+        return 0

--- a/app/brokers/alpaca_client.py
+++ b/app/brokers/alpaca_client.py
@@ -3,15 +3,19 @@
 import logging
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import (
+    GetOrdersRequest,
     LimitOrderRequest,
     MarketOrderRequest,
     StopLimitOrderRequest,
     StopOrderRequest,
 )
-from alpaca.trading.enums import OrderSide, TimeInForce
+from alpaca.trading.enums import OrderSide, QueryOrderStatus, TimeInForce
 from alpaca.common.exceptions import APIError
 
-from app.models import AccountSummary, OpenOrder, Order, OrderResult, Position
+from app.models import (
+    AccountSummary, FilledOrder, OpenOrder, OptionOrder,
+    OptionPositionData, Order, OrderResult, Position,
+)
 
 log = logging.getLogger(__name__)
 
@@ -68,6 +72,43 @@ class AlpacaTrader:
             )
             for o in self.client.get_orders()
         ]
+
+    def recent_orders(self, limit: int = 50) -> list[FilledOrder]:
+        """Return recent filled/cancelled stock orders."""
+        try:
+            req = GetOrdersRequest(
+                status=QueryOrderStatus.CLOSED,
+                limit=limit,
+            )
+            raw = self.client.get_orders(filter=req)
+            return [
+                FilledOrder(
+                    id=str(o.id),
+                    symbol=o.symbol,
+                    side=o.side.value,
+                    qty=float(o.qty) if o.qty else 0.0,
+                    order_type=o.type.value,
+                    limit_price=float(o.limit_price) if o.limit_price else None,
+                    stop_price=float(o.stop_price) if o.stop_price else None,
+                    average_price=float(o.filled_avg_price) if o.filled_avg_price else None,
+                    filled_qty=float(o.filled_qty) if o.filled_qty else 0.0,
+                    status=o.status.value,
+                    created_at=o.created_at.isoformat() if o.created_at else "",
+                    updated_at=o.updated_at.isoformat() if o.updated_at else "",
+                )
+                for o in raw
+            ]
+        except Exception:
+            log.exception("Failed to fetch recent orders from Alpaca")
+            return []
+
+    def option_positions(self) -> list[OptionPositionData]:
+        """Alpaca does not support options — return empty list."""
+        return []
+
+    def recent_option_orders(self, limit: int = 20) -> list[OptionOrder]:
+        """Alpaca does not support options — return empty list."""
+        return []
 
     # -- order submission ---------------------------------------------------
 

--- a/app/brokers/base.py
+++ b/app/brokers/base.py
@@ -2,7 +2,10 @@
 
 from typing import Protocol, runtime_checkable
 
-from app.models import AccountSummary, OpenOrder, Order, OrderResult, Position
+from app.models import (
+    AccountSummary, FilledOrder, OpenOrder, OptionOrder,
+    OptionPositionData, Order, OrderResult, Position,
+)
 
 
 @runtime_checkable
@@ -19,6 +22,18 @@ class BrokerClient(Protocol):
 
     def open_orders(self) -> list[OpenOrder]:
         """Return list of open orders on the broker."""
+        ...
+
+    def recent_orders(self, limit: int = 50) -> list[FilledOrder]:
+        """Return recent filled/cancelled stock orders."""
+        ...
+
+    def option_positions(self) -> list[OptionPositionData]:
+        """Return current option positions with Greeks."""
+        ...
+
+    def recent_option_orders(self, limit: int = 20) -> list[OptionOrder]:
+        """Return recent option orders."""
         ...
 
     def submit_order(self, order: Order) -> OrderResult | None:

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -4,7 +4,10 @@ import logging
 import robin_stocks.robinhood as rh
 import pyotp
 
-from app.models import AccountSummary, OpenOrder, Order, OrderResult, Position
+from app.models import (
+    AccountSummary, FilledOrder, OpenOrder, OptionOrder,
+    OptionPositionData, Order, OrderResult, Position,
+)
 from app.slack import notify as slack_notify
 
 log = logging.getLogger(__name__)
@@ -169,6 +172,202 @@ class RobinhoodTrader:
                 status=o.get("state", "unknown"),
             ))
         return result
+
+    def recent_orders(self, limit: int = 50) -> list[FilledOrder]:
+        """Return recent filled/cancelled stock orders from Robinhood."""
+        self._ensure_auth()
+        try:
+            raw = rh.orders.get_all_stock_orders()
+            result: list[FilledOrder] = []
+            for o in raw[:limit]:
+                state = o.get("state", "")
+                if state not in ("filled", "cancelled", "partially_filled"):
+                    continue
+                symbol = _symbol_from_instrument(o.get("instrument", ""))
+                result.append(FilledOrder(
+                    id=o.get("id", ""),
+                    symbol=symbol,
+                    side=o.get("side", "").upper(),
+                    qty=float(o.get("quantity", 0)),
+                    order_type=o.get("type", "market"),
+                    limit_price=float(o["price"]) if o.get("price") else None,
+                    stop_price=float(o["stop_price"]) if o.get("stop_price") else None,
+                    average_price=float(o["average_price"]) if o.get("average_price") else None,
+                    filled_qty=float(o.get("cumulative_quantity", 0)),
+                    status=state,
+                    created_at=o.get("created_at", ""),
+                    updated_at=o.get("updated_at", ""),
+                ))
+            return result
+        except Exception:
+            log.exception("Failed to fetch recent orders from Robinhood")
+            return []
+
+    def option_positions(self) -> list[OptionPositionData]:
+        """Return current option positions with Greeks from Robinhood."""
+        self._ensure_auth()
+        try:
+            raw = rh.options.get_open_option_positions()
+            if not raw:
+                return []
+
+            result: list[OptionPositionData] = []
+            for pos in raw:
+                qty = float(pos.get("quantity", 0))
+                if qty == 0:
+                    continue
+
+                # Fetch the option instrument details for Greeks
+                option_id = pos.get("option_id") or pos.get("option", "").split("/")[-2] if pos.get("option") else ""
+                chain_symbol = pos.get("chain_symbol", "")
+                avg_price = float(pos.get("average_price", 0)) / 100  # RH stores in cents
+                trade_value_multiplier = float(pos.get("trade_value_multiplier", 100))
+
+                # Get market data for this option
+                option_data = {}
+                if option_id:
+                    try:
+                        md = rh.options.get_option_market_data_by_id(option_id)
+                        if md and isinstance(md, list) and len(md) > 0:
+                            option_data = md[0]
+                        elif md and isinstance(md, dict):
+                            option_data = md
+                    except Exception:
+                        log.debug("Could not fetch option market data for %s", option_id)
+
+                # Get option instrument details
+                instrument = {}
+                if option_id:
+                    try:
+                        inst = rh.options.get_option_instrument_data_by_id(option_id)
+                        if inst:
+                            instrument = inst
+                    except Exception:
+                        log.debug("Could not fetch option instrument for %s", option_id)
+
+                mark_price = float(option_data.get("mark_price", 0) or 0)
+                iv = float(option_data.get("implied_volatility", 0) or 0)
+                delta = float(option_data.get("delta", 0) or 0)
+                gamma = float(option_data.get("gamma", 0) or 0)
+                theta = float(option_data.get("theta", 0) or 0)
+                vega = float(option_data.get("vega", 0) or 0)
+                rho_val = float(option_data.get("rho", 0) or 0)
+                chance = float(option_data.get("chance_of_profit_short" if qty < 0 else "chance_of_profit_long", 0) or 0)
+
+                strike = float(instrument.get("strike_price", 0) or 0)
+                expiration = instrument.get("expiration_date", "")
+                option_type = instrument.get("type", "call")
+
+                # Get underlying price
+                underlying_price = 0.0
+                if chain_symbol:
+                    try:
+                        px = rh.stocks.get_latest_price(chain_symbol)
+                        underlying_price = float(px[0]) if px and px[0] else 0.0
+                    except Exception:
+                        pass
+
+                position_type = "long" if qty > 0 else "short"
+                cost_basis = abs(qty) * avg_price * trade_value_multiplier
+                current_value = abs(qty) * mark_price * trade_value_multiplier
+                unrealized_pl = current_value - cost_basis if position_type == "long" else cost_basis - current_value
+                unrealized_pl_pct = unrealized_pl / cost_basis if cost_basis > 0 else 0.0
+
+                # Break-even calculation
+                if option_type == "call":
+                    break_even = strike + avg_price
+                else:
+                    break_even = strike - avg_price
+
+                result.append(OptionPositionData(
+                    chain_symbol=chain_symbol,
+                    option_type=option_type,
+                    strike=strike,
+                    expiration=expiration,
+                    quantity=abs(qty),
+                    position_type=position_type,
+                    avg_price=avg_price,
+                    mark_price=mark_price,
+                    multiplier=trade_value_multiplier,
+                    cost_basis=round(cost_basis, 2),
+                    current_value=round(current_value, 2),
+                    unrealized_pl=round(unrealized_pl, 2),
+                    unrealized_pl_pct=round(unrealized_pl_pct, 4),
+                    underlying_price=underlying_price,
+                    break_even=round(break_even, 2),
+                    delta=delta,
+                    gamma=gamma,
+                    theta=theta,
+                    vega=vega,
+                    rho=rho_val,
+                    iv=iv,
+                    chance_of_profit=chance,
+                ))
+            return result
+        except Exception:
+            log.exception("Failed to fetch option positions from Robinhood")
+            return []
+
+    def recent_option_orders(self, limit: int = 20) -> list[OptionOrder]:
+        """Return recent option orders from Robinhood."""
+        self._ensure_auth()
+        try:
+            raw = rh.orders.get_all_option_orders()
+            if not raw:
+                return []
+
+            result: list[OptionOrder] = []
+            for o in raw[:limit]:
+                state = o.get("state", "")
+                if state not in ("filled", "cancelled", "partially_filled"):
+                    continue
+
+                legs = []
+                for leg in o.get("legs", []):
+                    option_url = leg.get("option", "")
+                    # Extract option details from the leg
+                    leg_data = {
+                        "side": leg.get("side", ""),
+                        "position_effect": leg.get("position_effect", ""),
+                        "quantity": float(leg.get("quantity", 0) or 0),
+                    }
+                    # Try to get strike/expiration from option instrument
+                    if option_url:
+                        try:
+                            opt_id = option_url.rstrip("/").split("/")[-1]
+                            inst = rh.options.get_option_instrument_data_by_id(opt_id)
+                            if inst:
+                                leg_data["strike"] = float(inst.get("strike_price", 0) or 0)
+                                leg_data["expiration"] = inst.get("expiration_date", "")
+                                leg_data["option_type"] = inst.get("type", "call")
+                                leg_data["chain_symbol"] = inst.get("chain_symbol", "")
+                        except Exception:
+                            pass
+                    legs.append(leg_data)
+
+                premium = float(o.get("premium", 0) or 0)
+                processed_premium = float(o.get("processed_premium", 0) or 0)
+                price = float(o.get("price", 0) or 0)
+
+                result.append(OptionOrder(
+                    id=o.get("id", ""),
+                    state=state,
+                    quantity=float(o.get("quantity", 0)),
+                    price=price,
+                    premium=premium,
+                    direction=o.get("direction", ""),
+                    order_type=o.get("type", "limit"),
+                    trigger=o.get("trigger", "immediate"),
+                    time_in_force=o.get("time_in_force", "gfd"),
+                    opening_strategy=o.get("opening_strategy") or "",
+                    created_at=o.get("created_at", ""),
+                    updated_at=o.get("updated_at", ""),
+                    legs=legs,
+                ))
+            return result
+        except Exception:
+            log.exception("Failed to fetch recent option orders from Robinhood")
+            return []
 
     # -- order submission ---------------------------------------------------
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 """Canonical data models shared across brokers, engine, and API."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -44,6 +44,68 @@ class OpenOrder:
     limit_price: float | None = None
     stop_price: float | None = None
     status: str = "unknown"
+
+
+@dataclass
+class FilledOrder:
+    """A filled or cancelled order from history."""
+    id: str
+    symbol: str
+    side: str
+    qty: float
+    order_type: str = "market"
+    limit_price: float | None = None
+    stop_price: float | None = None
+    average_price: float | None = None
+    filled_qty: float = 0.0
+    status: str = "filled"
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class OptionPositionData:
+    """An option position with Greeks and pricing."""
+    chain_symbol: str
+    option_type: str
+    strike: float
+    expiration: str
+    quantity: float
+    position_type: str
+    avg_price: float
+    mark_price: float
+    multiplier: float = 100.0
+    cost_basis: float = 0.0
+    current_value: float = 0.0
+    unrealized_pl: float = 0.0
+    unrealized_pl_pct: float = 0.0
+    underlying_price: float = 0.0
+    break_even: float = 0.0
+    delta: float = 0.0
+    gamma: float = 0.0
+    theta: float = 0.0
+    vega: float = 0.0
+    rho: float = 0.0
+    iv: float = 0.0
+    chance_of_profit: float = 0.0
+
+
+@dataclass
+class OptionOrder:
+    """A filled/recent option order."""
+    id: str
+    state: str
+    quantity: float
+    price: float
+    premium: float
+    direction: str
+    order_type: str = "limit"
+    trigger: str = "immediate"
+    time_in_force: str = "gfd"
+    opening_strategy: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+    legs: list[dict] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Adds `FilledOrder`, `OptionPositionData`, and `OptionOrder` data models
- Extends `BrokerClient` protocol with `recent_orders()`, `option_positions()`, and `recent_option_orders()`
- Implements all three methods in **Alpaca** (closed orders via `GetOrdersRequest`) and **Robinhood** (stock order history, option positions with Greeks/market data, option order history with legs)
- Background loop now collects expanded data before each 15-min blob sync
- `blob_store.py` writes the full `OrderBookSnapshot` schema matching the frontend contract: `recent_orders`, `portfolio.options`, `open_option_orders`, `recent_option_orders`

This closes the 4KB → ~40KB gap between the engine's blob output and what the frontend expects.

## Test plan
- [ ] Deploy to staging and trigger a blob sync
- [ ] Verify blob size is closer to 40KB with options/orders populated
- [ ] Confirm frontend TradePage renders order history, options positions, and option orders
- [ ] Verify Alpaca path works (order history populated, options empty since Alpaca doesn't support them)
- [ ] Verify Robinhood path works with full option Greeks and order legs