### PR TITLE
Add POST /options/order endpoint (broker-agnostic)

### DIFF
--- a/app/api/options.py
+++ b/app/api/options.py
@@ -2,6 +2,7 @@
 
 from flask import Blueprint, jsonify, request, current_app
 from app.brokers import get_broker
+from app.enums import OrderSide
 
 bp = Blueprint("options", __name__)
 
@@ -33,5 +34,108 @@ def options_orders(broker_name=None):
             return jsonify({"error": f"Broker {broker_name} does not support options orders"}), 400
         data = broker.options_orders(limit=limit)
         return jsonify({"broker": broker_name, "count": len(data), "orders": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/options/order", methods=["POST"])
+@bp.route("/options/order/<broker_name>", methods=["POST"])
+def options_order(broker_name=None):
+    """Place an option order (broker-agnostic).
+
+    Body JSON:
+        chain_symbol: str   (required) underlying symbol, e.g. "AAPL"
+        option_type:  str   (required) "call" or "put"
+        strike:       float (required)
+        expiration:   str   (required) e.g. "2026-06-19"
+        side:         str   (required) "BUY" or "SELL"
+        quantity:     float (required) number of contracts
+
+        limit_price:                float (optional)
+        peg_delta:                  float (optional) Pegged-to-Stock delta offset
+        cancel_if_underlying_above: float (optional) conditional cancel trigger
+        cancel_if_underlying_below: float (optional) conditional cancel trigger
+    """
+    broker_name = broker_name or current_app.config["DEFAULT_BROKER"]
+    body = request.get_json(silent=True)
+    if not body:
+        return jsonify({"error": "JSON body required"}), 400
+
+    # --- validate required fields ---
+    chain_symbol = body.get("chain_symbol")
+    option_type = body.get("option_type")
+    strike = body.get("strike")
+    expiration = body.get("expiration")
+    side = body.get("side")
+    quantity = body.get("quantity")
+
+    errors = []
+    if not chain_symbol or not isinstance(chain_symbol, str):
+        errors.append("chain_symbol is required (string)")
+    if not option_type or not isinstance(option_type, str):
+        errors.append("option_type is required (string)")
+
+    if strike is None:
+        errors.append("strike is required")
+    else:
+        try:
+            strike = float(strike)
+        except (TypeError, ValueError):
+            errors.append("strike must be a number")
+
+    if not expiration or not isinstance(expiration, str):
+        errors.append("expiration is required (string)")
+
+    side_enum = None
+    if side is None or not isinstance(side, str):
+        errors.append("side must be 'BUY' or 'SELL'")
+    else:
+        side_upper = side.upper()
+        if side_upper not in (OrderSide.BUY, OrderSide.SELL):
+            errors.append("side must be 'BUY' or 'SELL'")
+        else:
+            side_enum = OrderSide(side_upper)
+
+    if quantity is None:
+        errors.append("quantity is required")
+    else:
+        try:
+            quantity = float(quantity)
+            if quantity <= 0:
+                errors.append("quantity must be positive")
+        except (TypeError, ValueError):
+            errors.append("quantity must be a number")
+
+    if errors:
+        return jsonify({"error": "Validation failed", "details": errors}), 400
+
+    try:
+        broker = get_broker(broker_name)
+        if not hasattr(broker, "submit_option_order"):
+            return jsonify({"error": f"Broker {broker_name} does not support option orders"}), 400
+
+        order = {
+            "chain_symbol": chain_symbol.upper(),
+            "option_type": option_type,
+            "strike": strike,
+            "expiration": expiration,
+            "side": side_enum,
+            "quantity": quantity,
+        }
+
+        # --- optional fields, forwarded only when provided ---
+        for field in (
+            "limit_price",
+            "peg_delta",
+            "cancel_if_underlying_above",
+            "cancel_if_underlying_below",
+        ):
+            if body.get(field) is not None:
+                order[field] = body[field]
+
+        result = broker.submit_option_order(order)
+        if result is None:
+            return jsonify({"error": "Order submission failed"}), 502
+        return jsonify({"broker": broker_name, "order": result})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/tests/test_options_order_api.py
+++ b/tests/test_options_order_api.py
@@ -1,0 +1,117 @@
+"""Tests for the POST /options/order endpoint (broker-agnostic)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import app.api.options as options_module
+from app import create_app
+from app.enums import OrderSide
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["DEFAULT_BROKER"] = "robinhood"
+    with app.test_client() as c:
+        yield c
+
+
+def _valid_body(**overrides):
+    body = {
+        "chain_symbol": "aapl",
+        "option_type": "call",
+        "strike": 190,
+        "expiration": "2026-06-19",
+        "side": "buy",
+        "quantity": 1,
+    }
+    body.update(overrides)
+    return body
+
+
+def _mock_broker(submit_return):
+    broker = MagicMock()
+    broker.submit_option_order.return_value = submit_return
+    return broker
+
+
+def test_places_order_and_returns_200(client, monkeypatch):
+    canned = {"id": "opt-123", "symbol": "AAPL 2026-06-19 C190", "status": "queued"}
+    broker = _mock_broker(canned)
+    monkeypatch.setattr(options_module, "get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json=_valid_body())
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["broker"] == "robinhood"
+    assert data["order"] == canned
+
+    # broker was called once with a normalized order dict
+    broker.submit_option_order.assert_called_once()
+    order = broker.submit_option_order.call_args.args[0]
+    assert order["chain_symbol"] == "AAPL"
+    assert order["side"] == OrderSide.BUY
+    assert order["strike"] == 190.0
+    assert order["quantity"] == 1.0
+    # optional peg/cancel fields not provided → absent
+    assert "peg_delta" not in order
+    assert "cancel_if_underlying_above" not in order
+    assert "cancel_if_underlying_below" not in order
+    assert "limit_price" not in order
+
+
+def test_forwards_optional_peg_and_cancel_fields(client, monkeypatch):
+    broker = _mock_broker({"id": "x", "symbol": "Y", "status": "queued"})
+    monkeypatch.setattr(options_module, "get_broker", lambda name: broker)
+
+    body = _valid_body(
+        limit_price=2.50,
+        peg_delta=0.05,
+        cancel_if_underlying_above=200,
+        cancel_if_underlying_below=150,
+    )
+    resp = client.post("/api/options/order", json=body)
+
+    assert resp.status_code == 200
+    order = broker.submit_option_order.call_args.args[0]
+    assert order["limit_price"] == 2.50
+    assert order["peg_delta"] == 0.05
+    assert order["cancel_if_underlying_above"] == 200
+    assert order["cancel_if_underlying_below"] == 150
+
+
+def test_missing_required_fields_returns_400(client, monkeypatch):
+    broker = _mock_broker({"id": "x"})
+    monkeypatch.setattr(options_module, "get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json={"chain_symbol": "AAPL"})
+
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["error"] == "Validation failed"
+    assert isinstance(data["details"], list)
+    assert len(data["details"]) >= 1
+    broker.submit_option_order.assert_not_called()
+
+
+def test_unsupported_broker_returns_400(client, monkeypatch):
+    broker = MagicMock(spec=[])  # no submit_option_order attribute
+    monkeypatch.setattr(options_module, "get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order/robinhood", json=_valid_body())
+
+    assert resp.status_code == 400
+    assert "does not support option orders" in resp.get_json()["error"]
+
+
+def test_none_result_returns_502(client, monkeypatch):
+    broker = _mock_broker(None)
+    monkeypatch.setattr(options_module, "get_broker", lambda name: broker)
+
+    resp = client.post("/api/options/order", json=_valid_body())
+
+    assert resp.status_code == 502
+    assert resp.get_json()["error"] == "Order submission failed"


### PR DESCRIPTION
## Summary
Adds a broker-agnostic HTTP endpoint to manually place/verify an option order, supporting Pegged-to-Stock parameters and optional conditional-cancel triggers. No IBKR code — the broker is referenced via duck-typing (`hasattr(broker, "submit_option_order")`).

## What changed
- `app/api/options.py`: new `POST /options/order` and `POST /options/order/<broker_name>` routes.
  - Resolves `broker_name` from path or `DEFAULT_BROKER` config.
  - Required: `chain_symbol, option_type, strike, expiration, side, quantity`. Validation errors aggregate into `400 {"error": "Validation failed", "details": [...]}`, mirroring `trade.py`.
  - `side` maps to `OrderSide.BUY/SELL` (case-insensitive input, uppercased).
  - Gates on `hasattr(broker, "submit_option_order")` → `400` if unsupported (same pattern as the GET routes).
  - Forwards optional `limit_price, peg_delta, cancel_if_underlying_above, cancel_if_underlying_below` into the order dict only when provided.
  - `None` result → `502 {"error": "Order submission failed"}`; exceptions → `500 {"error": str(e)}`.
- `tests/test_options_order_api.py`: Flask test-client tests with `get_broker` monkeypatched to a `MagicMock`. Covers 200 + body + peg/cancel field forwarding, 400 (missing required), 400 (unsupported broker), and 502 (None result).

## Contract
Depends on `broker.submit_option_order(order: dict) -> dict | None` returning `{"id","symbol","status"}`. Referenced only via duck-typing — no IBKR import.

## Testing
- `python3 -c "import app.api.options"` — ok
- `pytest tests/ -q` — 40 passed
- Live e2e skipped per recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)