### PR TITLE
Add dual-broker: Robinhood trades, Alpaca prices

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -37,6 +37,7 @@ def start_engine_thread(app):
 
             config = app.config
             broker = None
+            data_broker = None
             engine = None
             runtime = RuntimeClient(config["RUNTIME_SERVICE_URL"])
 
@@ -48,8 +49,10 @@ def start_engine_thread(app):
             last_blob_sync = 0.0
             retry_hour = config.get("RH_RETRY_HOUR_ET", 11)
 
-            log.info("Background engine started (interval=%ds, dry_run=%s, broker=%s)",
-                     interval, config["DRY_RUN"], config["ENGINE_BROKER"])
+            data_broker_name = config.get("DATA_BROKER", "")
+            log.info("Background engine started (interval=%ds, dry_run=%s, broker=%s, data_broker=%s)",
+                     interval, config["DRY_RUN"], config["ENGINE_BROKER"],
+                     data_broker_name or "none")
 
             positions = []
             open_orders = []
@@ -60,10 +63,19 @@ def start_engine_thread(app):
                 if broker is None:
                     try:
                         broker = get_broker(config["ENGINE_BROKER"])
+                        if data_broker_name and data_broker_name != config["ENGINE_BROKER"]:
+                            try:
+                                data_broker = get_broker(data_broker_name)
+                                log.info("Data broker (%s) initialized", data_broker_name)
+                            except Exception:
+                                log.exception("Failed to init data broker (%s) — continuing without",
+                                              data_broker_name)
+                                data_broker = None
                         engine = AllocationEngine(
                             trader=broker,
                             runtime=runtime,
                             dry_run=config["DRY_RUN"],
+                            data_broker=data_broker,
                         )
                         log.info("Broker initialized successfully")
                     except Exception as e:
@@ -87,6 +99,28 @@ def start_engine_thread(app):
                     positions = broker.positions()
                     open_orders = broker.open_orders()
                     account = broker.account()
+
+                    # Enrich positions with Alpaca market data prices
+                    if data_broker and hasattr(data_broker, "get_latest_prices") and positions:
+                        try:
+                            syms = [p["symbol"] for p in positions]
+                            prices = data_broker.get_latest_prices(syms)
+                            for p in positions:
+                                sym = p["symbol"]
+                                if sym in prices:
+                                    price = prices[sym]
+                                    qty = p["qty"]
+                                    p["current_price"] = price
+                                    p["market_value"] = round(qty * price, 2)
+                                    cost_basis = qty * p["avg_entry"]
+                                    p["unrealized_pl"] = round(qty * price - cost_basis, 2)
+                                    p["unrealized_pl_pct"] = round(
+                                        (qty * price - cost_basis) / cost_basis, 4
+                                    ) if cost_basis > 0 else 0.0
+                            log.info("[data] Enriched %d/%d positions with Alpaca prices",
+                                     len(prices), len(positions))
+                        except Exception:
+                            log.exception("Failed to enrich positions with Alpaca prices")
 
                     log.info(
                         f"[portfolio] Equity: ${account.get('equity', 0):,.2f} | "

--- a/app/brokers/alpaca_client.py
+++ b/app/brokers/alpaca_client.py
@@ -1,6 +1,8 @@
 """Alpaca trading client — wraps alpaca-py for order submission and account info."""
 
 import logging
+from alpaca.data.requests import StockLatestQuoteRequest
+from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import (
     LimitOrderRequest,
@@ -26,6 +28,7 @@ def _map_symbol(symbol: str) -> str:
 class AlpacaTrader:
     def __init__(self, api_key: str, secret_key: str, paper: bool = True):
         self.client = TradingClient(api_key, secret_key, paper=paper)
+        self.data_client = StockHistoricalDataClient(api_key, secret_key)
 
     # -- account / positions ------------------------------------------------
 
@@ -121,3 +124,25 @@ class AlpacaTrader:
     def cancel_order(self, order_id: str):
         self.client.cancel_order_by_id(order_id)
         log.info("Cancelled order %s", order_id)
+
+    # -- market data -----------------------------------------------------------
+
+    def get_latest_prices(self, symbols: list[str]) -> dict[str, float]:
+        """Fetch latest quote prices from Alpaca market data for the given symbols."""
+        if not symbols:
+            return {}
+        try:
+            mapped = [_map_symbol(s) for s in symbols]
+            req = StockLatestQuoteRequest(symbol_or_symbols=mapped)
+            quotes = self.data_client.get_stock_latest_quote(req)
+            prices = {}
+            for sym, quote in quotes.items():
+                # ask_price is more conservative; fall back to bid
+                price = float(quote.ask_price) if quote.ask_price else float(quote.bid_price)
+                prices[sym] = price
+            # Reverse-map symbols back to original names
+            reverse_map = {v: k for k, v in SYMBOL_MAP.items()}
+            return {reverse_map.get(k, k): v for k, v in prices.items()}
+        except Exception:
+            log.exception("Failed to fetch Alpaca prices for %s", symbols)
+            return {}

--- a/app/config.py
+++ b/app/config.py
@@ -45,4 +45,5 @@ class Config:
     POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "30"))
     DRY_RUN = os.getenv("DRY_RUN", "true").lower() == "true"
     ENGINE_ENABLED = os.getenv("ENGINE_ENABLED", "true").lower() == "true"
-    ENGINE_BROKER = os.getenv("ENGINE_BROKER", "alpaca")
+    ENGINE_BROKER = os.getenv("ENGINE_BROKER", "robinhood")
+    DATA_BROKER = os.getenv("DATA_BROKER", "alpaca")

--- a/app/engine.py
+++ b/app/engine.py
@@ -10,8 +10,15 @@ log = logging.getLogger(__name__)
 
 
 class AllocationEngine:
-    def __init__(self, trader: BrokerClient, runtime: RuntimeClient, dry_run: bool = True):
-        self.trader = trader
+    def __init__(
+        self,
+        trader: BrokerClient,
+        runtime: RuntimeClient,
+        dry_run: bool = True,
+        data_broker: BrokerClient | None = None,
+    ):
+        self.trader = trader          # execution broker (Robinhood)
+        self.data_broker = data_broker  # market data broker (Alpaca), optional
         self.runtime = runtime
         self.dry_run = dry_run
         self._last_snapshot_key: str | None = None


### PR DESCRIPTION
## Summary
- Adds `DATA_BROKER` config (default: alpaca) alongside `ENGINE_BROKER` (default: robinhood)
- Robinhood handles positions, orders, account, and order execution
- Alpaca provides live market prices via `get_latest_prices()` using `StockHistoricalDataClient`
- Background loop enriches Robinhood positions with Alpaca quote prices each tick

## Test plan
- [ ] Verify Robinhood auth works on Render with session pickle
- [ ] Verify Alpaca price enrichment logs show in Render logs
- [ ] Confirm positions show Alpaca-sourced current_price and updated P&L