### PR TITLE
Engine: submit live option orders with quantity cap

### DIFF
--- a/app/engine.py
+++ b/app/engine.py
@@ -333,21 +333,49 @@ class AllocationEngine:
     def _execute_option_orders(
         self, orders: list[dict], cancel_ids: list[str]
     ):
-        """Log option order actions. Execution not yet implemented — always dry-run."""
+        """Log stale option orders and submit new ones. Cancellation is logged-only."""
         if cancel_ids:
-            log.info("[OPTIONS] Found %d stale option order(s): %s", len(cancel_ids), cancel_ids)
+            log.info("[OPTIONS] Found %d stale option order(s) — cancellation disabled, "
+                     "skipping: %s", len(cancel_ids), cancel_ids)
 
+        cap = getattr(self, "max_option_order_qty", None) or self.max_order_qty
+
+        results = []
         for order in orders:
-            log.info(
-                "[OPTIONS DRY RUN] Would submit: %s %s %s %.2f %s qty=%g @ %s",
-                order.get("side", "?"),
-                order.get("chain_symbol", "?"),
-                order.get("option_type", "?"),
-                float(order.get("strike", 0)),
-                order.get("expiration", "?"),
-                float(order.get("quantity", 0)),
-                f"${order['limit_price']:,.2f}" if order.get("limit_price") else "MKT",
-            )
+            # Enforce max option order quantity
+            qty = order["quantity"]
+            if qty > cap:
+                log.warning(
+                    "Option order capped: %s %s qty %g -> %d (cap=%d)",
+                    order.get("side", "?"), order.get("chain_symbol", "?"),
+                    qty, cap, cap,
+                )
+                order["quantity"] = cap
+
+            if self.dry_run:
+                log.info(
+                    "[OPTIONS DRY RUN] Would submit: %s %s %s %.2f %s qty=%g @ %s",
+                    order.get("side", "?"),
+                    order.get("chain_symbol", "?"),
+                    order.get("option_type", "?"),
+                    float(order.get("strike", 0)),
+                    order.get("expiration", "?"),
+                    float(order.get("quantity", 0)),
+                    f"${order['limit_price']:,.2f}" if order.get("limit_price") else "MKT",
+                )
+            elif hasattr(self.trader, "submit_option_order"):
+                result = self.trader.submit_option_order(order)
+                log.info("[OPTIONS] Submitted option order: %s", result)
+                results.append(result)
+            else:
+                log.warning(
+                    "[OPTIONS] Broker %s cannot place option orders "
+                    "(no submit_option_order) — skipping %s %s",
+                    type(self.trader).__name__,
+                    order.get("side", "?"), order.get("chain_symbol", "?"),
+                )
+
+        return results
 
     # -- equity execution ----------------------------------------------------
 

--- a/tests/test_engine_option_exec.py
+++ b/tests/test_engine_option_exec.py
@@ -1,0 +1,106 @@
+"""Tests for AllocationEngine._execute_option_orders — option order submission."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine import AllocationEngine
+
+
+def _option_order(quantity: float = 2, side: str = "buy") -> dict:
+    return {
+        "chain_symbol": "AAPL",
+        "option_type": "call",
+        "strike": 150.0,
+        "expiration": "2026-07-17",
+        "side": side,
+        "quantity": quantity,
+        "limit_price": 1.25,
+        "order_type": "limit",
+    }
+
+
+def _engine(dry_run: bool, max_order_qty: int = 50) -> AllocationEngine:
+    trader = MagicMock()
+    runtime = MagicMock()
+    return AllocationEngine(
+        trader=trader,
+        runtime=runtime,
+        dry_run=dry_run,
+        max_order_qty=max_order_qty,
+    )
+
+
+def test_dry_run_does_not_submit():
+    engine = _engine(dry_run=True)
+    results = engine._execute_option_orders([_option_order(), _option_order()], [])
+
+    engine.trader.submit_option_order.assert_not_called()
+    assert not results  # dry-run returns empty list
+
+
+def test_live_submits_once_per_order():
+    engine = _engine(dry_run=False)
+    engine.trader.submit_option_order.return_value = {
+        "id": "opt-1", "symbol": "AAPL", "status": "queued"
+    }
+
+    orders = [_option_order(quantity=2), _option_order(quantity=3, side="sell")]
+    results = engine._execute_option_orders(orders, [])
+
+    assert engine.trader.submit_option_order.call_count == 2
+    assert len(results) == 2
+
+
+def test_live_caps_quantity():
+    engine = _engine(dry_run=False, max_order_qty=5)
+    engine.trader.submit_option_order.return_value = {
+        "id": "opt-1", "symbol": "AAPL", "status": "queued"
+    }
+
+    order = _option_order(quantity=100)
+    engine._execute_option_orders([order], [])
+
+    engine.trader.submit_option_order.assert_called_once()
+    submitted = engine.trader.submit_option_order.call_args[0][0]
+    assert submitted["quantity"] == 5  # capped to max_order_qty
+
+
+def test_max_option_order_qty_overrides_cap():
+    engine = _engine(dry_run=False, max_order_qty=50)
+    engine.max_option_order_qty = 3
+    engine.trader.submit_option_order.return_value = {
+        "id": "opt-1", "symbol": "AAPL", "status": "queued"
+    }
+
+    order = _option_order(quantity=10)
+    engine._execute_option_orders([order], [])
+
+    submitted = engine.trader.submit_option_order.call_args[0][0]
+    assert submitted["quantity"] == 3  # capped to max_option_order_qty
+
+
+def test_broker_without_submit_option_order_skips():
+    trader = MagicMock(spec=[])  # no submit_option_order attribute
+    runtime = MagicMock()
+    engine = AllocationEngine(
+        trader=trader, runtime=runtime, dry_run=False, max_order_qty=50
+    )
+
+    results = engine._execute_option_orders([_option_order()], [])
+
+    assert results == []  # nothing submitted, no crash
+
+
+def test_cancel_ids_logged_only():
+    engine = _engine(dry_run=False)
+    engine.trader.submit_option_order.return_value = {
+        "id": "opt-1", "symbol": "AAPL", "status": "queued"
+    }
+
+    # Stale cancellation is logged-only; submit_option_order is the only call path.
+    engine._execute_option_orders([], ["stale-1", "stale-2"])
+
+    engine.trader.submit_option_order.assert_not_called()
+    # No cancel method should be invoked for stale ids.
+    assert not engine.trader.cancel_option_order.called


### PR DESCRIPTION
## Unit: Engine option execution

Rewrites \`AllocationEngine._execute_option_orders\` so it actually submits option orders, matching the equity \`_execute\` structure.

### Behavior
- **Stale cancellation**: logged-only (consistent with equity \`_execute\`).
- **Quantity cap**: \`getattr(self, "max_option_order_qty", None) or self.max_order_qty\`. No new constructor arg — falls back to \`max_order_qty\`. Over-cap orders are warned and capped, mirroring the equity cap logic.
- **Dry-run**: preserves the existing \`[OPTIONS DRY RUN] Would submit: ...\` log line.
- **Live**: if \`hasattr(self.trader, "submit_option_order")\`, calls \`self.trader.submit_option_order(order)\`, logs the result, and collects results. If the broker lacks the method, logs a warning and skips — no IBKR import, broker-agnostic.
- Returns the list of submission results.

### Contract depended on (built by another worker)
\`self.trader.submit_option_order(order: dict) -> dict | None\` returning \`{"id","symbol","status"}\`. Every call is guarded by \`hasattr\`.

### Tests
\`tests/test_engine_option_exec.py\` (MagicMock trader, no network):
- dry-run does NOT call \`submit_option_order\`
- live mode calls it once per order
- quantity capping (max_order_qty and max_option_order_qty override)
- broker without \`submit_option_order\` skips gracefully
- stale cancel ids are logged-only

\`pytest tests/ -q\` → 41 passed. Code review found no correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)