### PR TITLE
Add refresh_pickle_watch.py wrapper with bounded retry + backoff

### DIFF
--- a/scripts/refresh_pickle.py
+++ b/scripts/refresh_pickle.py
@@ -44,8 +44,9 @@ def login():
         pickle.dump(stub, f)
     print(f"Using device_token={DEVICE_TOKEN[:8]}...{DEVICE_TOKEN[-4:]}")
 
-    email = Config.RH_USER or input("Robinhood email: ").strip()
-    password = Config.RH_PASS or input("Robinhood password: ").strip()
+    env_email, env_password = Config.rh_credentials()
+    email = env_email or input("Robinhood email: ").strip()
+    password = env_password or input("Robinhood password: ").strip()
 
     mfa_code = None
     if Config.RH_TOTP_SECRET:

--- a/scripts/refresh_pickle_watch.py
+++ b/scripts/refresh_pickle_watch.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Bounded-retry wrapper around scripts/refresh_pickle.py.
+
+Robinhood's login endpoint will return 429 if hammered (see CLAUDE.md
+"429 rate limit storm"). This wrapper attempts the refresh up to 5 times
+with exponential backoff, pings Slack on failures, and — when run from a
+TTY — prompts the user to re-arm the retry budget once it's exhausted so
+they can resume after Robinhood cools off without re-entering credentials.
+
+Run locally:  python scripts/refresh_pickle_watch.py
+"""
+
+import importlib.util
+import os
+import sys
+import time
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, ROOT)
+
+from app.config import Config
+from app.slack import notify as slack_notify
+
+_RP_PATH = os.path.join(os.path.dirname(__file__), "refresh_pickle.py")
+_spec = importlib.util.spec_from_file_location("refresh_pickle", _RP_PATH)
+rp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rp)
+
+MAX_ATTEMPTS = 5
+BACKOFF_SECONDS = [30, 60, 120, 240, 480]
+
+
+def resolve_credentials() -> None:
+    """Populate Config with email/password so rp.login() does not prompt
+    inside the retry loop."""
+    email, password = Config.rh_credentials()
+    if not email:
+        email = input("Robinhood email: ").strip()
+    if not password:
+        password = input("Robinhood password: ").strip()
+    if Config.RH_ACTIVE_ACCOUNT == "automated":
+        Config.RH_AUTO_EMAIL = email
+        Config.RH_AUTO_PASSWORD = password
+    else:
+        Config.RH_MAIN_EMAIL = email
+        Config.RH_MAIN_PASSWORD = password
+
+
+def attempt_with_backoff() -> bool:
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        print(f"\n[refresh_pickle_watch] Attempt {attempt}/{MAX_ATTEMPTS}")
+        try:
+            ok = rp.login()
+        except Exception as exc:
+            print(f"[refresh_pickle_watch] login() raised: {exc}")
+            ok = False
+
+        if ok:
+            rp.upload()
+            slack_notify(
+                f":white_check_mark: refresh_pickle_watch — pickle refreshed "
+                f"on attempt {attempt}/{MAX_ATTEMPTS}"
+            )
+            return True
+
+        if attempt < MAX_ATTEMPTS:
+            delay = BACKOFF_SECONDS[attempt - 1]
+            slack_notify(
+                f":warning: refresh_pickle_watch — login failed "
+                f"({attempt}/{MAX_ATTEMPTS}); sleeping {delay}s before retry"
+            )
+            print(f"[refresh_pickle_watch] Sleeping {delay}s before retry...")
+            time.sleep(delay)
+    return False
+
+
+def main() -> int:
+    resolve_credentials()
+    while True:
+        if attempt_with_backoff():
+            print("\nDone! Restart the Render service to pick up the new session.")
+            return 0
+        slack_notify(
+            f"<!channel> :rotating_light: refresh_pickle_watch — "
+            f"exhausted {MAX_ATTEMPTS} login attempts; backing off"
+        )
+        if not sys.stdin.isatty():
+            print("[refresh_pickle_watch] Non-interactive — exiting.")
+            return 1
+        try:
+            input(
+                "\n[refresh_pickle_watch] Press Enter to re-arm the retry "
+                "budget, or Ctrl+C to abort: "
+            )
+        except (KeyboardInterrupt, EOFError):
+            print("\n[refresh_pickle_watch] Aborted.")
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New `scripts/refresh_pickle_watch.py` wraps the existing `refresh_pickle.py` with up to 5 login attempts and 30s/60s/120s/240s/480s exponential backoff so an unattended refresh stops hammering Robinhood after a 429.
- Each failed attempt pings Slack via `app.slack.notify`; budget exhaustion pings `<!channel>`. When run from a TTY, the wrapper prompts to re-arm the retry counter so an attended run can resume after Robinhood cools off without re-entering credentials.
- Drive-by fix: `refresh_pickle.py` now reads creds via `Config.rh_credentials()` — the previous `Config.RH_USER` / `Config.RH_PASS` attributes no longer exist, so env-var creds were not being picked up.

## Test plan
- [ ] Run `python scripts/refresh_pickle_watch.py` locally with valid creds; confirm it succeeds on attempt 1 and uploads to Netlify Blobs.
- [ ] Force a failure (e.g. wrong password) and confirm the script honors the 30s backoff between attempts and stops after 5.
- [ ] Confirm Slack receives a per-attempt warning and a final `<!channel>` alert when `SLACK_WEBHOOK_URL` is set.
- [ ] Confirm the TTY re-arm prompt fires after exhaustion and that Ctrl+C cleanly aborts.
- [ ] Confirm a non-TTY run (e.g. `python scripts/refresh_pickle_watch.py < /dev/null`) exits non-zero instead of prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)