### PR TITLE
Wire Interactive Brokers (ibkr) into broker registry

### DIFF
--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -6,7 +6,7 @@ _broker_cache: dict[str, BrokerClient] = {}
 
 
 def get_broker(name: str) -> BrokerClient:
-    """Get or create a broker client by name ('alpaca' or 'robinhood')."""
+    """Get or create a broker client by name ('alpaca', 'robinhood', or 'ibkr')."""
     if name in _broker_cache:
         return _broker_cache[name]
 
@@ -30,6 +30,17 @@ def get_broker(name: str) -> BrokerClient:
             totp_secret=config.get("RH_TOTP_SECRET", ""),
             pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
             account_number=config.get("RH_AUTOMATED_ACCOUNT_NUMBER", ""),
+        )
+    elif name == "ibkr":
+        from app.brokers.ibkr import IBKRTrader
+        client = IBKRTrader(
+            account_id=config.get("IBKR_ACCOUNT_ID", ""),
+            host=config.get("IBKR_HOST", "127.0.0.1"),
+            port=config.get("IBKR_PORT", 4002),
+            client_id=config.get("IBKR_CLIENT_ID", 1),
+            paper=config.get("IBKR_PAPER", True),
+            peg_delta_default=config.get("IBKR_PEG_DELTA_DEFAULT", 0.5),
+            max_option_order_qty=config.get("IBKR_MAX_OPTION_ORDER_QTY", 50),
         )
     else:
         raise ValueError(f"Unknown broker: {name}")


### PR DESCRIPTION
## Summary
Adds an `ibkr` branch to `get_broker()` in `app/brokers/__init__.py`, mirroring the existing `alpaca` and `robinhood` branches. The branch lazily imports `IBKRTrader` from `app.brokers.ibkr` (built by another worker) and constructs it from the IB Gateway config keys.

This is the broker-registry wiring unit for the new Interactive Brokers integration that places live options as Pegged-to-Stock orders via `ib_async` + a persistent IB Gateway.

## Details
- Constructs `IBKRTrader(account_id, *, host, port, client_id, paper, peg_delta_default, max_option_order_qty)` per the agreed contract.
- Uses `config.get(...)` with defaults (host `127.0.0.1`, port `4002`, client_id `1`, paper `True`, peg_delta `0.5`, max qty `50`) so the registry stays import-safe before the config keys exist.
- Lazy import inside the `elif` keeps `app/brokers/__init__.py` importable even though `app.brokers.ibkr` does not yet exist in this worktree.

## Testing
- `python3 -c "import app.brokers"` — imports cleanly.
- `pytest tests/ -q` — 35 passed.
- Live e2e skipped (no IB Gateway). `get_broker("ibkr")` is expected to fail here until the `app.brokers.ibkr` package lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)