### PR TITLE
Standing fallback: route alerts back to Slack

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -152,9 +152,9 @@ def start_engine_thread(app):
 
             # Risk infrastructure
             risk_subject = RiskSubject()
-            if os.environ.get("TELEGRAM_BOT_TOKEN") and os.environ.get("TELEGRAM_CHAT_ID"):
+            if os.environ.get("SLACK_WEBHOOK_URL"):
                 risk_subject.attach(SlackAlertObserver())
-                log.info("Telegram risk observer attached to background engine")
+                log.info("Slack risk observer attached to background engine")
 
             # Shadow index config — project BTC/USD → Grayscale Bitcoin Mini Trust ETF
             shadow_index = BTC_MINI

--- a/app/risk/slack_observer.py
+++ b/app/risk/slack_observer.py
@@ -1,4 +1,4 @@
-"""Risk alerting observer — posts DQ events via the Telegram notifier.
+"""Slack alerting observer — posts DQ events via the Slack notifier.
 
 Class name `SlackAlertObserver` preserved so existing imports in main.py and
 app.background continue to resolve.
@@ -14,31 +14,32 @@ from app.slack import notify as _notify
 
 log = logging.getLogger(__name__)
 
-_SEVERITY_PREFIX = {
-    "critical": "🚨 CRITICAL",
-    "warning": "⚠️ WARNING",
-    "info": "ℹ️ INFO",
+_SEVERITY_EMOJI = {
+    "critical": ":rotating_light:",
+    "warning": ":warning:",
+    "info": ":information_source:",
 }
 
 
 class SlackAlertObserver(RiskObserver):
-    """Posts risk events to Telegram (class name preserved for compat)."""
+    """Posts risk events to Slack (class name preserved for compat)."""
 
     def __init__(self, webhook_url: str | None = None, timeout: int = 10) -> None:
         # webhook_url retained for backward-compat with existing call sites; ignored.
+        # SLACK_WEBHOOK_URL is read from the environment by app.slack._send.
         self.timeout = timeout
 
     def update(self, symbol: str, price: float) -> None:
         pass
 
     def on_risk_event(self, event: RiskEvent) -> None:
-        prefix = _SEVERITY_PREFIX.get(event.severity, "")
+        emoji = _SEVERITY_EMOJI.get(event.severity, "")
         text = (
-            f"{prefix} Risk DQ — {event.event_type.value.replace('_', ' ').title()}\n"
-            f"Symbol: {event.symbol}\n"
-            f"Drift: {event.drift_pct:.2%}\n"
-            f"Severity: {event.severity}\n"
-            f"Snapshot: {event.snapshot_key or 'n/a'}\n"
-            f"{event.message}"
+            f"{emoji} *Risk DQ — {event.event_type.value.replace('_', ' ').title()}*\n"
+            f">*Symbol:* `{event.symbol}`\n"
+            f">*Drift:* {event.drift_pct:.2%}\n"
+            f">*Severity:* {event.severity}\n"
+            f">*Snapshot:* `{event.snapshot_key or 'n/a'}`\n"
+            f">_{event.message}_"
         )
         _notify(text, bypass_debounce=(event.severity == "critical"))

--- a/app/slack.py
+++ b/app/slack.py
@@ -1,7 +1,9 @@
-"""Telegram notifications via bot API.
+"""Slack notifications via incoming webhook.
 
-Module name and `notify(message)` signature preserved for import-stability with
-existing call sites in app.brokers.robinhood_client and app.background.
+Standing fallback path — swap this in if Telegram becomes unreliable. Same
+public surface as the Telegram version (`notify(message, *, bypass_debounce)`)
+plus the same in-process debouncing, so call sites and operator behavior are
+unchanged when this PR is merged.
 """
 
 import hashlib
@@ -14,54 +16,37 @@ import requests
 
 log = logging.getLogger(__name__)
 
-_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
-_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
+_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
 _DEBOUNCE_WINDOW_SEC = int(os.getenv("ALERT_DEBOUNCE_SECONDS", "300"))
 
 _lock = threading.Lock()
 _last_sent: dict[str, tuple[float, int]] = {}
 
 
-def _strip_slack_markup(text: str) -> str:
-    """Drop Slack-only tokens that would render as literal text in Telegram."""
-    return (
-        text
-        .replace("<!channel>", "")
-        .replace("<!here>", "")
-        .strip()
-    )
-
-
 def _send(text: str) -> bool:
-    if not _TOKEN or not _CHAT_ID:
-        log.debug("[telegram] TELEGRAM_BOT_TOKEN/CHAT_ID not set, skipping")
+    if not _WEBHOOK_URL:
+        log.debug("[slack] SLACK_WEBHOOK_URL not set, skipping")
         return False
     try:
-        resp = requests.post(
-            f"https://api.telegram.org/bot{_TOKEN}/sendMessage",
-            json={
-                "chat_id": _CHAT_ID,
-                "text": text,
-                "disable_web_page_preview": True,
-            },
-            timeout=10,
-        )
+        resp = requests.post(_WEBHOOK_URL, json={"text": text}, timeout=10)
         resp.raise_for_status()
-        log.info("[telegram] Notification sent")
+        log.info("[slack] Notification sent")
         return True
     except Exception:
-        log.exception("[telegram] Failed to send message")
+        log.exception("[slack] Failed to send message")
         return False
 
 
 def notify(message: str, *, bypass_debounce: bool = False):
-    """Post a message to the configured Telegram chat.
+    """Post a message to the configured Slack webhook.
 
     Identical messages within ALERT_DEBOUNCE_SECONDS (default 300) are suppressed
-    and counted; the next emit appends `[+N suppressed in last Ns]`.
+    and counted; the next emit appends `[+N suppressed in last Ns]`. Slack
+    incoming-webhook quotas are tight (HTTP 429 message_limit_exceeded under
+    sustained load), so the debouncer matters more here than on Telegram.
     Pass `bypass_debounce=True` for critical alerts that must always go through.
     """
-    text = _strip_slack_markup(message)
+    text = message.strip()
     if not text:
         return
 

--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ def main():
 
         # Set up risk event bus with observers
         risk_subject = RiskSubject()
-        if os.getenv("TELEGRAM_BOT_TOKEN") and os.getenv("TELEGRAM_CHAT_ID"):
+        if os.getenv("SLACK_WEBHOOK_URL"):
             risk_subject.attach(SlackAlertObserver())
         rebalancer = RebalancerObserver()
 


### PR DESCRIPTION
## Purpose
**Standing flippable PR — do not merge casually.** Leave open as a one-merge fallback if Telegram becomes unreliable (bot banned, token revoked, Telegram outage, etc.). Merging this re-routes alerts from Telegram back to a Slack incoming webhook in a single deploy.

## Why this exists
After the Telegram swap (`main`), the only alert path is `@allocation_engine_1_bot` → user DM. If Telegram dies, there's no second channel. This PR is the safety net.

## What changes
- `app/slack.py`: `notify()` POSTs to `SLACK_WEBHOOK_URL` again. **Keeps** the in-process debounce + `bypass_debounce` semantics added during the Telegram swap — Slack's per-webhook quota is tight (HTTP 429 `message_limit_exceeded` is what motivated the original swap), so debouncing matters even more here than on Telegram.
- `app/risk/slack_observer.py`: `on_risk_event()` reverts to Slack markdown (`*bold*`, `:emoji:`) and routes through the same notifier. Critical events still `bypass_debounce`.
- `main.py` / `app/background.py`: gate observer attach on `SLACK_WEBHOOK_URL` (original behavior).

## Required env vars after merge
- `SLACK_WEBHOOK_URL` — already set on both `srv-d6i9evua2pns73901hj0` (worker) and `srv-d6sbe2k50q8c73fgn86g` (api). Was kept around explicitly as fallback bandwidth.
- Telegram env vars (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`) become dead — safe to leave or strip.

## Conflict with #73
This PR conflicts with #73 (the `ALERTS_ENABLED` toggle) on `app/slack.py`. Whichever PR merges second will need a small rebase to re-add the toggle gate inside the Slack `notify()`. Kept as two atomic PRs rather than combined so each can be flipped independently.

## Test plan
- [x] Local smoke test against the existing webhook: `notify()` calls Slack endpoint (got 429 because the prod webhook is currently in penalty — confirms the call path, not a regression).
- [x] Debounce verified: identical second call within 5min suppressed; distinct call goes through.
- [ ] After merge: deploy worker + api, confirm `[slack] Notification sent` in logs (assuming Slack quota has reset — give it a day).
- [ ] If immediate quota issues persist, rotate the webhook in Slack admin and update `SLACK_WEBHOOK_URL` on Render.