### PR TITLE
Add risk event Observer pattern with drift detection

### DIFF
--- a/app/brokers/alpaca_client.py
+++ b/app/brokers/alpaca_client.py
@@ -13,6 +13,7 @@ from alpaca.trading.requests import (
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.common.exceptions import APIError
 
+from app.brokers.base import BrokerClient
 from app.enums import OrderSide as AppOrderSide, OrderType
 
 log = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ def _map_symbol(symbol: str) -> str:
     return SYMBOL_MAP.get(symbol, symbol)
 
 
-class AlpacaTrader:
+class AlpacaTrader(BrokerClient):
     def __init__(self, api_key: str, secret_key: str, paper: bool = True):
         self.client = TradingClient(api_key, secret_key, paper=paper)
         self.data_client = StockHistoricalDataClient(api_key, secret_key)

--- a/app/brokers/base.py
+++ b/app/brokers/base.py
@@ -1,36 +1,41 @@
-"""Abstract broker interface — all broker implementations must satisfy this protocol."""
+"""Abstract broker interface — all broker implementations must inherit from this ABC."""
 
-from typing import Protocol, runtime_checkable
+from abc import ABC, abstractmethod
 
 
-@runtime_checkable
-class BrokerClient(Protocol):
-    """Interface that all broker implementations must satisfy."""
+class BrokerClient(ABC):
+    """Base class that all broker implementations must subclass."""
 
+    @abstractmethod
     def account(self) -> dict:
         """Return account summary: equity, cash, buying_power, portfolio_value."""
-        ...
+        pass
 
+    @abstractmethod
     def positions(self) -> list[dict]:
         """Return list of position dicts with standardized keys:
         symbol, qty, side, market_value, avg_entry, unrealized_pl, unrealized_pl_pct
         """
-        ...
+        pass
 
+    @abstractmethod
     def open_orders(self) -> list[dict]:
         """Return list of open order dicts with standardized keys:
         id, symbol, side, qty, type, limit_price, stop_price, status
         """
-        ...
+        pass
 
+    @abstractmethod
     def submit_order(self, order: dict) -> dict | None:
         """Submit an order. Returns order confirmation dict or None on failure."""
-        ...
+        pass
 
+    @abstractmethod
     def cancel_order(self, order_id: str) -> None:
         """Cancel a specific order by ID."""
-        ...
+        pass
 
+    @abstractmethod
     def cancel_all(self) -> None:
         """Cancel all open orders."""
-        ...
+        pass

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import pyotp
 import robin_stocks.robinhood as rh
 
+from app.brokers.base import BrokerClient
 from app.enums import OrderType
 from app.pickle_store import download_pickle, upload_pickle
 from app.slack import notify as slack_notify
@@ -60,7 +61,7 @@ def seconds_until_hour_et(hour: int = 11) -> float:
     return (target - now_et).total_seconds()
 
 
-class RobinhoodTrader:
+class RobinhoodTrader(BrokerClient):
     def __init__(
         self,
         email: str,

--- a/app/engine.py
+++ b/app/engine.py
@@ -1,13 +1,20 @@
 """Core allocation engine — reads desired state from the runtime service,
 reconciles against broker positions/orders, and submits the delta."""
 
+from __future__ import annotations
+
 import logging
 
 from app.brokers.base import BrokerClient
-from app.enums import OrderSide
+from app.enums import OrderSide, RiskEventType
+from app.risk.events import RiskEvent
+from app.risk.observer import RiskSubject
+from app.risk.rebalancer_observer import RebalancerObserver
 from app.runtime_client import RuntimeClient
 
 log = logging.getLogger(__name__)
+
+DRIFT_THRESHOLD = 0.08  # 8 %
 
 
 class AllocationEngine:
@@ -18,6 +25,7 @@ class AllocationEngine:
         dry_run: bool = True,
         data_broker: BrokerClient | None = None,
         max_order_qty: int = 50,
+        risk_subject: RiskSubject | None = None,
     ):
         self.trader = trader          # execution broker (Robinhood)
         self.data_broker = data_broker  # market data broker (Alpaca), optional
@@ -26,10 +34,19 @@ class AllocationEngine:
         self.max_order_qty = max_order_qty
         self._last_snapshot_key: str | None = None
 
+        # Risk event bus — observers attach here
+        self.risk_subject = risk_subject or RiskSubject()
+        self._rebalancer: RebalancerObserver | None = None
+
+    def register_rebalancer(self, rebalancer: RebalancerObserver) -> None:
+        """Attach a rebalancer so drift-triggered orders flow back into execution."""
+        self._rebalancer = rebalancer
+        self.risk_subject.attach(rebalancer)
+
     # -- public -------------------------------------------------------------
 
     def tick(self):
-        """Single reconciliation cycle: read desired state -> diff -> execute."""
+        """Single reconciliation cycle: read desired state -> drift check -> diff -> execute."""
         state = self.runtime.state()
         snapshot_key = state.get("snapshot_key")
 
@@ -44,13 +61,147 @@ class AllocationEngine:
         current_orders = self.trader.open_orders()
         current_positions = self.trader.positions()
 
+        # --- fetch market data & log consolidated view ---
+        market_data = self._fetch_market_data()
+        self._log_tick_summary(current_positions, current_orders, market_data)
+
+        # --- drift check ---
+        if market_data and current_positions:
+            self._check_drift(current_positions, market_data, snapshot_key)
+
         new_orders, stale_order_ids = self._reconcile(
             desired_orders, current_orders, current_positions
         )
 
+        # Append any rebalance orders queued by the rebalancer observer
+        if self._rebalancer:
+            rebalance_orders = self._rebalancer.drain()
+            if rebalance_orders:
+                log.info("Adding %d rebalance order(s) from drift events", len(rebalance_orders))
+                new_orders.extend(rebalance_orders)
+
         self._execute(new_orders, stale_order_ids)
 
     # -- internals ----------------------------------------------------------
+
+    def _fetch_market_data(self) -> dict:
+        """Pull market data from the runtime service. Returns ticker→metrics map."""
+        try:
+            data = self.runtime.market_data()
+            # Broadcast price updates to observers
+            for symbol, metrics in data.get("tickers", {}).items():
+                price = metrics.get("price")
+                if price is not None:
+                    self.risk_subject.set_price(symbol, float(price))
+            return data
+        except Exception:
+            log.exception("Failed to fetch market data — skipping drift check")
+            return {}
+
+    def _log_tick_summary(
+        self,
+        positions: list[dict],
+        open_orders: list[dict],
+        market_data: dict,
+    ) -> None:
+        """Log a consolidated view of market prices, positions, and open orders each tick.
+
+        Produces one table per tick so operators can visually cross-reference
+        market price vs entry price vs order limit price and spot drift.
+        """
+        tickers = market_data.get("tickers", {})
+
+        # Collect every symbol we know about
+        all_symbols: set[str] = set()
+        pos_map: dict[str, dict] = {}
+        for p in positions:
+            sym = p["symbol"]
+            all_symbols.add(sym)
+            pos_map[sym] = p
+
+        order_map: dict[str, list[dict]] = {}
+        for o in open_orders:
+            sym = o["symbol"]
+            all_symbols.add(sym)
+            order_map.setdefault(sym, []).append(o)
+
+        all_symbols.update(tickers.keys())
+
+        if not all_symbols:
+            log.info("No positions, orders, or market data to display")
+            return
+
+        # Header
+        log.info(
+            "%-6s  %10s  %10s  %6s  %8s  %10s  %6s  %s",
+            "SYM", "MKT PRICE", "ENTRY", "QTY", "MV", "ORD PRICE", "DRIFT", "FLAG",
+        )
+        log.info("-" * 80)
+
+        for sym in sorted(all_symbols):
+            mkt = tickers.get(sym, {})
+            pos = pos_map.get(sym)
+            orders = order_map.get(sym, [])
+
+            mkt_price = mkt.get("price")
+            drift = mkt.get("drift_pct", 0)
+            flag = "DRIFT" if abs(drift) >= DRIFT_THRESHOLD else ""
+
+            mkt_str = f"${mkt_price:,.2f}" if mkt_price is not None else "-"
+            entry_str = f"${pos['avg_entry']:,.2f}" if pos and pos.get("avg_entry") else "-"
+            qty_str = str(pos["qty"]) if pos else "-"
+            mv_str = f"${pos['market_value']:,.2f}" if pos and pos.get("market_value") is not None else "-"
+            drift_str = f"{drift:+.2%}" if mkt else "-"
+
+            if orders:
+                for o in orders:
+                    lp = o.get("limit_price")
+                    ord_str = f"${lp:,.2f}" if lp else "MKT"
+                    ord_label = f"{o['side']} {o['qty']}@{ord_str}"
+                    log.info(
+                        "%-6s  %10s  %10s  %6s  %8s  %10s  %6s  %s",
+                        sym, mkt_str, entry_str, qty_str, mv_str, ord_label, drift_str, flag,
+                    )
+                    # Only show position columns on the first row for this symbol
+                    entry_str = ""
+                    qty_str = ""
+                    mv_str = ""
+            else:
+                log.info(
+                    "%-6s  %10s  %10s  %6s  %8s  %10s  %6s  %s",
+                    sym, mkt_str, entry_str, qty_str, mv_str, "-", drift_str, flag,
+                )
+
+        log.info("-" * 80)
+
+    def _check_drift(
+        self,
+        positions: list[dict],
+        market_data: dict,
+        snapshot_key: str | None,
+    ) -> None:
+        """Compare position drift against threshold; emit risk events if breached."""
+        tickers = market_data.get("tickers", {})
+        for pos in positions:
+            symbol = pos["symbol"]
+            metrics = tickers.get(symbol)
+            if not metrics:
+                continue
+            drift = abs(metrics.get("drift_pct", 0))
+            if drift >= DRIFT_THRESHOLD:
+                event = RiskEvent(
+                    event_type=RiskEventType.STRUCTURAL_DRIFT,
+                    symbol=symbol,
+                    drift_pct=drift,
+                    message=(
+                        f"{symbol} drift {drift:.2%} exceeds {DRIFT_THRESHOLD:.0%} threshold "
+                        f"— possible structural change"
+                    ),
+                    snapshot_key=snapshot_key,
+                    metadata={"position_qty": pos.get("qty", 0)},
+                )
+                log.warning("RISK EVENT: %s", event.message)
+                self.risk_subject.notify(event)
 
     def _desired_orders(self) -> list[dict]:
         """Fetch the target order set from the runtime service."""
@@ -86,15 +237,10 @@ class AllocationEngine:
             o["id"] for key, o in current_map.items() if key not in desired_keys
         ]
 
-        position_symbols = {p["symbol"] for p in current_positions}
-
         to_submit = []
         for o in desired:
             key = _order_key(o)
             if key in current_map:
-                continue
-            if o["symbol"] in position_symbols and o["side"] == OrderSide.BUY:
-                log.info("Skipping %s BUY — already holding position", o["symbol"])
                 continue
             to_submit.append(o)
 
@@ -124,9 +270,12 @@ class AllocationEngine:
                 order["quantity"] = self.max_order_qty
 
             if self.dry_run:
-                log.info("[DRY RUN] Would submit: %s %s %s @ %s",
+                otype = order.get("order_type", "market")
+                lp = order.get("limit_price")
+                price_str = f"${lp:,.2f}" if lp else "MKT"
+                log.info("[DRY RUN] Would submit: %s %s %s %s @ %s",
                          order["side"], order["quantity"],
-                         order["symbol"], order.get("limit_price", "MKT"))
+                         order["symbol"], otype, price_str)
             else:
                 result = self.trader.submit_order(order)
                 results.append(result)

--- a/app/enums.py
+++ b/app/enums.py
@@ -1,4 +1,4 @@
-"""Shared enums for order side, type, asset type, state, and trigger."""
+"""Shared enums for order side, type, asset type, state, trigger, and risk events."""
 
 from enum import StrEnum
 
@@ -43,3 +43,10 @@ OPEN_STATES = frozenset({
 class OrderTrigger(StrEnum):
     IMMEDIATE = "immediate"
     STOP = "stop"
+
+
+class RiskEventType(StrEnum):
+    """Risk events emitted during engine reconciliation."""
+    STRUCTURAL_DRIFT = "structural_drift"   # drift > threshold → possible structural change
+    POSITION_LIMIT = "position_limit"       # position exceeds concentration limit
+    ORDER_REJECTED = "order_rejected"       # broker rejected an order

--- a/app/risk/__init__.py
+++ b/app/risk/__init__.py
@@ -1,0 +1,15 @@
+"""Risk event infrastructure — Observer pattern for DQ events."""
+
+from app.risk.events import RiskEvent
+from app.risk.observer import RiskObserver, Subject, RiskSubject
+from app.risk.slack_observer import SlackAlertObserver
+from app.risk.rebalancer_observer import RebalancerObserver
+
+__all__ = [
+    "RiskEvent",
+    "RiskObserver",
+    "Subject",
+    "RiskSubject",
+    "SlackAlertObserver",
+    "RebalancerObserver",
+]

--- a/app/risk/events.py
+++ b/app/risk/events.py
@@ -1,0 +1,29 @@
+"""Risk event data model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from app.enums import RiskEventType
+
+
+@dataclass(frozen=True)
+class RiskEvent:
+    """Immutable risk event emitted by the engine during reconciliation."""
+
+    event_type: RiskEventType
+    symbol: str
+    drift_pct: float                          # observed drift as a decimal (0.09 = 9%)
+    message: str
+    snapshot_key: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def severity(self) -> str:
+        if self.drift_pct >= 0.15:
+            return "critical"
+        if self.drift_pct >= 0.08:
+            return "warning"
+        return "info"

--- a/app/risk/observer.py
+++ b/app/risk/observer.py
@@ -1,0 +1,123 @@
+"""Observer pattern base classes for risk event dispatch.
+
+Follows the classic Subject/Observer ABC pattern:
+  - Observer(ABC)  defines  @abstractmethod update(symbol, price)
+  - Subject(ABC)   defines  @abstractmethod attach / detach / notify_observers
+  - RiskSubject    is the concrete Subject that manages subscriptions + dispatch
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+
+from app.enums import RiskEventType
+from app.risk.events import RiskEvent
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Observer ABC
+# ---------------------------------------------------------------------------
+
+class RiskObserver(ABC):
+    """Interface that all risk-event subscribers must implement."""
+
+    @abstractmethod
+    def update(self, symbol: str, price: float) -> None:
+        """Called when a watched symbol's price changes."""
+        pass
+
+    @abstractmethod
+    def on_risk_event(self, event: RiskEvent) -> None:
+        """Called when a risk DQ event is emitted."""
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Subject ABC
+# ---------------------------------------------------------------------------
+
+class Subject(ABC):
+    """Abstract subject (observable) that observers subscribe to."""
+
+    @abstractmethod
+    def attach(self, observer: RiskObserver, event_type: RiskEventType | None = None) -> None:
+        pass
+
+    @abstractmethod
+    def detach(self, observer: RiskObserver) -> None:
+        pass
+
+    @abstractmethod
+    def notify_observers(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Concrete Subject
+# ---------------------------------------------------------------------------
+
+class RiskSubject(Subject):
+    """Concrete observable that dispatches RiskEvents to registered observers.
+
+    Observers can subscribe globally or to specific event types.
+    """
+
+    def __init__(self) -> None:
+        self._observers: list[tuple[RiskObserver, RiskEventType | None]] = []
+        self._last_event: RiskEvent | None = None
+
+    def attach(
+        self,
+        observer: RiskObserver,
+        event_type: RiskEventType | None = None,
+    ) -> None:
+        """Register an observer. If *event_type* is None, it receives all events."""
+        self._observers.append((observer, event_type))
+        log.info(
+            "Attached %s (filter=%s)",
+            observer.__class__.__name__,
+            event_type or "ALL",
+        )
+
+    def detach(self, observer: RiskObserver) -> None:
+        self._observers = [
+            (obs, et) for obs, et in self._observers if obs is not observer
+        ]
+
+    def notify_observers(self) -> None:
+        """Dispatch the most recent event to all matching observers."""
+        if self._last_event is None:
+            return
+        self._dispatch(self._last_event)
+
+    def notify(self, event: RiskEvent) -> None:
+        """Store *event* and dispatch to all matching observers."""
+        self._last_event = event
+        self._dispatch(event)
+
+    def set_price(self, symbol: str, price: float) -> None:
+        """Broadcast a price update to all observers (mirrors Stock.set_price in the diagram)."""
+        for observer, _filter_type in self._observers:
+            try:
+                observer.update(symbol, price)
+            except Exception:
+                log.exception(
+                    "Observer %s failed on update(%s, %s)",
+                    observer.__class__.__name__, symbol, price,
+                )
+
+    def _dispatch(self, event: RiskEvent) -> None:
+        for observer, filter_type in self._observers:
+            if filter_type is not None and filter_type != event.event_type:
+                continue
+            try:
+                observer.on_risk_event(event)
+            except Exception:
+                log.exception(
+                    "Observer %s failed on %s",
+                    observer.__class__.__name__,
+                    event.event_type,
+                )

--- a/app/risk/rebalancer_observer.py
+++ b/app/risk/rebalancer_observer.py
@@ -1,0 +1,55 @@
+"""Rebalancer observer — reacts to structural drift by queuing rebalance orders."""
+
+from __future__ import annotations
+
+import logging
+
+from app.enums import OrderSide, RiskEventType
+from app.risk.events import RiskEvent
+from app.risk.observer import RiskObserver
+
+log = logging.getLogger(__name__)
+
+
+class RebalancerObserver(RiskObserver):
+    """On STRUCTURAL_DRIFT, generates a market sell to flatten the drifted position.
+
+    Rebalance orders are collected in ``pending_orders`` so the engine can
+    pick them up on the next execution pass.
+    """
+
+    def __init__(self) -> None:
+        self.pending_orders: list[dict] = []
+
+    def update(self, symbol: str, price: float) -> None:
+        """Price update — rebalancer only acts on risk events, not raw prices."""
+        pass
+
+    def on_risk_event(self, event: RiskEvent) -> None:
+        if event.event_type != RiskEventType.STRUCTURAL_DRIFT:
+            return
+
+        position_qty = event.metadata.get("position_qty", 0)
+        if position_qty <= 0:
+            log.info("No position to rebalance for %s, skipping", event.symbol)
+            return
+
+        order = {
+            "symbol": event.symbol,
+            "side": OrderSide.SELL,
+            "quantity": position_qty,
+            "order_type": "market",
+            "limit_price": None,
+            "reason": f"structural_drift:{event.drift_pct:.2%}",
+        }
+        self.pending_orders.append(order)
+        log.warning(
+            "Rebalance queued: SELL %s %s (drift=%s)",
+            position_qty, event.symbol, f"{event.drift_pct:.2%}",
+        )
+
+    def drain(self) -> list[dict]:
+        """Return and clear all pending rebalance orders."""
+        orders = self.pending_orders
+        self.pending_orders = []
+        return orders

--- a/app/risk/slack_observer.py
+++ b/app/risk/slack_observer.py
@@ -1,0 +1,45 @@
+"""Slack alerting observer — posts DQ events to a Slack webhook."""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from app.risk.events import RiskEvent
+from app.risk.observer import RiskObserver
+
+log = logging.getLogger(__name__)
+
+_SEVERITY_EMOJI = {"critical": ":rotating_light:", "warning": ":warning:", "info": ":information_source:"}
+
+
+class SlackAlertObserver(RiskObserver):
+    """Posts risk events to a Slack incoming-webhook URL."""
+
+    def __init__(self, webhook_url: str, timeout: int = 10) -> None:
+        self.webhook_url = webhook_url
+        self.timeout = timeout
+
+    def update(self, symbol: str, price: float) -> None:
+        """Price update — Slack observer only acts on risk events, not raw prices."""
+        pass
+
+    def on_risk_event(self, event: RiskEvent) -> None:
+        emoji = _SEVERITY_EMOJI.get(event.severity, "")
+        text = (
+            f"{emoji} *Risk DQ — {event.event_type.value.replace('_', ' ').title()}*\n"
+            f">*Symbol:* `{event.symbol}`\n"
+            f">*Drift:* {event.drift_pct:.2%}\n"
+            f">*Severity:* {event.severity}\n"
+            f">*Snapshot:* `{event.snapshot_key or 'n/a'}`\n"
+            f">_{event.message}_"
+        )
+        payload = {"text": text}
+
+        try:
+            resp = requests.post(self.webhook_url, json=payload, timeout=self.timeout)
+            resp.raise_for_status()
+            log.info("Slack alert sent for %s %s", event.symbol, event.event_type)
+        except requests.RequestException:
+            log.exception("Failed to send Slack alert for %s", event.symbol)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ For production, use: gunicorn app.wsgi:application
 
 import argparse
 import logging
+import os
 import sys
 import time
 
@@ -13,6 +14,7 @@ from app import create_app
 from app.config import Config
 from app.engine import AllocationEngine
 from app.brokers import get_broker
+from app.risk import RiskSubject, SlackAlertObserver, RebalancerObserver
 from app.runtime_client import RuntimeClient
 
 logging.basicConfig(
@@ -65,10 +67,26 @@ def status(engine: AllocationEngine, broker_name: str):
         print(f"  {o['side']} {o['quantity']} {o['symbol']} "
               f"{o.get('order_type', 'market')} @ {o.get('limit_price', 'MKT')}")
 
+    # -- Market data & drift --
+    try:
+        mkt = engine.runtime.market_data()
+        tickers = mkt.get("tickers", {})
+        print(f"\n=== Market Data ({len(tickers)} tickers) ===")
+        for sym, m in sorted(tickers.items()):
+            drift = m.get("drift_pct", 0)
+            flag = " ** DRIFT" if abs(drift) >= 0.08 else ""
+            price = m.get("price")
+            price_str = f"${price:,.2f}" if price is not None else "n/a"
+            print(f"  {sym:6s}  {price_str:>12s}  "
+                  f"target={m.get('target_pct', 0):6.2%}  "
+                  f"actual={m.get('actual_pct', 0):6.2%}  "
+                  f"drift={drift:+6.2%}{flag}")
+    except Exception as e:
+        print(f"\n=== Market Data (unavailable: {e}) ===")
+
 
 def serve():
     """Run the Flask development server (use gunicorn for production)."""
-    import os
     app = create_app()
     port = int(os.getenv("PORT", "10000"))
     app.run(host="0.0.0.0", port=port, debug=Config.DEBUG)
@@ -97,7 +115,19 @@ def main():
     with app.app_context():
         broker = get_broker(args.broker)
         runtime = RuntimeClient(Config.RUNTIME_SERVICE_URL)
-        engine = AllocationEngine(trader=broker, runtime=runtime, dry_run=Config.DRY_RUN)
+
+        # Set up risk event bus with observers
+        risk_subject = RiskSubject()
+        slack_url = os.getenv("SLACK_WEBHOOK_URL")
+        if slack_url:
+            risk_subject.attach(SlackAlertObserver(slack_url))
+        rebalancer = RebalancerObserver()
+
+        engine = AllocationEngine(
+            trader=broker, runtime=runtime,
+            dry_run=Config.DRY_RUN, risk_subject=risk_subject,
+        )
+        engine.register_rebalancer(rebalancer)
 
         if args.command == "run":
             run_loop(engine, Config.POLL_INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary

- Observer/Subject ABCs for risk events with concrete `RiskSubject` dispatch
- `SlackAlertObserver` (DQ alerts) and `RebalancerObserver` (queues flatten-sells on drift >= 8%)
- `BrokerClient` converted from Protocol to ABC — both brokers now inherit with `@abstractmethod` enforcement
- Consolidated tick logging: market price vs entry vs order price vs drift each tick
- Limit buy/sell orders flow through reconciliation (removed blanket BUY-skip)

## Developer operational checks

When working on this codebase, run these before pushing:

```bash
# 1. Import smoke test — catches circular imports and missing ABC implementations
python -c "from app.engine import AllocationEngine; from app.risk import RiskSubject, SlackAlertObserver, RebalancerObserver"

# 2. ABC enforcement — should TypeError, proving contracts are enforced
python -c "from app.brokers.base import BrokerClient; BrokerClient()"
python -c "from app.risk.observer import RiskObserver; RiskObserver()"

# 3. Dry-run tick — full cycle without live orders
DRY_RUN=true python main.py once --broker alpaca

# 4. Type check on the new modules
mypy app/brokers/base.py app/risk/ app/engine.py

# 5. Status command — validates market data formatting
python main.py status --broker alpaca
```

When adding a new observer: inherit `RiskObserver`, implement `update()` and `on_risk_event()`, attach via `risk_subject.attach()` in `main.py`. The ABC will fail at instantiation if you miss a method.

When adding a new broker: inherit `BrokerClient`, implement all 6 abstract methods. Register in `app/brokers/__init__.py`.

## Testing plan

- [ ] Deploy to staging with `DRY_RUN=true`, run `once`, confirm tick table + drift flags in logs
- [ ] Set `SLACK_WEBHOOK_URL` to test channel, verify alert fires on high-drift ticker
- [ ] Flip to paper trading, confirm limit buy + sell orders submit correctly

next - launch for scaled IWN BTC dca for Mar-23 