### PR TITLE
Add IBKR broker client (Client Portal Web API via OAuth 1.0a)

### DIFF
--- a/app/brokers/ibkr/__init__.py
+++ b/app/brokers/ibkr/__init__.py
@@ -1,0 +1,5 @@
+"""Interactive Brokers (IBKR) broker package — Client Portal Web API via OAuth 1.0a (ibind)."""
+
+from app.brokers.ibkr.client import IBKRTrader
+
+__all__ = ["IBKRTrader"]

--- a/app/brokers/ibkr/client.py
+++ b/app/brokers/ibkr/client.py
@@ -1,0 +1,110 @@
+"""IBKRTrader — BrokerClient implementation backed by the IBKR Client Portal Web API.
+
+Composes the session lifecycle (session.py), contract resolution (contracts.py),
+order placement (orders.py) and portfolio reads (positions.py). Every public
+method establishes/refreshes the brokerage session via ``ensure_auth`` first,
+mirroring ``RobinhoodTrader._ensure_auth``.
+"""
+
+import logging
+
+from app.brokers.base import BrokerClient
+from app.brokers.ibkr import contracts, orders, positions
+from app.brokers.ibkr.session import IBKRSession
+
+log = logging.getLogger(__name__)
+
+
+class IBKRTrader(BrokerClient):
+    def __init__(
+        self,
+        account_id: str,
+        *,
+        paper: bool = True,
+        consumer_key: str = "",
+        access_token: str = "",
+        access_token_secret: str = "",
+        dh_prime: str = "",
+        signature_key_path: str = "",
+        encryption_key_path: str = "",
+    ):
+        self.account_id = account_id
+        self.paper = paper
+        self._session = IBKRSession(
+            account_id,
+            paper=paper,
+            consumer_key=consumer_key,
+            access_token=access_token,
+            access_token_secret=access_token_secret,
+            dh_prime=dh_prime,
+            signature_key_path=signature_key_path,
+            encryption_key_path=encryption_key_path,
+        )
+
+    @property
+    def _client(self):
+        return self._session.client
+
+    # -- account / positions ------------------------------------------------
+
+    def account(self) -> dict:
+        self._session.ensure_auth()
+        return positions.account(self._client, self.account_id)
+
+    def positions(self) -> list[dict]:
+        self._session.ensure_auth()
+        return positions.positions(self._client, self.account_id)
+
+    def options_positions(self) -> list[dict]:
+        self._session.ensure_auth()
+        return positions.options_positions(self._client, self.account_id)
+
+    # -- orders -------------------------------------------------------------
+
+    def open_orders(self) -> list[dict]:
+        self._session.ensure_auth()
+        return orders.open_orders(self._client, self.account_id)
+
+    def options_orders(self, limit: int = 50, open_only: bool = False) -> list[dict]:
+        self._session.ensure_auth()
+        return orders.options_orders(self._client, limit=limit, open_only=open_only)
+
+    def submit_order(self, order: dict) -> dict | None:
+        self._session.ensure_auth()
+        return orders.submit_order(self._client, self.account_id, order)
+
+    def submit_option_order(self, order: dict) -> dict | None:
+        """Resolve the option contract then place the order with reply/confirm handling."""
+        self._session.ensure_auth()
+        try:
+            conid = contracts.resolve_option_conid(
+                self._client,
+                order["chain_symbol"],
+                order["expiration"],
+                float(order["strike"]),
+                order["option_type"],
+            )
+        except Exception as e:
+            log.error("[ibkr] Failed to resolve option conid: %s", e)
+            return None
+
+        if conid is None:
+            log.error("[ibkr] Could not resolve conid for %s %s %s %s",
+                      order.get("chain_symbol"), order.get("expiration"),
+                      order.get("strike"), order.get("option_type"))
+            return None
+
+        return orders.submit_option_order(self._client, self.account_id, conid, order)
+
+    def cancel_order(self, order_id: str) -> None:
+        self._session.ensure_auth()
+        orders.cancel_order(self._client, self.account_id, order_id)
+
+    def cancel_all(self) -> None:
+        self._session.ensure_auth()
+        orders.cancel_all(self._client, self.account_id)
+
+    # -- auth status --------------------------------------------------------
+
+    def auth_status(self) -> dict:
+        return self._session.auth_status()

--- a/app/brokers/ibkr/contracts.py
+++ b/app/brokers/ibkr/contracts.py
@@ -1,0 +1,139 @@
+"""IBKR option contract resolution via the Client Portal secdef endpoints.
+
+Resolution is a mandatory, ordered three-step dance:
+  1. ``/iserver/secdef/search``  — resolve the underlying conid for the symbol
+  2. ``/iserver/secdef/strikes`` — list valid months/strikes for OPT
+  3. ``/iserver/secdef/info``    — resolve the exact option conid for a given
+                                   strike / right / expiry (month)
+"""
+
+import logging
+from datetime import datetime
+
+from app.brokers.ibkr.session import _result_data
+
+log = logging.getLogger(__name__)
+
+# option_type -> CP "right" code
+_RIGHT = {"call": "C", "put": "P"}
+
+
+def _expiry_to_month(expiration: str) -> str:
+    """Convert 'YYYY-MM-DD' to the CP month token 'MMMYY' (e.g. 2026-06-19 -> JUN26)."""
+    dt = datetime.strptime(expiration, "%Y-%m-%d")
+    return dt.strftime("%b%y").upper()
+
+
+def resolve_option_conid(
+    client,
+    chain_symbol: str,
+    expiration: str,
+    strike: float,
+    option_type: str,
+) -> int | None:
+    """Resolve an option contract to its IBKR conid.
+
+    Returns the integer conid, or ``None`` if it cannot be resolved.
+    """
+    right = _RIGHT.get(option_type.lower())
+    if right is None:
+        log.error("[ibkr] Unknown option_type %r (expected call/put)", option_type)
+        return None
+
+    try:
+        month = _expiry_to_month(expiration)
+    except (ValueError, TypeError) as e:
+        log.error("[ibkr] Bad expiration %r: %s", expiration, e)
+        return None
+
+    try:
+        # 1. Resolve the underlying conid.
+        search = _result_data(
+            client.get(
+                "iserver/secdef/search",
+                params={"symbol": chain_symbol, "name": True, "secType": "STK"},
+            )
+        )
+        underlying_conid = _extract_underlying_conid(search)
+        if underlying_conid is None:
+            log.error("[ibkr] Could not resolve underlying conid for %s", chain_symbol)
+            return None
+
+        # 2. Fetch valid strikes for the month (validates the chain exists).
+        strikes = _result_data(
+            client.get(
+                "iserver/secdef/strikes",
+                params={
+                    "conid": underlying_conid,
+                    "sectype": "OPT",
+                    "month": month,
+                },
+            )
+        )
+        if not _strike_available(strikes, right, strike):
+            log.error(
+                "[ibkr] Strike %s %s not available for %s %s",
+                strike, right, chain_symbol, month,
+            )
+            return None
+
+        # 3. Resolve the exact option conid.
+        info = _result_data(
+            client.get(
+                "iserver/secdef/info",
+                params={
+                    "conid": underlying_conid,
+                    "sectype": "OPT",
+                    "month": month,
+                    "strike": strike,
+                    "right": right,
+                },
+            )
+        )
+        conid = _extract_option_conid(info)
+        if conid is None:
+            log.error(
+                "[ibkr] secdef/info returned no conid for %s %s %s %s",
+                chain_symbol, month, strike, right,
+            )
+        return conid
+    except Exception:
+        log.exception("[ibkr] Option conid resolution failed for %s %s %s %s",
+                      chain_symbol, expiration, strike, option_type)
+        return None
+
+
+def _extract_underlying_conid(search) -> int | None:
+    """secdef/search returns a list of matches; take the first conid."""
+    if isinstance(search, list) and search:
+        first = search[0]
+        if isinstance(first, dict):
+            conid = first.get("conid")
+            if conid is not None:
+                return int(conid)
+    return None
+
+
+def _strike_available(strikes, right, strike: float) -> bool:
+    """secdef/strikes returns {'call': [...], 'put': [...]} of available strikes."""
+    if not isinstance(strikes, dict):
+        return False
+    key = "call" if right == "C" else "put"
+    available = strikes.get(key) or []
+    # Compare with float tolerance.
+    return any(abs(float(s) - float(strike)) < 1e-6 for s in available)
+
+
+def _extract_option_conid(info) -> int | None:
+    """secdef/info returns a list of contract dicts; take the first conid."""
+    if isinstance(info, list) and info:
+        first = info[0]
+        if isinstance(first, dict):
+            conid = first.get("conid")
+            if conid is not None:
+                return int(conid)
+    elif isinstance(info, dict):
+        conid = info.get("conid")
+        if conid is not None:
+            return int(conid)
+    return None

--- a/app/brokers/ibkr/orders.py
+++ b/app/brokers/ibkr/orders.py
@@ -1,0 +1,295 @@
+"""IBKR order placement / cancellation via the Client Portal Web API.
+
+Order placement on the CP API is two-phase: the initial POST may return an
+array of "reply" objects (warnings / confirmations) each with an ``id`` and a
+``message``. Each must be confirmed via ``POST /iserver/reply/{id}`` until a
+real order id (or a rejection) is returned.
+"""
+
+import logging
+
+from app.brokers.ibkr.session import _result_data
+from app.enums import OrderType
+
+log = logging.getLogger(__name__)
+
+# Max reply/confirm round-trips before giving up (guards against a loop).
+_MAX_REPLY_HOPS = 10
+
+# CP order states considered "open" / live.
+_OPEN_ORDER_STATES = {
+    "PreSubmitted", "Submitted", "PendingSubmit", "PendingCancel", "Inactive",
+}
+
+
+def _cp_order_type(order_type: str | None, limit_price) -> str:
+    """Map an app order type to a CP orderType ('LMT' / 'MKT')."""
+    if order_type is not None and str(order_type).lower() == OrderType.LIMIT and limit_price is not None:
+        return "LMT"
+    if limit_price is not None and order_type is None:
+        return "LMT"
+    return "MKT"
+
+
+def _normalize_side(side: str) -> str:
+    return str(side).upper()
+
+
+def _build_order_body(conid: int, side: str, order_type: str, quantity, price=None) -> dict:
+    body = {
+        "conid": int(conid),
+        "side": _normalize_side(side),
+        "orderType": order_type,
+        "quantity": int(quantity),
+        "tif": "DAY",
+    }
+    if order_type == "LMT" and price is not None:
+        body["price"] = float(price)
+    return body
+
+
+def _place_with_confirm(client, account_id: str, order_body: dict):
+    """POST the order then walk the reply/confirm chain.
+
+    Returns the final order payload dict (containing an 'order_id' / 'id') or
+    None if the order was rejected or no id could be obtained.
+    """
+    result = client.post(
+        f"iserver/account/{account_id}/orders",
+        params={"orders": [order_body]},
+    )
+    data = _result_data(result)
+
+    hops = 0
+    while hops < _MAX_REPLY_HOPS:
+        order_dict = _extract_order_dict(data)
+        if order_dict is not None:
+            return order_dict
+
+        reply_id = _extract_reply_id(data)
+        if reply_id is None:
+            # Neither a confirmable reply nor a resolvable order id.
+            log.error("[ibkr] Unrecognised order response: %s", data)
+            return None
+
+        # Check for an explicit rejection in the reply message.
+        if _is_rejection(data):
+            log.error("[ibkr] Order rejected: %s", data)
+            return None
+
+        reply = client.post(
+            f"iserver/reply/{reply_id}",
+            params={"confirmed": True},
+        )
+        data = _result_data(reply)
+        hops += 1
+
+    log.error("[ibkr] Exceeded reply/confirm hops (%d) without a final order id", _MAX_REPLY_HOPS)
+    return None
+
+
+def _extract_order_dict(data) -> dict | None:
+    """Return the dict carrying a real order id, if present."""
+    items = data if isinstance(data, list) else [data]
+    for item in items:
+        if isinstance(item, dict) and (item.get("order_id") or item.get("orderId")):
+            return item
+    return None
+
+
+def _extract_reply_id(data) -> str | None:
+    """Return the first reply/confirmation id requiring acknowledgement."""
+    items = data if isinstance(data, list) else [data]
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        rid = item.get("id")
+        # A reply object has an 'id' + a 'message' (list of warnings).
+        if rid is not None and "message" in item:
+            return str(rid)
+    return None
+
+
+def _is_rejection(data) -> bool:
+    items = data if isinstance(data, list) else [data]
+    for item in items:
+        if isinstance(item, dict):
+            if item.get("error"):
+                return True
+            msgs = item.get("message")
+            if isinstance(msgs, list):
+                for m in msgs:
+                    if "reject" in str(m).lower():
+                        return True
+    return False
+
+
+def _order_id_of(order_dict: dict) -> str:
+    return str(order_dict.get("order_id") or order_dict.get("orderId") or "")
+
+
+def _order_status_of(order_dict: dict) -> str:
+    return str(order_dict.get("order_status") or order_dict.get("status") or "")
+
+
+# -- public order operations -------------------------------------------------
+
+def submit_order(client, account_id: str, order: dict) -> dict | None:
+    """Submit an equity order. Returns {id, symbol, status} or None on failure."""
+    symbol = order.get("symbol", "")
+    side = order.get("side", "")
+    qty = order.get("quantity")
+    order_type = order.get("order_type")
+    limit_px = order.get("limit_price")
+    conid = order.get("conid")
+
+    try:
+        if conid is None:
+            log.error("[ibkr] submit_order requires a 'conid' for %s", symbol)
+            return None
+        cp_type = _cp_order_type(order_type, limit_px)
+        body = _build_order_body(conid, side, cp_type, qty, limit_px)
+        order_dict = _place_with_confirm(client, account_id, body)
+        if order_dict is None:
+            return None
+        oid = _order_id_of(order_dict)
+        log.info("[ibkr] Order submitted: %s %s conid=%s -> %s",
+                 _normalize_side(side), qty, conid, oid)
+        return {"id": oid, "symbol": symbol, "status": _order_status_of(order_dict)}
+    except Exception as e:
+        log.error("[ibkr] submit_order error for %s: %s", symbol, e)
+        return None
+
+
+def submit_option_order(client, account_id: str, conid: int, order: dict) -> dict | None:
+    """Submit an option order against an already-resolved conid.
+
+    Returns {id, symbol, status} or None on failure.
+    """
+    chain_symbol = order.get("chain_symbol", "")
+    side = order.get("side", "")
+    qty = order.get("quantity")
+    order_type = order.get("order_type")
+    limit_px = order.get("limit_price")
+
+    try:
+        cp_type = _cp_order_type(order_type, limit_px)
+        body = _build_order_body(conid, side, cp_type, qty, limit_px)
+        order_dict = _place_with_confirm(client, account_id, body)
+        if order_dict is None:
+            return None
+        oid = _order_id_of(order_dict)
+        log.info("[ibkr] Option order submitted: %s %s conid=%s -> %s",
+                 _normalize_side(side), qty, conid, oid)
+        return {"id": oid, "symbol": chain_symbol, "status": _order_status_of(order_dict)}
+    except Exception as e:
+        log.error("[ibkr] submit_option_order error for %s: %s", chain_symbol, e)
+        return None
+
+
+def cancel_order(client, account_id: str, order_id: str) -> None:
+    client.delete(f"iserver/account/{account_id}/order/{order_id}")
+    log.info("[ibkr] Cancelled order %s", order_id)
+
+
+def cancel_all(client, account_id: str) -> None:
+    for o in open_orders(client, account_id):
+        oid = o.get("id")
+        if oid:
+            try:
+                cancel_order(client, account_id, oid)
+            except Exception as e:
+                log.warning("[ibkr] Failed to cancel order %s: %s", oid, e)
+    log.info("[ibkr] cancel_all complete")
+
+
+def _raw_live_orders(client) -> list[dict]:
+    data = _result_data(client.get("iserver/account/orders"))
+    if isinstance(data, dict):
+        orders = data.get("orders") or []
+    elif isinstance(data, list):
+        orders = data
+    else:
+        orders = []
+    return [o for o in orders if isinstance(o, dict)]
+
+
+def open_orders(client, account_id: str) -> list[dict]:
+    """Return open equity orders in the standardized shape."""
+    result = []
+    for o in _raw_live_orders(client):
+        status = o.get("status") or o.get("order_status") or ""
+        if status not in _OPEN_ORDER_STATES:
+            continue
+        # Skip option legs; this is the equity-shaped view.
+        if str(o.get("secType", "")).upper() == "OPT":
+            continue
+        result.append({
+            "id": str(o.get("orderId") or o.get("order_id") or ""),
+            "symbol": o.get("ticker") or o.get("symbol") or "",
+            "side": str(o.get("side", "")).upper(),
+            "qty": _to_float(o.get("totalSize") if o.get("totalSize") is not None else o.get("remainingQuantity")),
+            "type": str(o.get("orderType", "")).lower(),
+            "limit_price": _to_float(o.get("price")),
+            "stop_price": _to_float(o.get("stop_price") or o.get("auxPrice")),
+            "status": status,
+        })
+    return result
+
+
+def options_orders(client, limit: int = 50, open_only: bool = False) -> list[dict]:
+    """Return recent option orders in the standardized options shape."""
+    result = []
+    for o in _raw_live_orders(client):
+        if str(o.get("secType", "")).upper() != "OPT":
+            continue
+        status = o.get("status") or o.get("order_status") or ""
+        if open_only and status not in _OPEN_ORDER_STATES:
+            continue
+        side = str(o.get("side", "")).upper()
+        leg = {
+            "side": side,
+            "position_effect": "open",
+            "quantity": _to_float(o.get("totalSize")),
+            "strike": _to_float(o.get("strike")),
+            "expiration": o.get("expiry") or o.get("expiration") or "",
+            "option_type": _right_to_type(o.get("right")),
+            "chain_symbol": o.get("ticker") or o.get("symbol") or "",
+        }
+        result.append({
+            "order_id": str(o.get("orderId") or o.get("order_id") or ""),
+            "state": status,
+            "quantity": _to_float(o.get("totalSize")),
+            "price": _to_float(o.get("price")),
+            "premium": _to_float(o.get("price")),
+            "processed_premium": _to_float(o.get("avgPrice")),
+            "direction": "credit" if side == "SELL" else "debit",
+            "order_type": str(o.get("orderType", "")).lower(),
+            "trigger": "immediate",
+            "time_in_force": o.get("timeInForce") or o.get("tif") or "",
+            "opening_strategy": "",
+            "created_at": o.get("lastExecutionTime") or "",
+            "updated_at": o.get("lastExecutionTime") or "",
+            "legs": [leg],
+        })
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _right_to_type(right) -> str:
+    r = str(right or "").upper()
+    if r == "C":
+        return "call"
+    if r == "P":
+        return "put"
+    return ""
+
+
+def _to_float(v):
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return None

--- a/app/brokers/ibkr/positions.py
+++ b/app/brokers/ibkr/positions.py
@@ -1,0 +1,155 @@
+"""IBKR account summary and positions via the Client Portal portfolio endpoints."""
+
+import logging
+from datetime import datetime, timezone
+
+from app.brokers.ibkr.session import _result_data
+
+log = logging.getLogger(__name__)
+
+
+def _summary_field(summary: dict, *keys) -> float:
+    """CP /portfolio/{acct}/summary values are nested as {key: {amount: x}}."""
+    for k in keys:
+        v = summary.get(k)
+        if isinstance(v, dict):
+            amt = v.get("amount")
+            if amt is not None:
+                return _to_float(amt)
+        elif v is not None:
+            return _to_float(v)
+    return 0.0
+
+
+def account(client, account_id: str) -> dict:
+    """GET /portfolio/{account}/summary -> {equity, cash, buying_power, portfolio_value}."""
+    summary = _result_data(client.get(f"portfolio/{account_id}/summary")) or {}
+    if not isinstance(summary, dict):
+        summary = {}
+    equity = _summary_field(summary, "equitywithloanvalue", "netliquidation")
+    return {
+        "equity": equity,
+        "cash": _summary_field(summary, "totalcashvalue", "availablefunds"),
+        "buying_power": _summary_field(summary, "buyingpower"),
+        "portfolio_value": _summary_field(summary, "netliquidation", "equitywithloanvalue"),
+    }
+
+
+def _raw_positions(client, account_id: str) -> list[dict]:
+    data = _result_data(client.get(f"portfolio/{account_id}/positions/0"))
+    if isinstance(data, list):
+        return [p for p in data if isinstance(p, dict)]
+    return []
+
+
+def positions(client, account_id: str) -> list[dict]:
+    """Return non-option positions in the standardized shape."""
+    result = []
+    for p in _raw_positions(client, account_id):
+        if str(p.get("assetClass", "")).upper() == "OPT":
+            continue
+        qty = _to_float(p.get("position"))
+        if not qty:
+            continue
+        avg = _to_float(p.get("avgCost") or p.get("avgPrice"))
+        mkt_value = _to_float(p.get("mktValue"))
+        cost_basis = qty * avg if avg else 0.0
+        unrealized = (mkt_value - cost_basis) if mkt_value is not None else 0.0
+        result.append({
+            "symbol": p.get("contractDesc") or p.get("ticker") or "",
+            "qty": qty,
+            "side": "long" if qty > 0 else "short",
+            "market_value": round(mkt_value, 2) if mkt_value is not None else 0.0,
+            "avg_entry": avg or 0.0,
+            "unrealized_pl": round(unrealized, 2),
+            "unrealized_pl_pct": round(unrealized / cost_basis, 4) if cost_basis else 0.0,
+        })
+    return result
+
+
+def options_positions(client, account_id: str) -> list[dict]:
+    """Return option positions in the standardized options shape."""
+    result = []
+    for p in _raw_positions(client, account_id):
+        if str(p.get("assetClass", "")).upper() != "OPT":
+            continue
+        qty = _to_float(p.get("position"))
+        if not qty:
+            continue
+
+        chain_symbol = p.get("ticker") or _underlying_from_desc(p.get("contractDesc", "")) or ""
+        multiplier = _to_float(p.get("multiplier")) or 100.0
+        avg_cost = _to_float(p.get("avgCost"))  # per-contract cost (premium * mult)
+        # avgCost is the total per-contract cost basis; per-share premium = avgCost / multiplier.
+        avg_price = (avg_cost / multiplier) if avg_cost else 0.0
+        mkt_price = _to_float(p.get("mktPrice")) or avg_price
+        mkt_value = _to_float(p.get("mktValue"))
+
+        strike = _to_float(p.get("strike")) or 0.0
+        expiration = _format_expiry(p.get("expiry"))
+        option_type = _right_to_type(p.get("putOrCall") or p.get("right"))
+        dte = _dte(expiration)
+
+        cost_basis = qty * avg_price * multiplier
+        current_value = mkt_value if mkt_value is not None else qty * mkt_price * multiplier
+        unrealized = current_value - cost_basis
+
+        result.append({
+            "chain_symbol": chain_symbol,
+            "option_type": option_type,
+            "position_type": "long" if qty > 0 else "short",
+            "strike": strike,
+            "expiration": expiration,
+            "dte": dte,
+            "quantity": qty,
+            "avg_price": round(avg_price, 4),
+            "mark_price": round(mkt_price, 4),
+            "multiplier": multiplier,
+            "cost_basis": round(cost_basis, 2),
+            "current_value": round(current_value, 2),
+            "unrealized_pl": round(unrealized, 2),
+            "unrealized_pl_pct": round(unrealized / cost_basis, 4) if cost_basis else 0.0,
+            "underlying_price": _to_float(p.get("undPrice")),
+            "greeks": {"delta": None, "gamma": None, "theta": None, "vega": None, "iv": None},
+        })
+    return result
+
+
+def _right_to_type(right) -> str:
+    r = str(right or "").upper()
+    if r in ("C", "CALL"):
+        return "call"
+    if r in ("P", "PUT"):
+        return "put"
+    return ""
+
+
+def _format_expiry(expiry) -> str:
+    """CP expiry is often 'YYYYMMDD'; normalise to 'YYYY-MM-DD'."""
+    s = str(expiry or "")
+    if len(s) == 8 and s.isdigit():
+        return f"{s[0:4]}-{s[4:6]}-{s[6:8]}"
+    return s
+
+
+def _underlying_from_desc(desc: str) -> str:
+    return str(desc).split(" ", 1)[0] if desc else ""
+
+
+def _dte(expiration: str) -> int:
+    if not expiration:
+        return 0
+    try:
+        exp = datetime.strptime(expiration, "%Y-%m-%d").date()
+        return (exp - datetime.now(timezone.utc).date()).days
+    except (ValueError, TypeError):
+        return 0
+
+
+def _to_float(v):
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return None

--- a/app/brokers/ibkr/session.py
+++ b/app/brokers/ibkr/session.py
@@ -1,0 +1,138 @@
+"""IBKR session lifecycle — builds the ibind OAuth 1.0a client and manages the
+live-session-token handshake, brokerage session init, and tickle keepalive.
+
+ibind (``pip install ibind[oauth]``) performs the RSA / Diffie-Hellman live
+session token handshake internally when ``use_oauth=True``. We layer a thin
+``ensure_auth`` / ``tickle`` / ``auth_status`` lifecycle on top so every broker
+method can lazily (re)establish a brokerage session before issuing requests.
+"""
+
+import logging
+import time
+
+import ibind
+from ibind import IbkrClient
+from ibind.oauth.oauth1a import OAuth1aConfig
+
+log = logging.getLogger(__name__)
+
+# Live session token lifetime is ~24h. Refresh the brokerage session a little
+# before that to avoid edge-of-expiry failures.
+_SESSION_TTL_SECONDS = 23 * 60 * 60
+
+
+def _result_data(result):
+    """Extract the payload from an ibind Result (or pass through a raw dict/list)."""
+    if result is None:
+        return None
+    data = getattr(result, "data", None)
+    if data is not None:
+        return data
+    # Some monkeypatched/test doubles return the payload directly.
+    if isinstance(result, (dict, list)):
+        return result
+    return data
+
+
+class IBKRSession:
+    """Owns the ibind client and the OAuth/brokerage-session lifecycle."""
+
+    def __init__(
+        self,
+        account_id: str,
+        *,
+        paper: bool = True,
+        consumer_key: str = "",
+        access_token: str = "",
+        access_token_secret: str = "",
+        dh_prime: str = "",
+        signature_key_path: str = "",
+        encryption_key_path: str = "",
+    ):
+        self.account_id = account_id
+        self.paper = paper
+        self._authenticated = False
+        self._session_started_at: float | None = None
+
+        oauth_config = OAuth1aConfig(
+            consumer_key=consumer_key,
+            access_token=access_token,
+            access_token_secret=access_token_secret,
+            dh_prime=dh_prime,
+            signature_key_fp=signature_key_path or None,
+            encryption_key_fp=encryption_key_path or None,
+        )
+        self.client = IbkrClient(
+            account_id=account_id,
+            use_oauth=True,
+            oauth_config=oauth_config,
+        )
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def ensure_auth(self):
+        """Ensure a live brokerage session exists, (re)initialising if needed.
+
+        Establishes the brokerage session via ``/iserver/auth/ssodh/init`` and
+        keeps it alive. Tolerates transient errors so a single blip does not
+        force a full re-handshake.
+        """
+        if self._authenticated and not self._session_expired():
+            # Cheap keepalive; ignore transient failures.
+            try:
+                self.tickle()
+                return
+            except Exception:
+                log.warning("[ibkr] tickle failed during ensure_auth — re-initialising session")
+                self._authenticated = False
+
+        self._init_brokerage_session()
+
+    def _session_expired(self) -> bool:
+        if self._session_started_at is None:
+            return True
+        return (time.time() - self._session_started_at) >= _SESSION_TTL_SECONDS
+
+    def _init_brokerage_session(self):
+        """POST /iserver/auth/ssodh/init to open a brokerage session."""
+        try:
+            result = self.client.post(
+                "iserver/auth/ssodh/init",
+                params={"publish": True, "compete": True},
+            )
+            data = _result_data(result) or {}
+            authenticated = bool(data.get("authenticated", True)) if isinstance(data, dict) else True
+            self._authenticated = authenticated
+            self._session_started_at = time.time()
+            log.info("[ibkr] Brokerage session initialised (authenticated=%s)", authenticated)
+        except Exception as e:
+            self._authenticated = False
+            log.error("[ibkr] Failed to initialise brokerage session: %s", e)
+            raise
+
+    def tickle(self):
+        """GET /tickle keepalive. Returns the parsed payload."""
+        result = self.client.tickle()
+        return _result_data(result)
+
+    def auth_status(self) -> dict:
+        """Return standardized auth status: authenticated, session_expires_at, account_id."""
+        authenticated = self._authenticated
+        try:
+            result = self.client.get("iserver/auth/status")
+            data = _result_data(result)
+            if isinstance(data, dict) and "authenticated" in data:
+                authenticated = bool(data["authenticated"])
+                self._authenticated = authenticated
+        except Exception as e:
+            log.warning("[ibkr] auth_status check failed: %s", e)
+
+        expires_at = None
+        if self._session_started_at is not None:
+            expires_at = self._session_started_at + _SESSION_TTL_SECONDS
+
+        return {
+            "authenticated": authenticated,
+            "session_expires_at": expires_at,
+            "account_id": self.account_id,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ flask-cors>=4.0.0
 alpaca-py>=0.31.0
 robin-stocks>=3.0.0
 pyotp>=2.9.0
+ibind[oauth]>=0.1.23
 
 # Validation
 pydantic>=2.5.0

--- a/tests/test_ibkr_client.py
+++ b/tests/test_ibkr_client.py
@@ -1,0 +1,523 @@
+"""Tests for the IBKR broker client (app.brokers.ibkr).
+
+No network: the ibind IbkrClient and OAuth1aConfig are monkeypatched so
+construction performs no handshake, and a FakeClient records/answers requests.
+"""
+
+import pytest
+
+import app.brokers.ibkr.session as session_mod
+from app.brokers.ibkr import IBKRTrader
+from app.brokers.ibkr import contracts, orders, positions
+
+
+class FakeResult:
+    """Mimics ibind's Result object (has a .data attribute)."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class Queue:
+    """Wrap multiple sequential responses for the same path."""
+
+    def __init__(self, *items):
+        self.items = list(items)
+
+    def next(self):
+        if len(self.items) > 1:
+            return self.items.pop(0)
+        return self.items[0]
+
+
+class FakeClient:
+    """Records get/post/delete calls and returns scripted responses.
+
+    `responses` maps a path (str) to a payload. The payload is returned as-is
+    (so a list payload is delivered verbatim). To script multiple sequential
+    responses for one path, wrap them in a ``Queue``.
+    """
+
+    def __init__(self, responses=None):
+        self.responses = responses or {}
+        self.calls = []  # list of (verb, path, params)
+
+    def _resolve(self, path):
+        resp = self.responses.get(path, {})
+        if isinstance(resp, Queue):
+            return resp.next()
+        return resp
+
+    def get(self, path, params=None, **kw):
+        self.calls.append(("GET", path, params))
+        return FakeResult(self._resolve(path))
+
+    def post(self, path, params=None, **kw):
+        self.calls.append(("POST", path, params))
+        return FakeResult(self._resolve(path))
+
+    def delete(self, path, params=None, **kw):
+        self.calls.append(("DELETE", path, params))
+        return FakeResult(self._resolve(path))
+
+    def tickle(self, log=False):
+        self.calls.append(("TICKLE", "tickle", None))
+        return FakeResult({"iserver": {"authStatus": {"authenticated": True}}})
+
+
+@pytest.fixture
+def patched_ibind(monkeypatch):
+    """Replace the ibind client + oauth config so construction is inert."""
+    created = {}
+
+    class FakeOAuth1aConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeIbkrClient:
+        def __init__(self, account_id=None, use_oauth=False, oauth_config=None):
+            self.account_id = account_id
+            self.use_oauth = use_oauth
+            self.oauth_config = oauth_config
+            created["client"] = self
+
+    monkeypatch.setattr(session_mod, "OAuth1aConfig", FakeOAuth1aConfig)
+    monkeypatch.setattr(session_mod, "IbkrClient", FakeIbkrClient)
+    return created
+
+
+def _make_trader(fake_client):
+    """Build a trader, swap in a FakeClient, and pre-authenticate the session."""
+    trader = IBKRTrader(
+        "DU123456",
+        paper=True,
+        consumer_key="ck",
+        access_token="at",
+        access_token_secret="ats",
+        dh_prime="ff",
+        signature_key_path="/tmp/sig.pem",
+        encryption_key_path="/tmp/enc.pem",
+    )
+    trader._session.client = fake_client
+    trader._session._authenticated = True
+    trader._session._session_started_at = 0.0  # not expired path overridden below
+
+    # Make ensure_auth a no-op so individual tests focus on the operation.
+    trader._session.ensure_auth = lambda: None
+    return trader
+
+
+# -- construction ------------------------------------------------------------
+
+def test_construct_passes_oauth_config(patched_ibind):
+    trader = IBKRTrader(
+        "DU999",
+        consumer_key="my-ck",
+        access_token="my-at",
+        access_token_secret="my-ats",
+        dh_prime="deadbeef",
+        signature_key_path="/keys/sig.pem",
+        encryption_key_path="/keys/enc.pem",
+    )
+    client = patched_ibind["client"]
+    assert client.account_id == "DU999"
+    assert client.use_oauth is True
+    cfg = client.oauth_config.kwargs
+    assert cfg["consumer_key"] == "my-ck"
+    assert cfg["access_token"] == "my-at"
+    assert cfg["access_token_secret"] == "my-ats"
+    assert cfg["dh_prime"] == "deadbeef"
+    assert cfg["signature_key_fp"] == "/keys/sig.pem"
+    assert cfg["encryption_key_fp"] == "/keys/enc.pem"
+    assert trader.account_id == "DU999"
+
+
+# -- contract resolution -----------------------------------------------------
+
+def test_resolve_option_conid_calls_three_secdef_endpoints_in_order():
+    fake = FakeClient({
+        "iserver/secdef/search": [{"conid": 8314, "symbol": "IBM"}],
+        "iserver/secdef/strikes": {"call": [180.0, 185.0, 190.0], "put": [180.0]},
+        "iserver/secdef/info": [{"conid": 987654321, "strike": 185.0, "right": "C"}],
+    })
+
+    conid = contracts.resolve_option_conid(fake, "IBM", "2026-06-19", 185.0, "call")
+
+    assert conid == 987654321
+    paths = [c[1] for c in fake.calls]
+    assert paths == [
+        "iserver/secdef/search",
+        "iserver/secdef/strikes",
+        "iserver/secdef/info",
+    ]
+    # strikes/info requested the resolved underlying conid + JUN26 month + right
+    strikes_params = fake.calls[1][2]
+    assert strikes_params["conid"] == 8314
+    assert strikes_params["month"] == "JUN26"
+    info_params = fake.calls[2][2]
+    assert info_params["right"] == "C"
+    assert info_params["strike"] == 185.0
+
+
+def test_resolve_option_conid_returns_none_when_strike_missing():
+    fake = FakeClient({
+        "iserver/secdef/search": [{"conid": 8314}],
+        "iserver/secdef/strikes": {"call": [180.0], "put": [180.0]},
+    })
+    conid = contracts.resolve_option_conid(fake, "IBM", "2026-06-19", 999.0, "call")
+    assert conid is None
+    # Must not have called secdef/info.
+    assert [c[1] for c in fake.calls] == [
+        "iserver/secdef/search",
+        "iserver/secdef/strikes",
+    ]
+
+
+def test_resolve_option_conid_bad_option_type():
+    fake = FakeClient({})
+    assert contracts.resolve_option_conid(fake, "IBM", "2026-06-19", 185.0, "banana") is None
+    assert fake.calls == []
+
+
+# -- option order submission -------------------------------------------------
+
+def test_submit_option_order_builds_body_and_confirms(patched_ibind):
+    fake = FakeClient({
+        "iserver/secdef/search": [{"conid": 8314}],
+        "iserver/secdef/strikes": {"call": [185.0], "put": []},
+        "iserver/secdef/info": [{"conid": 987654321}],
+        # First POST returns a confirmation reply, then a real order id.
+        "iserver/account/DU123456/orders": [{"id": "reply-1", "message": ["Are you sure?"]}],
+        "iserver/reply/reply-1": [{"order_id": "ORD-42", "order_status": "Submitted"}],
+        # (single payloads; no Queue needed since each path is hit once)
+    })
+    trader = _make_trader(fake)
+
+    out = trader.submit_option_order({
+        "chain_symbol": "IBM",
+        "option_type": "call",
+        "strike": 185.0,
+        "expiration": "2026-06-19",
+        "side": "BUY",
+        "quantity": 2,
+        "limit_price": 3.25,
+    })
+
+    assert out == {"id": "ORD-42", "symbol": "IBM", "status": "Submitted"}
+
+    # Verify the order body that was POSTed.
+    order_post = next(c for c in fake.calls if c[1] == "iserver/account/DU123456/orders")
+    body = order_post[2]["orders"][0]
+    assert body == {
+        "conid": 987654321,
+        "side": "BUY",
+        "orderType": "LMT",
+        "price": 3.25,
+        "quantity": 2,
+        "tif": "DAY",
+    }
+    # Verify the reply/confirm step happened with confirmed=True.
+    reply_post = next(c for c in fake.calls if c[1] == "iserver/reply/reply-1")
+    assert reply_post[2] == {"confirmed": True}
+
+
+def test_submit_option_order_market_when_no_limit(patched_ibind):
+    fake = FakeClient({
+        "iserver/secdef/search": [{"conid": 8314}],
+        "iserver/secdef/strikes": {"call": [185.0], "put": []},
+        "iserver/secdef/info": [{"conid": 111}],
+        "iserver/account/DU123456/orders": [{"order_id": "ORD-7", "order_status": "Filled"}],
+    })
+    trader = _make_trader(fake)
+
+    out = trader.submit_option_order({
+        "chain_symbol": "IBM",
+        "option_type": "call",
+        "strike": 185.0,
+        "expiration": "2026-06-19",
+        "side": "SELL",
+        "quantity": 1,
+        "limit_price": None,
+    })
+    assert out == {"id": "ORD-7", "symbol": "IBM", "status": "Filled"}
+    body = next(c for c in fake.calls if c[1] == "iserver/account/DU123456/orders")[2]["orders"][0]
+    assert body["orderType"] == "MKT"
+    assert "price" not in body
+
+
+def test_submit_option_order_returns_none_on_unresolvable_conid(patched_ibind):
+    fake = FakeClient({
+        "iserver/secdef/search": [],  # no underlying -> None
+    })
+    trader = _make_trader(fake)
+    out = trader.submit_option_order({
+        "chain_symbol": "ZZZ",
+        "option_type": "put",
+        "strike": 10.0,
+        "expiration": "2026-06-19",
+        "side": "BUY",
+        "quantity": 1,
+        "limit_price": 1.0,
+    })
+    assert out is None
+
+
+def test_submit_option_order_returns_none_on_api_error(patched_ibind):
+    class ExplodingClient(FakeClient):
+        def post(self, path, params=None, **kw):
+            if "orders" in path:
+                raise RuntimeError("CP 500")
+            return super().post(path, params, **kw)
+
+    fake = ExplodingClient({
+        "iserver/secdef/search": [{"conid": 8314}],
+        "iserver/secdef/strikes": {"call": [185.0], "put": []},
+        "iserver/secdef/info": [{"conid": 111}],
+    })
+    trader = _make_trader(fake)
+    out = trader.submit_option_order({
+        "chain_symbol": "IBM",
+        "option_type": "call",
+        "strike": 185.0,
+        "expiration": "2026-06-19",
+        "side": "BUY",
+        "quantity": 1,
+        "limit_price": 2.0,
+    })
+    assert out is None
+
+
+def test_submit_option_order_rejection_returns_none(patched_ibind):
+    fake = FakeClient({
+        "iserver/secdef/search": [{"conid": 8314}],
+        "iserver/secdef/strikes": {"call": [185.0], "put": []},
+        "iserver/secdef/info": [{"conid": 111}],
+        "iserver/account/DU123456/orders": [{"id": "r1", "message": ["Order rejected: insufficient funds"]}],
+    })
+    trader = _make_trader(fake)
+    out = trader.submit_option_order({
+        "chain_symbol": "IBM",
+        "option_type": "call",
+        "strike": 185.0,
+        "expiration": "2026-06-19",
+        "side": "BUY",
+        "quantity": 1,
+        "limit_price": 2.0,
+    })
+    assert out is None
+
+
+# -- equity order submission -------------------------------------------------
+
+def test_submit_order_equity(patched_ibind):
+    fake = FakeClient({
+        "iserver/account/DU123456/orders": [{"order_id": "E-1", "order_status": "Submitted"}],
+    })
+    trader = _make_trader(fake)
+    out = trader.submit_order({
+        "symbol": "AAPL",
+        "conid": 265598,
+        "side": "BUY",
+        "quantity": 10,
+        "order_type": "limit",
+        "limit_price": 190.5,
+    })
+    assert out == {"id": "E-1", "symbol": "AAPL", "status": "Submitted"}
+    body = fake.calls[0][2]["orders"][0]
+    assert body == {
+        "conid": 265598,
+        "side": "BUY",
+        "orderType": "LMT",
+        "price": 190.5,
+        "quantity": 10,
+        "tif": "DAY",
+    }
+
+
+def test_submit_order_missing_conid_returns_none(patched_ibind):
+    fake = FakeClient({})
+    trader = _make_trader(fake)
+    assert trader.submit_order({"symbol": "AAPL", "side": "BUY", "quantity": 1}) is None
+
+
+# -- positions / orders mapping ----------------------------------------------
+
+def test_account_mapping(patched_ibind):
+    fake = FakeClient({
+        "portfolio/DU123456/summary": {
+            "equitywithloanvalue": {"amount": 100000.0},
+            "totalcashvalue": {"amount": 25000.0},
+            "buyingpower": {"amount": 50000.0},
+            "netliquidation": {"amount": 99000.0},
+        },
+    })
+    trader = _make_trader(fake)
+    acct = trader.account()
+    assert acct == {
+        "equity": 100000.0,
+        "cash": 25000.0,
+        "buying_power": 50000.0,
+        "portfolio_value": 99000.0,
+    }
+
+
+def test_positions_mapping(patched_ibind):
+    fake = FakeClient({
+        "portfolio/DU123456/positions/0": [
+            {
+                "contractDesc": "AAPL", "assetClass": "STK", "position": 100,
+                "avgCost": 150.0, "mktValue": 16000.0,
+            },
+            {"assetClass": "OPT", "position": 1, "avgCost": 300.0},  # excluded
+            {"contractDesc": "ZERO", "assetClass": "STK", "position": 0},  # zero qty skipped
+        ],
+    })
+    trader = _make_trader(fake)
+    pos = trader.positions()
+    assert len(pos) == 1
+    p = pos[0]
+    assert p["symbol"] == "AAPL"
+    assert p["qty"] == 100.0
+    assert p["side"] == "long"
+    assert p["market_value"] == 16000.0
+    assert p["avg_entry"] == 150.0
+    assert p["unrealized_pl"] == 1000.0  # 16000 - 15000
+    assert p["unrealized_pl_pct"] == round(1000.0 / 15000.0, 4)
+
+
+def test_options_positions_mapping(patched_ibind):
+    fake = FakeClient({
+        "portfolio/DU123456/positions/0": [
+            {
+                "ticker": "IBM", "assetClass": "OPT", "position": 2,
+                "avgCost": 300.0, "mktPrice": 3.5, "mktValue": 700.0,
+                "strike": 185.0, "expiry": "20260619", "putOrCall": "C",
+                "multiplier": 100, "undPrice": 188.0,
+            },
+            {"ticker": "AAPL", "assetClass": "STK", "position": 10},  # excluded
+        ],
+    })
+    trader = _make_trader(fake)
+    opts = trader.options_positions()
+    assert len(opts) == 1
+    o = opts[0]
+    assert o["chain_symbol"] == "IBM"
+    assert o["option_type"] == "call"
+    assert o["position_type"] == "long"
+    assert o["strike"] == 185.0
+    assert o["expiration"] == "2026-06-19"
+    assert o["quantity"] == 2.0
+    assert o["avg_price"] == 3.0  # 300 / 100
+    assert o["mark_price"] == 3.5
+    assert o["multiplier"] == 100.0
+    assert o["cost_basis"] == 600.0  # 2 * 3.0 * 100
+    assert o["current_value"] == 700.0
+    assert o["unrealized_pl"] == 100.0
+    assert o["underlying_price"] == 188.0
+    assert set(o["greeks"].keys()) == {"delta", "gamma", "theta", "vega", "iv"}
+
+
+def test_open_orders_mapping(patched_ibind):
+    fake = FakeClient({
+        "iserver/account/orders": {
+            "orders": [
+                {
+                    "orderId": 111, "ticker": "AAPL", "side": "BUY",
+                    "totalSize": 10, "orderType": "LMT", "price": 190.0,
+                    "status": "Submitted", "secType": "STK",
+                },
+                {
+                    "orderId": 222, "ticker": "MSFT", "side": "SELL",
+                    "totalSize": 5, "orderType": "MKT", "status": "Filled",
+                    "secType": "STK",
+                },  # not open -> excluded
+                {
+                    "orderId": 333, "ticker": "IBM", "side": "BUY",
+                    "totalSize": 1, "status": "Submitted", "secType": "OPT",
+                },  # option -> excluded from equity view
+            ]
+        },
+    })
+    trader = _make_trader(fake)
+    oo = trader.open_orders()
+    assert len(oo) == 1
+    o = oo[0]
+    assert o["id"] == "111"
+    assert o["symbol"] == "AAPL"
+    assert o["side"] == "BUY"
+    assert o["qty"] == 10.0
+    assert o["type"] == "lmt"
+    assert o["limit_price"] == 190.0
+    assert o["status"] == "Submitted"
+
+
+def test_options_orders_mapping(patched_ibind):
+    fake = FakeClient({
+        "iserver/account/orders": {
+            "orders": [
+                {
+                    "orderId": 333, "ticker": "IBM", "side": "SELL",
+                    "totalSize": 2, "orderType": "LMT", "price": 3.5,
+                    "status": "Submitted", "secType": "OPT",
+                    "strike": 185.0, "expiry": "20260619", "right": "P",
+                    "timeInForce": "DAY",
+                },
+                {"orderId": 444, "secType": "STK", "status": "Submitted"},  # excluded
+            ]
+        },
+    })
+    trader = _make_trader(fake)
+    oo = trader.options_orders()
+    assert len(oo) == 1
+    o = oo[0]
+    assert o["order_id"] == "333"
+    assert o["state"] == "Submitted"
+    assert o["quantity"] == 2.0
+    assert o["price"] == 3.5
+    assert o["direction"] == "credit"  # SELL
+    assert o["time_in_force"] == "DAY"
+    assert len(o["legs"]) == 1
+    leg = o["legs"][0]
+    assert leg["side"] == "SELL"
+    assert leg["strike"] == 185.0
+    assert leg["expiration"] == "20260619"
+    assert leg["option_type"] == "put"
+    assert leg["chain_symbol"] == "IBM"
+
+
+# -- cancel ------------------------------------------------------------------
+
+def test_cancel_order(patched_ibind):
+    fake = FakeClient({})
+    trader = _make_trader(fake)
+    trader.cancel_order("ORD-9")
+    assert fake.calls == [("DELETE", "iserver/account/DU123456/order/ORD-9", None)]
+
+
+def test_cancel_all(patched_ibind):
+    fake = FakeClient({
+        "iserver/account/orders": {
+            "orders": [
+                {"orderId": 1, "secType": "STK", "status": "Submitted"},
+                {"orderId": 2, "secType": "STK", "status": "Submitted"},
+            ]
+        },
+    })
+    trader = _make_trader(fake)
+    trader.cancel_all()
+    deletes = [c for c in fake.calls if c[0] == "DELETE"]
+    assert len(deletes) == 2
+
+
+# -- auth status -------------------------------------------------------------
+
+def test_auth_status(patched_ibind):
+    fake = FakeClient({
+        "iserver/auth/status": {"authenticated": True},
+    })
+    trader = _make_trader(fake)
+    trader._session._session_started_at = 1000.0
+    status = trader.auth_status()
+    assert status["authenticated"] is True
+    assert status["account_id"] == "DU123456"
+    assert status["session_expires_at"] == 1000.0 + 23 * 60 * 60


### PR DESCRIPTION
## Summary
Adds the `app/brokers/ibkr/` package: a `BrokerClient` implementation that places live options (and equity) orders against IBKR's **Client Portal Web API** using the **ibind** library's OAuth 1.0a live-session-token handshake — headless, no CP Gateway process.

This is one unit of a larger change (a broker registry, built separately, will read config and construct `IBKRTrader` with explicit args).

## Package layout
- `session.py` — builds the ibind `IbkrClient` with `OAuth1aConfig`; lifecycle `ensure_auth()` (POST `/iserver/auth/ssodh/init`), `tickle()` keepalive, `auth_status()` (GET `/iserver/auth/status`).
- `contracts.py` — `resolve_option_conid()` via the mandatory ordered sequence `/iserver/secdef/search` → `/iserver/secdef/strikes` → `/iserver/secdef/info`; call/put → right C/P.
- `orders.py` — `submit_order`, `submit_option_order` (with the `/iserver/reply/{id}` confirm loop), `cancel_order`, `cancel_all`, `open_orders`, `options_orders`.
- `positions.py` — `account()`, `positions()`, `options_positions()` in the standardized output shapes.
- `client.py` — `IBKRTrader(BrokerClient)` composing the above; explicit-arg constructor (not Flask config). Every public method calls `ensure_auth()` first; order-submit methods catch exceptions and return `None` on failure.
- `requirements.txt` — adds `ibind[oauth]`.

## Interface contract honored
- Constructor: `IBKRTrader(account_id, *, paper=True, consumer_key="", access_token="", access_token_secret="", dh_prime="", signature_key_path="", encryption_key_path="")`.
- Implements the 6 abstract `BrokerClient` methods plus `options_positions`, `options_orders`, `auth_status`, and new `submit_option_order`.
- Output shapes match the existing standardized shapes (mirrors `robinhood_client.py`).

## Tests
`tests/test_ibkr_client.py` monkeypatches the ibind client (no network). Covers: secdef 3-endpoint ordering + conid resolution, option/equity order body construction + reply/confirm step, error and rejection → `None`, positions/orders/options mapping, and `auth_status`.

## Verification
- `pip install ibind[oauth]` ✓
- `pytest tests/test_ibkr_client.py -q` → 19 passed
- `pytest tests/ -q` → 54 passed
- `python -c "import app.brokers.ibkr"` ✓
- LIVE e2e skipped (no IBKR OAuth creds in worktree; requires market hours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)