### PR TITLE
Consistent device_token via env var to prevent device challenges

### DIFF
--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -107,13 +107,14 @@ class RobinhoodTrader:
             )
             return
 
-        # No blob either — seed a stub pickle with the known device_token
+        # No blob either — seed a stub pickle with the static device_token
         # so robin_stocks reuses our approved device instead of generating
         # a random one that triggers Robinhood's device verification.
-        device_token = os.getenv("RH_DEVICE_TOKEN", "")
+        from app.config import Config
+        device_token = Config.RH_DEVICE_TOKEN
         if not device_token:
-            log.warning("[pickle] No blob pickle and RH_DEVICE_TOKEN not set — "
-                        "fresh login will generate a random device_token "
+            log.warning("[pickle] RH_DEVICE_TOKEN not set — "
+                        "robin_stocks will generate a random device_token "
                         "(may trigger device challenge)")
             return
 
@@ -126,7 +127,7 @@ class RobinhoodTrader:
         }
         with open(self._pickle_path, "wb") as f:
             pickle.dump(stub, f)
-        log.info("[pickle] Seeded stub pickle with RH_DEVICE_TOKEN=%s...%s",
+        log.info("[pickle] Seeded stub pickle with static device_token=%s...%s",
                  device_token[:8], device_token[-4:])
 
     def _upload_pickle_to_blob(self):

--- a/app/config.py
+++ b/app/config.py
@@ -24,7 +24,12 @@ class Config:
     RH_USER = os.getenv("RH_USER", "")
     RH_PASS = os.getenv("RH_PASS", "")
     RH_TOTP_SECRET = os.getenv("RH_TOTP_SECRET", "")
-    RH_DEVICE_TOKEN = os.getenv("RH_DEVICE_TOKEN", "")
+    # Static device token — approved by Robinhood for this account.
+    # Stored in Netlify env vars and Render env vars.
+    # Only change this if Robinhood revokes the device server-side.
+    RH_DEVICE_TOKEN = os.getenv(
+        "RH_DEVICE_TOKEN", "8508c7fc-a1f3-bc44-b23e-0f28b6d0ecdb"
+    )
     RH_PICKLE_NAME = os.getenv("RH_PICKLE_NAME", "taipei_session")
 
     # -- Robinhood session persistence --


### PR DESCRIPTION
## Summary
- Seed a stub pickle with `RH_DEVICE_TOKEN` env var when no local pickle or blob exists, so robin_stocks always uses our pre-approved device_token instead of generating a random one
- Fix `_ensure_auth` to tolerate HTTP 429 errors and block re-login when in device challenge mode

## Problem
When Render deploys destroy the local pickle AND the blob is unavailable, `robin_stocks.login()` generates a random `device_token` via `generate_device_token()`. Robinhood doesn't recognize the new device and triggers an infinite verification polling loop.

## How the fix works
robin_stocks' `login()` flow:
1. Calls `generate_device_token()` (random UUID)
2. If pickle file exists, **overwrites** the generated token with `pickle_data['device_token']`
3. Tests session with positions API
4. If test fails (expired tokens), falls through to fresh login **with the same device_token**

By seeding a stub pickle with our approved device_token, step 2 always picks up the known device, and step 4 logs in without triggering device verification.

## Fallback chain
```
1. Local pickle on disk         → use it (robin_stocks handles natively)
2. Blob pickle from Netlify     → download and restore
3. Stub pickle with env var     → seed with RH_DEVICE_TOKEN (last resort)
```

## Render env var
`RH_DEVICE_TOKEN=8508c7fc-a1f3-bc44-b23e-0f28b6d0ecdb` has been set on the Render service.

## Test plan
- [ ] Merge and deploy — should see `[pickle] Restored session pickle from blob store` (blob has the full pickle from today)
- [ ] To test stub fallback: delete the blob, redeploy — should see `[pickle] Seeded stub pickle with RH_DEVICE_TOKEN=8508c7fc...ecdb` and login should succeed without device challenge
- [ ] Verify no more 429 / device challenge spam in logs