### PR TITLE
Wire IBKR broker into broker registry

### DIFF
--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -31,6 +31,20 @@ def get_broker(name: str) -> BrokerClient:
             pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
             account_number=config.get("RH_AUTOMATED_ACCOUNT_NUMBER", ""),
         )
+    elif name == "ibkr":
+        from app.brokers.ibkr import IBKRTrader
+        from app.config import Config
+        sig_path, enc_path = Config.ibkr_key_files()
+        client = IBKRTrader(
+            account_id=config.get("IBKR_ACCOUNT_ID", ""),
+            paper=config.get("IBKR_PAPER", True),
+            consumer_key=config.get("IBKR_CONSUMER_KEY", ""),
+            access_token=config.get("IBKR_ACCESS_TOKEN", ""),
+            access_token_secret=config.get("IBKR_ACCESS_TOKEN_SECRET", ""),
+            dh_prime=config.get("IBKR_DH_PRIME", ""),
+            signature_key_path=sig_path,
+            encryption_key_path=enc_path,
+        )
     else:
         raise ValueError(f"Unknown broker: {name}")
 


### PR DESCRIPTION
## Summary
Adds an `ibkr` branch to `get_broker(name)` in `app/brokers/__init__.py`, mirroring the existing alpaca and robinhood branches.

- Lazily imports `IBKRTrader` from `app.brokers.ibkr` (import only fires when `ibkr` is requested, so the module stays import-safe before the IBKR package/config keys land).
- Resolves key files via `Config.ibkr_key_files() -> (sig_path, enc_path)`.
- Constructs `IBKRTrader(account_id, *, paper, consumer_key, access_token, access_token_secret, dh_prime, signature_key_path, encryption_key_path)` using `config.get(...)` with defaults.

## Testing
- `python3 -c "import app.brokers"` -> import OK
- `pytest tests/ -q` -> 35 passed

Live e2e and `get_broker("ibkr")` are intentionally skipped: the `app.brokers.ibkr` package and `Config.ibkr_key_files()` are delivered by other workers and are absent in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)