### PR TITLE
Fix _ensure_auth spawning device challenge loops on 429s

### DIFF
--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -91,11 +91,21 @@ class RobinhoodTrader:
     def _ensure_auth(self):
         """Re-authenticate if session has expired."""
         if not self._authenticated:
+            if self._device_challenge_mode:
+                raise RuntimeError("Cannot authenticate — device challenge pending")
             self._login()
             return
+        # Session is authenticated — do a lightweight check.
+        # Tolerate transient errors (429, network blips) so we don't
+        # trigger a full re-login that could hit the device challenge loop.
         try:
             rh.profiles.load_account_profile()
-        except Exception:
+        except Exception as e:
+            err_str = str(e)
+            if "429" in err_str or "Too Many Requests" in err_str:
+                log.warning("Robinhood 429 during session check — "
+                            "skipping re-auth (session likely still valid)")
+                return
             log.warning("Robinhood session expired, re-authenticating...")
             slack_notify(
                 "<!channel> :warning: FlipActivate: allocation-engine-2.0 — "


### PR DESCRIPTION
## Summary
- Tolerate HTTP 429 (Too Many Requests) in `_ensure_auth` session check instead of triggering a full re-login that enters the device challenge infinite loop
- Block re-login attempts when already in `_device_challenge_mode`

## Problem
After the pickle persistence deploy, `_ensure_auth()` calls `load_account_profile()` to validate the session. When Robinhood returns 429 (rate limit), the code treated it as an expired session and called `_login()`, which spawned new daemon threads hitting the device challenge polling loop. These threads pile up and flood Robinhood with requests.

## Changes
| File | Change |
|------|--------|
| `app/brokers/robinhood_client.py` | Skip re-auth on 429 errors (session is still valid), raise immediately if in device challenge mode |

## Test plan
- [ ] Deploy and confirm no more `429 Too Many Requests` / `Check robinhood app for device approvals` spam in logs
- [ ] Verify normal session expiry still triggers re-login correctly