### PR TITLE
Add ALERTS_ENABLED env-var toggle (default off)

### DIFF
--- a/app/slack.py
+++ b/app/slack.py
@@ -17,8 +17,8 @@ log = logging.getLogger(__name__)
 _TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 _CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
 _DEBOUNCE_WINDOW_SEC = int(os.getenv("ALERT_DEBOUNCE_SECONDS", "300"))
-_ALERTS_ENABLED = os.getenv("ALERTS_ENABLED", "true").strip().lower() not in (
-    "false", "0", "no", "off",
+_ALERTS_ENABLED = os.getenv("ALERTS_ENABLED", "false").strip().lower() in (
+    "true", "1", "yes", "on",
 )
 
 _lock = threading.Lock()
@@ -70,7 +70,10 @@ def notify(message: str, *, bypass_debounce: bool = False):
         global _last_disabled_log_ts
         now = time.time()
         if now - _last_disabled_log_ts >= _DISABLED_LOG_THROTTLE_SEC:
-            log.info("[telegram] notify() called but ALERTS_ENABLED=false")
+            log.info(
+                "[telegram] notify() suppressed — ALERTS_ENABLED is not truthy "
+                "(set ALERTS_ENABLED=true on Render to enable)"
+            )
             _last_disabled_log_ts = now
         return
 

--- a/app/slack.py
+++ b/app/slack.py
@@ -17,9 +17,14 @@ log = logging.getLogger(__name__)
 _TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 _CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
 _DEBOUNCE_WINDOW_SEC = int(os.getenv("ALERT_DEBOUNCE_SECONDS", "300"))
+_ALERTS_ENABLED = os.getenv("ALERTS_ENABLED", "true").strip().lower() not in (
+    "false", "0", "no", "off",
+)
 
 _lock = threading.Lock()
 _last_sent: dict[str, tuple[float, int]] = {}
+_last_disabled_log_ts: float = 0.0
+_DISABLED_LOG_THROTTLE_SEC = 60.0
 
 
 def _strip_slack_markup(text: str) -> str:
@@ -61,6 +66,14 @@ def notify(message: str, *, bypass_debounce: bool = False):
     and counted; the next emit appends `[+N suppressed in last Ns]`.
     Pass `bypass_debounce=True` for critical alerts that must always go through.
     """
+    if not _ALERTS_ENABLED:
+        global _last_disabled_log_ts
+        now = time.time()
+        if now - _last_disabled_log_ts >= _DISABLED_LOG_THROTTLE_SEC:
+            log.info("[telegram] notify() called but ALERTS_ENABLED=false")
+            _last_disabled_log_ts = now
+        return
+
     text = _strip_slack_markup(message)
     if not text:
         return


### PR DESCRIPTION
## Summary
- Adds `ALERTS_ENABLED` env-var toggle gating `notify()` in `app/slack.py`.
- **Default is OFF** — alerts only fire when `ALERTS_ENABLED` is one of `true`, `1`, `yes`, `on` (case-insensitive). Unset / blank / `false` / `no` / typos all evaluate to off.
- `bypass_debounce=True` (used for critical risk events) is also gated. Off means off; if you want criticals-only that's a separate `ALERTS_MIN_SEVERITY` toggle.
- A throttled log line (`[telegram] notify() suppressed — ALERTS_ENABLED is not truthy ...`) fires at most once per 60s so logs make the kill-switch state visible without spam.

## Why default off
Caller wants explicit opt-in per service so a fresh deploy doesn't start paging until somebody actively flips it on. Telegram bot quota isn't the binding constraint — phone notification fatigue during failure storms is.

## How to enable after this lands
Both services need it set to send: `srv-d6i9evua2pns73901hj0` (worker) and `srv-d6sbe2k50q8c73fgn86g` (api).

```sh
RKEY=$(awk '/^    key:/ {print $2}' ~/.render/cli.yaml)
for SVC in srv-d6i9evua2pns73901hj0 srv-d6sbe2k50q8c73fgn86g; do
  curl -X PUT -H "Authorization: Bearer $RKEY" -H "Content-Type: application/json" \
    "https://api.render.com/v1/services/$SVC/env-vars/ALERTS_ENABLED" \
    -d '{"value":"true"}'  # flip back off with "false"
done
```
Render restarts the service automatically on env-var change (~30-60s window).

## Test plan
- [x] `ALERTS_ENABLED` unset → 0 sends, 1 throttled log line.
- [x] `ALERTS_ENABLED=true` → call hits Telegram (`[telegram] Notification sent`).
- [x] `ALERTS_ENABLED=false` → 0 sends, 1 throttled log line.
- [x] `bypass_debounce=True` under disabled state → still no send (off means off).
- [ ] After merge: deploy worker + api, confirm `[telegram] notify() suppressed ...` appears in logs (default-off).
- [ ] Flip `ALERTS_ENABLED=true` on worker, confirm `[telegram] Notification sent` resumes within ~60s after restart.