### PR TITLE
Add POST /options/order endpoint for option order submission

### DIFF
--- a/app/api/options.py
+++ b/app/api/options.py
@@ -2,6 +2,7 @@
 
 from flask import Blueprint, jsonify, request, current_app
 from app.brokers import get_broker
+from app.enums import OrderSide
 
 bp = Blueprint("options", __name__)
 
@@ -33,5 +34,87 @@ def options_orders(broker_name=None):
             return jsonify({"error": f"Broker {broker_name} does not support options orders"}), 400
         data = broker.options_orders(limit=limit)
         return jsonify({"broker": broker_name, "count": len(data), "orders": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/options/order", methods=["POST"])
+@bp.route("/options/order/<broker_name>", methods=["POST"])
+def submit_option_order(broker_name=None):
+    """Place an option order.
+
+    Body JSON:
+        chain_symbol: str   (required) e.g. "AAPL"
+        option_type:  str   (required) "call" or "put"
+        strike:       float (required)
+        expiration:   str   (required) e.g. "2026-06-19"
+        side:         str   (required) "BUY" or "SELL"
+        quantity:     float (required)
+        limit_price:  float (optional)
+        order_type:   str   (optional) default "limit"
+    """
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    body = request.get_json(silent=True)
+    if not body:
+        return jsonify({"error": "JSON body required"}), 400
+
+    # --- validate required fields ---
+    chain_symbol = body.get("chain_symbol")
+    option_type = body.get("option_type")
+    strike = body.get("strike")
+    expiration = body.get("expiration")
+    side = body.get("side")
+    quantity = body.get("quantity")
+
+    errors = []
+    if not chain_symbol or not isinstance(chain_symbol, str):
+        errors.append("chain_symbol is required (string)")
+    if option_type not in ("call", "put"):
+        errors.append("option_type must be 'call' or 'put'")
+    if strike is None:
+        errors.append("strike is required")
+    else:
+        try:
+            strike = float(strike)
+            if strike <= 0:
+                errors.append("strike must be positive")
+        except (TypeError, ValueError):
+            errors.append("strike must be a number")
+    if not expiration or not isinstance(expiration, str):
+        errors.append("expiration is required (string)")
+    if side not in (OrderSide.BUY, OrderSide.SELL):
+        errors.append("side must be 'BUY' or 'SELL'")
+    if quantity is None:
+        errors.append("quantity is required")
+    else:
+        try:
+            quantity = float(quantity)
+            if quantity <= 0:
+                errors.append("quantity must be positive")
+        except (TypeError, ValueError):
+            errors.append("quantity must be a number")
+
+    if errors:
+        return jsonify({"error": "Validation failed", "details": errors}), 400
+
+    order = {
+        "chain_symbol": chain_symbol.upper(),
+        "option_type": option_type,
+        "strike": strike,
+        "expiration": expiration,
+        "side": side,
+        "quantity": quantity,
+        "limit_price": body.get("limit_price"),
+        "order_type": body.get("order_type", "limit"),
+    }
+
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "submit_option_order"):
+            return jsonify({"error": f"Broker {broker_name} does not support option orders"}), 400
+        result = broker.submit_option_order(order)
+        if result is None:
+            return jsonify({"error": "Order submission failed"}), 502
+        return jsonify({"broker": broker_name, "order": result})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/tests/test_options_order_api.py
+++ b/tests/test_options_order_api.py
@@ -1,0 +1,83 @@
+"""Tests for the POST /options/order endpoint."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["DEFAULT_BROKER"] = "test"
+    return app.test_client()
+
+
+def _valid_body():
+    return {
+        "chain_symbol": "aapl",
+        "option_type": "call",
+        "strike": 150,
+        "expiration": "2026-06-19",
+        "side": "BUY",
+        "quantity": 1,
+        "limit_price": 2.50,
+    }
+
+
+def test_submit_option_order_success(client, monkeypatch):
+    broker = MagicMock()
+    broker.submit_option_order.return_value = {
+        "id": "opt-1",
+        "symbol": "AAPL",
+        "status": "submitted",
+    }
+    monkeypatch.setattr("app.api.options.get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json=_valid_body())
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["broker"] == "test"
+    assert data["order"] == {"id": "opt-1", "symbol": "AAPL", "status": "submitted"}
+
+    # broker received an upper-cased chain_symbol and defaulted order_type
+    submitted = broker.submit_option_order.call_args[0][0]
+    assert submitted["chain_symbol"] == "AAPL"
+    assert submitted["order_type"] == "limit"
+
+
+def test_submit_option_order_missing_fields(client, monkeypatch):
+    broker = MagicMock()
+    monkeypatch.setattr("app.api.options.get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json={"chain_symbol": "AAPL"})
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+    broker.submit_option_order.assert_not_called()
+
+
+def test_submit_option_order_no_body(client):
+    resp = client.post("/api/options/order", json={})
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_submit_option_order_unsupported_broker(client, monkeypatch):
+    broker = MagicMock(spec=[])  # no submit_option_order attribute
+    monkeypatch.setattr("app.api.options.get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json=_valid_body())
+    assert resp.status_code == 400
+    assert "does not support option orders" in resp.get_json()["error"]
+
+
+def test_submit_option_order_submission_failed(client, monkeypatch):
+    broker = MagicMock()
+    broker.submit_option_order.return_value = None
+    monkeypatch.setattr("app.api.options.get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json=_valid_body())
+    assert resp.status_code == 502
+    assert resp.get_json()["error"] == "Order submission failed"


### PR DESCRIPTION
## Summary
Adds the HTTP endpoint used to manually place/verify an option order, part of the larger IBKR live-options-order change.

- New `POST /options/order` (+ `POST /options/order/<broker_name>`) route in `app/api/options.py`
- Resolves `broker_name` from path or `DEFAULT_BROKER` config
- Parses JSON body `{chain_symbol, option_type, strike, expiration, side, quantity, limit_price?, order_type?}` and validates required fields, returning `400 {"error": ...}` (mirrors `trade.py` validation/error style)
- Duck-types the broker via `hasattr(broker, "submit_option_order")` (same pattern as existing GET options routes); returns `400` if unsupported
- Calls `broker.submit_option_order(order)`; returns `502` on `None`, else `{"broker", "order"}`
- Wrapped in try/except returning `500 {"error": str(e)}`

## Contract depended on
`broker.submit_option_order(order: dict) -> dict | None` returning `{"id","symbol","status"}` — referenced only via duck-typing, built by another worker.

## Testing
- `python3 -c "import app.api.options"` — import-safe
- New `tests/test_options_order_api.py` (Flask test client, `get_broker` monkeypatched to a MagicMock): success 200, missing fields 400, empty body 400, unsupported broker 400, submission-failed 502
- `pytest tests/ -q` — 40 passed
- Live e2e skipped (no broker creds), per unit scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)