### PR TITLE
Add Interactive Brokers Gateway config (ib_async / TWS socket)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,17 @@ class Config:
             return cls.RH_AUTO_EMAIL, cls.RH_AUTO_PASSWORD
         return cls.RH_MAIN_EMAIL, cls.RH_MAIN_PASSWORD
 
+    # -- Interactive Brokers (IB Gateway via ib_async / TWS socket) --
+    IBKR_HOST = os.getenv("IBKR_HOST", "127.0.0.1")
+    IBKR_PORT = int(os.getenv("IBKR_PORT", "4002"))          # 4002 paper / 4001 live
+    IBKR_CLIENT_ID = int(os.getenv("IBKR_CLIENT_ID", "1"))
+    IBKR_ACCOUNT_ID = os.getenv("IBKR_ACCOUNT_ID", "")
+    IBKR_PAPER = os.getenv("IBKR_PAPER", "true").lower() == "true"
+    IBKR_PEG_DELTA_DEFAULT = float(os.getenv("IBKR_PEG_DELTA_DEFAULT", "0.5"))
+    IBKR_MAX_OPTION_ORDER_QTY = int(os.getenv("IBKR_MAX_OPTION_ORDER_QTY", os.getenv("MAX_ORDER_QTY", "50")))
+    IBKR_OPEN_BUFFER_MIN = int(os.getenv("IBKR_OPEN_BUFFER_MIN", "2"))
+    IBKR_CLOSE_BUFFER_MIN = int(os.getenv("IBKR_CLOSE_BUFFER_MIN", "5"))
+
     # -- Runtime service --
     RUNTIME_SERVICE_URL = os.getenv(
         "RUNTIME_SERVICE_URL",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ flask-cors>=4.0.0
 alpaca-py>=0.31.0
 robin-stocks>=3.0.0
 pyotp>=2.9.0
+ib_async>=1.0.1
+pandas_market_calendars>=4.4.0
 
 # Validation
 pydantic>=2.5.0


### PR DESCRIPTION
## Summary
Adds an Interactive Brokers (IB Gateway via `ib_async` / TWS socket) configuration section, the first unit toward placing live options as Pegged-to-Stock orders through a persistent IB Gateway.

- **app/config.py** — new IBKR Gateway section mirroring the Alpaca/Robinhood patterns: `IBKR_HOST`, `IBKR_PORT` (4002 paper / 4001 live), `IBKR_CLIENT_ID`, `IBKR_ACCOUNT_ID`, `IBKR_PAPER`, `IBKR_PEG_DELTA_DEFAULT`, `IBKR_MAX_OPTION_ORDER_QTY` (falls back to `MAX_ORDER_QTY`), `IBKR_OPEN_BUFFER_MIN`, `IBKR_CLOSE_BUFFER_MIN`.
- **requirements.txt** — adds `ib_async>=1.0.1` under Brokers and `pandas_market_calendars>=4.4.0` for session gating. No ibind (the abandoned OAuth/ibind path is intentionally not reintroduced).

## Verification
- `python -c "from app.config import Config; print(Config.IBKR_HOST, Config.IBKR_PORT, Config.IBKR_PAPER, Config.IBKR_OPEN_BUFFER_MIN)"` → `127.0.0.1 4002 True 2`
- `pip install --dry-run` resolves cleanly (ib_async 2.1.0, pandas_market_calendars 5.4.0)
- `pytest tests/ -q` → 35 passed
- Code review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)