### PR TITLE
Add trading API: history, P&L, options, quotes

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -6,7 +6,12 @@ def register_blueprints(app):
     from app.api.portfolio import bp as portfolio_bp
     from app.api.engine_api import bp as engine_bp
     from app.api.trade import bp as trade_bp
+    from app.api.quote import bp as quote_bp
+    from app.api.history import bp as history_bp
+    from app.api.options import bp as options_bp
+    from app.api.auth import bp as auth_bp
 
     for blueprint in [health_bp, account_bp, positions_bp, orders_bp,
-                      portfolio_bp, engine_bp, trade_bp]:
+                      portfolio_bp, engine_bp, trade_bp, quote_bp,
+                      history_bp, options_bp, auth_bp]:
         app.register_blueprint(blueprint, url_prefix="/api")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,29 @@
+"""Auth status API — check broker authentication state."""
+
+from flask import Blueprint, jsonify, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("auth", __name__)
+
+
+@bp.route("/auth/status")
+@bp.route("/auth/status/<broker_name>")
+def auth_status(broker_name=None):
+    """Return authentication status for the given broker."""
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        if hasattr(broker, "auth_status"):
+            return jsonify({"broker": broker_name, **broker.auth_status()})
+        # Generic fallback — if broker initialized, it's authenticated
+        return jsonify({
+            "broker": broker_name,
+            "authenticated": True,
+            "device_challenge_pending": False,
+        })
+    except Exception as e:
+        return jsonify({
+            "broker": broker_name,
+            "authenticated": False,
+            "error": str(e),
+        }), 500

--- a/app/api/history.py
+++ b/app/api/history.py
@@ -1,0 +1,38 @@
+"""Order history & P&L API."""
+
+from flask import Blueprint, jsonify, request, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("history", __name__)
+
+
+@bp.route("/orders/history")
+@bp.route("/orders/history/<broker_name>")
+def order_history(broker_name=None):
+    """Return recent order history (all states, not just open)."""
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    limit = request.args.get("limit", 50, type=int)
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "order_history"):
+            return jsonify({"error": f"Broker {broker_name} does not support order history"}), 400
+        data = broker.order_history(limit=limit)
+        return jsonify({"broker": broker_name, "count": len(data), "orders": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/pnl")
+@bp.route("/pnl/<broker_name>")
+def pnl(broker_name=None):
+    """Return realized P&L for the given time period."""
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    days = request.args.get("days", 30, type=int)
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "realized_pnl"):
+            return jsonify({"error": f"Broker {broker_name} does not support P&L"}), 400
+        data = broker.realized_pnl(days=days)
+        return jsonify({"broker": broker_name, **data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/options.py
+++ b/app/api/options.py
@@ -1,0 +1,37 @@
+"""Options API — positions and orders."""
+
+from flask import Blueprint, jsonify, request, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("options", __name__)
+
+
+@bp.route("/options/positions")
+@bp.route("/options/positions/<broker_name>")
+def options_positions(broker_name=None):
+    """Return current options positions."""
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "options_positions"):
+            return jsonify({"error": f"Broker {broker_name} does not support options"}), 400
+        data = broker.options_positions()
+        return jsonify({"broker": broker_name, "count": len(data), "positions": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/options/orders")
+@bp.route("/options/orders/<broker_name>")
+def options_orders(broker_name=None):
+    """Return recent options orders."""
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    limit = request.args.get("limit", 50, type=int)
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "options_orders"):
+            return jsonify({"error": f"Broker {broker_name} does not support options orders"}), 400
+        data = broker.options_orders(limit=limit)
+        return jsonify({"broker": broker_name, "count": len(data), "orders": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/quote.py
+++ b/app/api/quote.py
@@ -1,0 +1,55 @@
+"""Quote API — fetch live prices from the data broker (Alpaca)."""
+
+from flask import Blueprint, jsonify, request, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("quote", __name__)
+
+
+@bp.route("/quote/<symbol>")
+def quote(symbol):
+    """Get latest quote for a symbol via the data broker (Alpaca)."""
+    data_broker_name = current_app.config.get("DATA_BROKER", "")
+    if not data_broker_name:
+        return jsonify({"error": "DATA_BROKER not configured"}), 500
+
+    try:
+        broker = get_broker(data_broker_name)
+        if not hasattr(broker, "get_latest_quote"):
+            # Fall back to get_latest_prices
+            prices = broker.get_latest_prices([symbol.upper()])
+            price = prices.get(symbol.upper())
+            if price is None:
+                return jsonify({"error": f"No quote found for {symbol}"}), 404
+            return jsonify({
+                "symbol": symbol.upper(),
+                "price": price,
+                "bidPrice": None,
+                "askPrice": price,
+                "previousClose": None,
+            })
+
+        data = broker.get_latest_quote(symbol.upper())
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/quotes")
+def quotes():
+    """Get latest quotes for multiple symbols (comma-separated query param)."""
+    symbols_str = request.args.get("symbols", "")
+    if not symbols_str:
+        return jsonify({"error": "symbols query param required"}), 400
+
+    symbols = [s.strip().upper() for s in symbols_str.split(",") if s.strip()]
+    data_broker_name = current_app.config.get("DATA_BROKER", "")
+    if not data_broker_name:
+        return jsonify({"error": "DATA_BROKER not configured"}), 500
+
+    try:
+        broker = get_broker(data_broker_name)
+        prices = broker.get_latest_prices(symbols)
+        return jsonify({"prices": prices})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/app/api/trade.py
+++ b/app/api/trade.py
@@ -1,4 +1,4 @@
-"""Direct trading API — submit and cancel orders without the reconciliation loop."""
+"""Trading API — submit and cancel orders."""
 
 from flask import Blueprint, jsonify, request, current_app
 from app.brokers import get_broker
@@ -58,7 +58,7 @@ def place_order(broker_name=None):
         return jsonify({"error": "stop_price required for stop/stop_limit orders"}), 400
 
     # --- check dry_run ---
-    dry_run = body.get("dry_run", current_app.config.get("DRY_RUN", True))
+    dry_run = body.get("dry_run", body.get("dryRun", current_app.config.get("DRY_RUN", True)))
 
     order_dict = {
         "symbol": symbol.upper(),
@@ -71,6 +71,7 @@ def place_order(broker_name=None):
 
     if dry_run:
         return jsonify({
+            "status": "simulated",
             "dry_run": True,
             "broker": broker_name,
             "order": order_dict,
@@ -83,7 +84,9 @@ def place_order(broker_name=None):
         if result is None:
             return jsonify({"error": "Broker rejected the order", "order": order_dict}), 502
         return jsonify({
+            "status": "submitted",
             "broker": broker_name,
+            "orderId": result.get("id"),
             "order": order_dict,
             "result": result,
         }), 201
@@ -91,27 +94,54 @@ def place_order(broker_name=None):
         return jsonify({"error": str(e), "order": order_dict}), 500
 
 
-@bp.route("/trade/cancel/<order_id>", methods=["DELETE"])
-@bp.route("/trade/cancel/<order_id>/<broker_name>", methods=["DELETE"])
-def cancel_order(order_id, broker_name=None):
+# Convenience aliases for the UI
+@bp.route("/trade/buy", methods=["POST"])
+@bp.route("/trade/buy/<broker_name>", methods=["POST"])
+def buy(broker_name=None):
+    """Convenience: place a BUY order."""
+    data = request.get_json(force=True)
+    data["side"] = "BUY"
+    request._cached_json = (data, data)
+    return place_order(broker_name)
+
+
+@bp.route("/trade/sell", methods=["POST"])
+@bp.route("/trade/sell/<broker_name>", methods=["POST"])
+def sell(broker_name=None):
+    """Convenience: place a SELL order."""
+    data = request.get_json(force=True)
+    data["side"] = "SELL"
+    request._cached_json = (data, data)
+    return place_order(broker_name)
+
+
+@bp.route("/trade/cancel", methods=["POST", "DELETE"])
+@bp.route("/trade/cancel/<order_id>", methods=["POST", "DELETE"])
+@bp.route("/trade/cancel/<order_id>/<broker_name>", methods=["POST", "DELETE"])
+def cancel_order(order_id=None, broker_name=None):
     """Cancel a specific order by ID."""
     broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    if order_id is None:
+        body = request.get_json(silent=True) or {}
+        order_id = body.get("order_id")
+    if not order_id:
+        return jsonify({"error": "order_id required"}), 400
     try:
         broker = get_broker(broker_name)
         broker.cancel_order(order_id)
-        return jsonify({"broker": broker_name, "cancelled": order_id})
+        return jsonify({"status": "cancelled", "broker": broker_name, "order_id": order_id})
     except Exception as e:
         return jsonify({"error": str(e), "order_id": order_id}), 500
 
 
-@bp.route("/trade/cancel-all", methods=["DELETE"])
-@bp.route("/trade/cancel-all/<broker_name>", methods=["DELETE"])
+@bp.route("/trade/cancel-all", methods=["POST", "DELETE"])
+@bp.route("/trade/cancel-all/<broker_name>", methods=["POST", "DELETE"])
 def cancel_all(broker_name=None):
     """Cancel all open orders."""
     broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
     try:
         broker = get_broker(broker_name)
         broker.cancel_all()
-        return jsonify({"broker": broker_name, "message": "All orders cancelled"})
+        return jsonify({"status": "all_cancelled", "broker": broker_name})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/app/brokers/alpaca_client.py
+++ b/app/brokers/alpaca_client.py
@@ -146,3 +146,19 @@ class AlpacaTrader:
         except Exception:
             log.exception("Failed to fetch Alpaca prices for %s", symbols)
             return {}
+
+    def get_latest_quote(self, symbol: str) -> dict:
+        """Fetch detailed quote for a single symbol (bid, ask, last)."""
+        mapped = _map_symbol(symbol)
+        req = StockLatestQuoteRequest(symbol_or_symbols=[mapped])
+        quotes = self.data_client.get_stock_latest_quote(req)
+        quote = quotes.get(mapped)
+        if not quote:
+            raise ValueError(f"No quote found for {symbol}")
+        return {
+            "symbol": symbol,
+            "price": float(quote.ask_price) if quote.ask_price else float(quote.bid_price),
+            "bidPrice": float(quote.bid_price) if quote.bid_price else None,
+            "askPrice": float(quote.ask_price) if quote.ask_price else None,
+            "previousClose": None,
+        }

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -365,3 +365,249 @@ class RobinhoodTrader:
         self._ensure_auth()
         rh.orders.cancel_all_stock_orders()
         log.info("All RH stock orders cancelled")
+
+    # -- order history & P&L ------------------------------------------------
+
+    def order_history(self, limit: int = 50) -> list[dict]:
+        """Return recent filled/completed orders."""
+        self._ensure_auth()
+        all_orders = rh.orders.get_all_stock_orders()
+        result = []
+        for o in (all_orders or []):
+            if not isinstance(o, dict):
+                continue
+            symbol = _symbol_from_instrument(o.get("instrument", ""))
+            avg_price = o.get("average_price")
+            result.append({
+                "id": o.get("id"),
+                "symbol": symbol,
+                "side": o.get("side", "").upper(),
+                "quantity": float(o.get("quantity", 0)),
+                "filled_quantity": float(o.get("cumulative_quantity", 0)),
+                "price": float(avg_price) if avg_price else None,
+                "limit_price": float(o["price"]) if o.get("price") else None,
+                "stop_price": float(o["stop_price"]) if o.get("stop_price") else None,
+                "type": o.get("type", "market"),
+                "state": o.get("state", "unknown"),
+                "created_at": o.get("created_at", ""),
+                "updated_at": o.get("updated_at", ""),
+            })
+            if len(result) >= limit:
+                break
+        return result
+
+    def realized_pnl(self, days: int = 30) -> dict:
+        """Compute realized P&L from filled orders within the last N days."""
+        self._ensure_auth()
+        all_orders = rh.orders.get_all_stock_orders()
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+        buys: dict[str, list] = {}
+        sells: dict[str, list] = {}
+        total_buy_volume = 0.0
+        total_sell_volume = 0.0
+
+        for o in (all_orders or []):
+            if not isinstance(o, dict):
+                continue
+            if o.get("state") != "filled":
+                continue
+            created = o.get("created_at", "")
+            if not created:
+                continue
+            try:
+                order_time = datetime.fromisoformat(created.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            if order_time < cutoff:
+                continue
+
+            symbol = _symbol_from_instrument(o.get("instrument", ""))
+            qty = float(o.get("cumulative_quantity", 0))
+            avg_price = o.get("average_price")
+            if not avg_price or qty == 0:
+                continue
+            price = float(avg_price)
+            side = o.get("side", "")
+            volume = qty * price
+
+            entry = {"qty": qty, "price": price, "time": created}
+            if side == "buy":
+                buys.setdefault(symbol, []).append(entry)
+                total_buy_volume += volume
+            elif side == "sell":
+                sells.setdefault(symbol, []).append(entry)
+                total_sell_volume += volume
+
+        # Compute per-symbol realized P&L using average cost basis
+        symbols_pnl = []
+        total_realized = 0.0
+        all_symbols = set(list(buys.keys()) + list(sells.keys()))
+        for sym in sorted(all_symbols):
+            sym_buys = buys.get(sym, [])
+            sym_sells = sells.get(sym, [])
+            total_bought_qty = sum(b["qty"] for b in sym_buys)
+            total_bought_vol = sum(b["qty"] * b["price"] for b in sym_buys)
+            total_sold_qty = sum(s["qty"] for s in sym_sells)
+            total_sold_vol = sum(s["qty"] * s["price"] for s in sym_sells)
+            avg_buy_price = total_bought_vol / total_bought_qty if total_bought_qty > 0 else 0
+            avg_sell_price = total_sold_vol / total_sold_qty if total_sold_qty > 0 else 0
+            matched_qty = min(total_bought_qty, total_sold_qty)
+            realized = matched_qty * (avg_sell_price - avg_buy_price) if matched_qty > 0 else 0
+
+            total_realized += realized
+            symbols_pnl.append({
+                "symbol": sym,
+                "realizedPnL": round(realized, 2),
+                "totalBought": round(total_bought_vol, 2),
+                "totalSold": round(total_sold_vol, 2),
+                "buyCount": len(sym_buys),
+                "sellCount": len(sym_sells),
+                "avgBuyPrice": round(avg_buy_price, 4),
+                "avgSellPrice": round(avg_sell_price, 4),
+                "remainingShares": round(total_bought_qty - total_sold_qty, 4),
+            })
+
+        return {
+            "totalRealizedPnL": round(total_realized, 2),
+            "totalBuyVolume": round(total_buy_volume, 2),
+            "totalSellVolume": round(total_sell_volume, 2),
+            "days": days,
+            "symbols": symbols_pnl,
+        }
+
+    # -- options ------------------------------------------------------------
+
+    def options_positions(self) -> list[dict]:
+        """Return current options positions."""
+        self._ensure_auth()
+        try:
+            raw = rh.options.get_open_option_positions()
+        except Exception:
+            log.exception("Failed to fetch options positions")
+            return []
+
+        result = []
+        for pos in (raw or []):
+            if not isinstance(pos, dict):
+                continue
+            qty = float(pos.get("quantity", 0))
+            if qty == 0:
+                continue
+
+            chain_symbol = pos.get("chain_symbol", "")
+            option_type = pos.get("type", "")
+            avg_price = float(pos.get("average_price", 0)) / 100  # RH stores in cents
+            trade_value_multiplier = float(pos.get("trade_value_multiplier", 100))
+
+            # Get option instrument details
+            option_data = {}
+            option_url = pos.get("option", "")
+            if option_url:
+                try:
+                    option_data = rh.options.get_option_instrument_data_by_id(
+                        pos.get("option_id", "")
+                    ) or {}
+                except Exception:
+                    pass
+
+            strike = float(option_data.get("strike_price", 0))
+            expiration = option_data.get("expiration_date", "")
+
+            # Calculate DTE
+            dte = 0
+            if expiration:
+                try:
+                    exp_date = datetime.strptime(expiration, "%Y-%m-%d").date()
+                    dte = (exp_date - datetime.now(timezone.utc).date()).days
+                except (ValueError, TypeError):
+                    pass
+
+            # Get market data for this option
+            mark_price = avg_price
+            try:
+                market_data = rh.options.get_option_market_data(
+                    chain_symbol, expiration, str(strike),
+                    option_type, info=None
+                )
+                if market_data and isinstance(market_data, list) and market_data[0]:
+                    md = market_data[0]
+                    mark_price = float(md.get("mark_price", avg_price))
+            except Exception:
+                pass
+
+            cost_basis = qty * avg_price * trade_value_multiplier
+            current_value = qty * mark_price * trade_value_multiplier
+            unrealized_pl = current_value - cost_basis
+
+            result.append({
+                "chain_symbol": chain_symbol,
+                "option_type": option_type,
+                "strike": strike,
+                "expiration": expiration,
+                "dte": dte,
+                "quantity": qty,
+                "avg_price": round(avg_price, 4),
+                "mark_price": round(mark_price, 4),
+                "multiplier": trade_value_multiplier,
+                "cost_basis": round(cost_basis, 2),
+                "current_value": round(current_value, 2),
+                "unrealized_pl": round(unrealized_pl, 2),
+                "unrealized_pl_pct": round(unrealized_pl / cost_basis, 4) if cost_basis else 0,
+            })
+        return result
+
+    def options_orders(self, limit: int = 50) -> list[dict]:
+        """Return recent options orders."""
+        self._ensure_auth()
+        try:
+            raw = rh.orders.get_all_option_orders()
+        except Exception:
+            log.exception("Failed to fetch options orders")
+            return []
+
+        result = []
+        for o in (raw or []):
+            if not isinstance(o, dict):
+                continue
+            legs = []
+            for leg in o.get("legs", []):
+                legs.append({
+                    "side": leg.get("side", ""),
+                    "position_effect": leg.get("position_effect", ""),
+                    "quantity": float(leg.get("quantity", 0)) if leg.get("quantity") else 0,
+                    "strike": float(leg.get("strike_price", 0)) if leg.get("strike_price") else 0,
+                    "expiration": leg.get("expiration_date", ""),
+                    "option_type": leg.get("option_type", ""),
+                    "chain_symbol": o.get("chain_symbol", ""),
+                })
+
+            result.append({
+                "order_id": o.get("id", ""),
+                "state": o.get("state", ""),
+                "quantity": float(o.get("quantity", 0)),
+                "price": float(o.get("price", 0)) if o.get("price") else 0,
+                "premium": float(o.get("premium", 0)) if o.get("premium") else 0,
+                "processed_premium": float(o.get("processed_premium", 0)) if o.get("processed_premium") else 0,
+                "direction": o.get("direction", ""),
+                "order_type": o.get("type", ""),
+                "trigger": o.get("trigger", ""),
+                "time_in_force": o.get("time_in_force", ""),
+                "opening_strategy": o.get("opening_strategy") or o.get("closing_strategy") or "",
+                "created_at": o.get("created_at", ""),
+                "updated_at": o.get("updated_at", ""),
+                "legs": legs,
+            })
+            if len(result) >= limit:
+                break
+        return result
+
+    # -- auth status --------------------------------------------------------
+
+    def auth_status(self) -> dict:
+        """Return current authentication state."""
+        return {
+            "authenticated": self._authenticated,
+            "device_challenge_pending": self._device_challenge_mode,
+            "email": self.email,
+        }


### PR DESCRIPTION
## Summary
- Trade endpoints: `POST /api/trade/buy`, `/sell`, `/cancel`, `/cancel-all` with dry-run support
- Quote endpoints: `GET /api/quote/<symbol>`, `/api/quotes?symbols=` via Alpaca data
- Order history: `GET /api/orders/history?limit=` — all order states from Robinhood
- Realized P&L: `GET /api/pnl?days=` — per-symbol P&L with buy/sell aggregation
- Options: `GET /api/options/positions`, `/api/options/orders` — positions with DTE, orders with legs
- Auth: `GET /api/auth/status` — authentication & device challenge state

Covers the data contracts needed by the allocation-manager trade page UI.

## Test plan
- [ ] Verify quote endpoint returns prices from Alpaca live API
- [ ] Verify order history returns filled orders from Robinhood
- [ ] Verify P&L calculation matches manual computation
- [ ] Verify options positions/orders return correctly
- [ ] Verify trade buy/sell dry-run mode works