### PR TITLE
IB Gateway deployment + IBKR setup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,21 @@ If you deploy first, the service downloads the old/stale pickle from Netlify and
 - `GET /api/auth/status/robinhood` — broker-specific status
 - `GET /api/health` — general service health
 
+## Interactive Brokers (IBKR)
+
+An IBKR broker places **live options orders, always as Pegged-to-Stock (`PEG STK`)**, with an
+optional conditional cancel (cancel the working order if the underlying trades above/below a
+threshold). It connects via [`ib_async`](https://github.com/ib-api-reloaded/ib_async) over the
+TWS socket to a persistent **IB Gateway** running as a separate private Render service
+(`deploy/ib-gateway/`, dockerized `gnzsnz/ib-gateway`; ports 4001 live / 4002 paper). `PEG STK`
+and native cancel-on-price conditions are TWS/Gateway-only — the Client Portal Web API can't do
+them, which is why a Gateway process is required. **Caveat:** pegged orders are DAY orders and
+their cancel guards are **intraday-only** (not an overnight stop); the engine re-stages each RTH
+session and gates submission with open/close buffers (`IBKR_OPEN_BUFFER_MIN`/`IBKR_CLOSE_BUFFER_MIN`).
+Secrets (`TWS_*` on the gateway; `IBKR_*`, `ENGINE_BROKER=ibkr`, `DRY_RUN` on worker+api), the
+2FA operational risk, and paper-first rollout are documented in
+[docs/ibkr-setup.md](docs/ibkr-setup.md).
+
 ## Render CLI
 
 ```bash

--- a/deploy/ib-gateway/.env.example
+++ b/deploy/ib-gateway/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env for local `docker compose up`. Never commit the filled-in file.
+
+# IBKR login (use a paper account, or a dedicated API username for live).
+TWS_USERID=your_ibkr_username
+TWS_PASSWORD=your_ibkr_password
+
+# paper -> port 4002, live -> port 4001
+TRADING_MODE=paper
+IB_API_PORT=4002
+
+# no = orders allowed; yes = read-only API (no order placement)
+READ_ONLY_API=no
+
+# Daily Gateway restart/re-login (quiet overnight window, clear of 09:30 ET open)
+AUTO_RESTART_TIME=23:45
+TZ=America/New_York
+
+BIND_ADDRESS=0.0.0.0

--- a/deploy/ib-gateway/README.md
+++ b/deploy/ib-gateway/README.md
@@ -1,0 +1,64 @@
+# IB Gateway deployment
+
+Headless [Interactive Brokers Gateway](https://www.interactivebrokers.com/en/trading/ibgateway-stable.php)
+packaged by [`gnzsnz/ib-gateway-docker`](https://github.com/gnzsnz/ib-gateway-docker).
+The image bundles **IBC** (automates the Gateway login), **Xvfb** (a virtual X
+display so the Java GUI runs without a screen), and **socat** (forwards the
+in-container API port to the host). The engine talks to it over the TWS socket
+API using [`ib_async`](https://github.com/ib-api-reloaded/ib_async).
+
+This is the persistent process that `ENGINE_BROKER=ibkr` requires: native
+**Pegged-to-Stock (`PEG STK`)** orders and `PriceCondition` conditional cancels
+are only available over the TWS socket API, not the Client Portal Web API.
+
+Ports: **4002 = paper**, **4001 = live**.
+
+## Local (paper) testing
+
+```bash
+cp .env.example .env          # fill TWS_USERID / TWS_PASSWORD (paper account)
+docker compose up             # boots IBC -> Gateway, exposes 4002
+```
+
+Point the engine at it:
+
+```bash
+IBKR_HOST=127.0.0.1 IBKR_PORT=4002 IBKR_PAPER=true ENGINE_BROKER=ibkr DRY_RUN=true
+```
+
+Validate parsing without booting:
+
+```bash
+docker compose config
+```
+
+To watch the Gateway GUI while debugging, uncomment the `5900:5900` VNC port in
+`docker-compose.yml` and connect a VNC client to `localhost:5900`.
+
+## Render deployment
+
+Deploy as a **separate private service** (`type: pserv`) — see `render.yaml`. A
+private service has no public URL and is reachable only from other services in
+the same Render account/region, which is exactly what a credential-holding
+broker gateway should be.
+
+1. Create the service from `deploy/ib-gateway/render.yaml` (or add it to the
+   root blueprint). Set `TWS_USERID` / `TWS_PASSWORD` as secrets in the Render
+   dashboard (`sync: false`).
+2. Keep its **region** equal to the worker/api region so private networking
+   works.
+3. On the **worker** and **api**, set `IBKR_HOST=ib-gateway` (the gateway
+   service `name`) and `IBKR_PORT=4002` (paper) / `4001` (live).
+4. Start with `TRADING_MODE=paper`. Flip to `live` only after the paper
+   validation in `docs/ibkr-setup.md` passes.
+
+> **2FA warning:** unattended login assumes IBKR's Secure Login System / 2FA is
+> disabled for this username, or that a dedicated API user is used. A username
+> enforcing IBKEY push needs a **daily manual approval**, which breaks
+> unattended live trading. See `docs/ibkr-setup.md` § "Operational risk — 2FA".
+
+The Gateway re-logs in daily (`AUTO_RESTART_TIME`, default `23:45` ET) — a quiet
+overnight window, clear of the 09:30 ET open.
+
+See **`docs/ibkr-setup.md`** for the full secrets table, session-handling
+caveats, and the go-live runbook.

--- a/deploy/ib-gateway/docker-compose.yml
+++ b/deploy/ib-gateway/docker-compose.yml
@@ -1,0 +1,48 @@
+# IB Gateway (headless) via gnzsnz/ib-gateway-docker.
+# Bundles IBC (login automation) + Xvfb (virtual X display) + socat (port forward),
+# so the Gateway runs unattended and exposes the TWS socket API on the host.
+#
+# Local usage (paper):
+#   1. Copy .env.example -> .env and fill TWS_USERID / TWS_PASSWORD
+#   2. docker compose up
+#   3. Point the engine at it: IBKR_HOST=127.0.0.1 IBKR_PORT=4002 IBKR_PAPER=true
+#
+# Ports:
+#   4001 -> live API     4002 -> paper API
+#   5900 -> VNC (optional, for debugging the Gateway UI; gnzsnz exposes a VNC server)
+services:
+  ib-gateway:
+    image: ghcr.io/gnzsnz/ib-gateway:latest
+    restart: always
+    environment:
+      # --- Credentials (do NOT commit; supply via .env / Render secrets) ---
+      TWS_USERID: ${TWS_USERID}
+      TWS_PASSWORD: ${TWS_PASSWORD}
+      # paper | live  -> selects which port IBC logs into (4002 / 4001)
+      TRADING_MODE: ${TRADING_MODE:-paper}
+
+      # --- API hardening ---
+      # false = allow order placement/cancel (required for live trading).
+      # Set true to make the API read-only (market data + positions only).
+      READ_ONLY_API: ${READ_ONLY_API:-no}
+
+      # --- Persistence ---
+      # Persist Gateway/IBC settings + jts.ini across restarts so the
+      # "trusted IP" and UI prefs survive container recreation.
+      TWS_SETTINGS_PATH: /home/ibgateway/Jts
+
+      # --- Daily auto-restart / re-login ---
+      # IBC restarts the Gateway daily. Schedule it in a quiet overnight
+      # window (ET), well clear of the 09:30 ET open. 23:45 ET is the default
+      # we standardize on; adjust for the container's TZ.
+      AUTO_RESTART_TIME: ${AUTO_RESTART_TIME:-23:45}
+      TZ: ${TZ:-America/New_York}
+
+      # --- Bind controls ---
+      # Bind the API to all interfaces inside the container so socat/Render
+      # private networking can reach it. Trusted IPs are still enforced by IBC.
+      BIND_ADDRESS: ${BIND_ADDRESS:-0.0.0.0}
+    ports:
+      - "${IB_API_PORT:-4002}:${IB_API_PORT:-4002}"
+      # Uncomment to inspect the Gateway GUI over VNC while debugging:
+      # - "5900:5900"

--- a/deploy/ib-gateway/render.yaml
+++ b/deploy/ib-gateway/render.yaml
@@ -1,0 +1,39 @@
+# Deploy IB Gateway as a SEPARATE private Render service.
+#
+# The worker (allocation-engine-2.0) and api (allocation-engine-api) reach it
+# over Render PRIVATE networking — never expose the API port publicly.
+#   IBKR_HOST=ib-gateway   (the service `name` below)
+#   IBKR_PORT=4002 (paper) / 4001 (live)
+#
+# `pserv` (private service) has no public URL and is only reachable from other
+# services in the same Render account/region. This is the correct type for a
+# broker gateway holding live credentials.
+#
+# This file is standalone for the gateway. Merge the env vars into the root
+# render.yaml only if you prefer a single blueprint; keeping it separate avoids
+# coupling gateway redeploys to the app.
+services:
+  - type: pserv
+    name: ib-gateway
+    runtime: image
+    image:
+      url: ghcr.io/gnzsnz/ib-gateway:latest
+    region: ohio            # match the worker/api region for private networking
+    plan: starter
+    envVars:
+      - key: TWS_USERID
+        sync: false
+      - key: TWS_PASSWORD
+        sync: false
+      - key: TRADING_MODE
+        value: paper        # flip to "live" only after paper validation
+      - key: READ_ONLY_API
+        value: "no"
+      - key: TWS_SETTINGS_PATH
+        value: /home/ibgateway/Jts
+      - key: AUTO_RESTART_TIME
+        value: "23:45"
+      - key: TZ
+        value: America/New_York
+      - key: BIND_ADDRESS
+        value: 0.0.0.0

--- a/docs/ibkr-setup.md
+++ b/docs/ibkr-setup.md
@@ -1,0 +1,107 @@
+# Interactive Brokers (IB Gateway) Setup
+
+The IBKR broker places **live options orders, always as Pegged-to-Stock (`PEG STK`)**, with an
+optional **conditional cancel** (cancel the working order if the underlying trades above/below a
+threshold). It talks to a persistent **IB Gateway** over the TWS socket using the
+[`ib_async`](https://github.com/ib-api-reloaded/ib_async) library.
+
+## Why IB Gateway (and not the Client Portal Web API)
+`PEG STK` and native `PriceCondition` + `conditionsCancelOrder` (cancel-on-price) are **only
+available on the TWS/IB Gateway API** — the Client Portal Web API does not offer them. Pegged-to-stock
+is a managed product requirement here, so we run a real Gateway process. The tradeoff: unlike the
+headless Robinhood pickle flow, this requires a **persistent Gateway service** to be up during RTH.
+
+## Architecture
+```
+allocation-engine worker / api
+   └─ ib_async (TWS socket) ──▶ IB Gateway (dockerized, gnzsnz/ib-gateway)
+                                  ports: 4001 live / 4002 paper
+```
+The Gateway runs as a **separate private Render service** (`deploy/ib-gateway/`); the worker and
+api reach it over Render **private networking** (`IBKR_HOST=ib-gateway`). The API port is never
+exposed publicly — it holds live trading credentials.
+
+## Secrets / environment
+### On the IB Gateway service (`deploy/ib-gateway/`)
+| Var | Purpose |
+|---|---|
+| `TWS_USERID` | IBKR username the Gateway logs in with |
+| `TWS_PASSWORD` | IBKR password |
+| `TRADING_MODE` | `paper` (port 4002) or `live` (port 4001) |
+| `READ_ONLY_API` | `no` to allow order placement/cancel (required for trading) |
+| `AUTO_RESTART_TIME` | daily IBC restart, default `23:45` ET (kept clear of the 09:30 open) |
+| `TZ` | `America/New_York` |
+
+### On the worker + api (`allocation-engine-*`)
+| Var | Purpose |
+|---|---|
+| `IBKR_HOST` | Gateway service hostname (`ib-gateway` on Render private net) |
+| `IBKR_PORT` | `4002` paper / `4001` live |
+| `IBKR_CLIENT_ID` | TWS API client id (use a distinct id per connecting process) |
+| `IBKR_ACCOUNT_ID` | IBKR account number |
+| `IBKR_PAPER` | `true` / `false` |
+| `IBKR_PEG_DELTA_DEFAULT` | fallback peg delta when none is supplied/derivable |
+| `IBKR_MAX_OPTION_ORDER_QTY` | per-order contract cap |
+| `IBKR_OPEN_BUFFER_MIN` | minutes after the open to start trading (default 2) |
+| `IBKR_CLOSE_BUFFER_MIN` | minutes before the close to stop submitting (default 5) |
+| `ENGINE_BROKER` | set to `ibkr` to route trading through IBKR |
+| `DRY_RUN` | `true` = log only; `false` = place real orders |
+
+## Pegged-to-Stock + conditional cancel behavior
+- **Always `PEG STK`.** `submit_option_order` ignores any incoming `order_type` and builds a
+  Pegged-to-Stock order. `startingPrice` defaults to the order `limit_price` if given, else the
+  option's NBBO midpoint; `stockRefPrice` is left unset so IB pegs off the live underlying NBBO.
+- **delta source (priority):** per-order `peg_delta` → the option's live IB greek delta →
+  `IBKR_PEG_DELTA_DEFAULT`. The delta is signed automatically: **positive for calls, negative for puts**.
+- **conditional cancel (optional, per order):** `cancel_if_underlying_above` and/or
+  `cancel_if_underlying_below` attach a `PriceCondition` on the underlying with
+  `conditionsCancelOrder=True`. Both set ⇒ the order is cancelled when the underlying moves
+  **outside the band**.
+- **PEG STK fallback:** if an exchange rejects `PEG STK`, the client falls back to a limit order at
+  `startingPrice` so an order still lands (logged).
+
+## Session handling (CRITICAL — read this)
+`PEG STK` needs a live underlying NBBO and is a **DAY** order, so behavior varies across the day:
+- **RTH only.** Orders are only submitted during regular trading hours, skipping a buffer at the
+  open (`IBKR_OPEN_BUFFER_MIN`, auction NBBO is wide/gappy) and before the close
+  (`IBKR_CLOSE_BUFFER_MIN`, thin liquidity + churn). Half-days (1:00 PM ET) are honored.
+- **DAY lifecycle, re-staged each session.** Unfilled pegged orders **and their attached cancel
+  guards expire at the close.** The engine re-stages desired orders each RTH session via its normal
+  reconcile. **⚠️ The conditional cancel is therefore INTRADAY-ONLY — it is NOT an overnight stop.**
+  Fills/positions persist; only working orders die at the close.
+- **Overnight gaps.** A `PriceCondition` can fire immediately at the next open if the underlying
+  gapped through the level.
+- **Daily Gateway restart.** IBC restarts the Gateway once/day; scheduled to `~23:45 ET`, clear of
+  the open. The client reconnects and re-syncs open orders afterward.
+
+## Going live (paper first)
+1. Deploy the Gateway in **paper**: `TRADING_MODE=paper` (port 4002). Locally:
+   `cd deploy/ib-gateway && cp .env.example .env` (fill `TWS_USERID`/`TWS_PASSWORD`), then
+   `docker compose up`.
+2. On the worker/api set `IBKR_HOST`, `IBKR_PORT=4002`, `IBKR_PAPER=true`, `ENGINE_BROKER=ibkr`,
+   and keep `DRY_RUN=true` to dry-run. Confirm `GET /api/auth/status/ibkr` shows `connected: true`.
+3. Flip `DRY_RUN=false` and place a 1-lot far-OTM test order with a cancel threshold:
+   ```
+   curl -XPOST $API/api/options/order/ibkr -H 'Content-Type: application/json' -d '{
+     "chain_symbol":"SPY","option_type":"put","strike":<far_otm>,
+     "expiration":"YYYY-MM-DD","side":"BUY","quantity":1,
+     "peg_delta":0.3,"cancel_if_underlying_below":<level>
+   }'
+   ```
+   Verify in IB that the order is `PEG STK` and that moving the underlying past the level cancels it.
+4. When satisfied on paper, switch the Gateway to `TRADING_MODE=live` (port 4001), set
+   `IBKR_PORT=4001`, `IBKR_PAPER=false`.
+
+## ⚠️ Operational risk — two-factor authentication
+IBC's full automation assumes the Gateway login does **not** require an interactive second factor.
+- Accounts on IBKR's Secure Login System that enforce **IBKEY mobile push** require a **daily
+  manual approval** at Gateway login/restart — which breaks fully-unattended live trading.
+- Mitigations: use a **dedicated API username** configured so the Gateway can log in headlessly, or
+  run **paper** (no 2FA) until a headless live login path is confirmed.
+- Schedule `AUTO_RESTART_TIME` overnight so any required approval lands outside market hours.
+
+## References
+- [gnzsnz/ib-gateway-docker](https://github.com/gnzsnz/ib-gateway-docker) (IBC + Xvfb + socat)
+- [ib_async](https://github.com/ib-api-reloaded/ib_async)
+- [IBKR Pegged-to-Stock](https://www.interactivebrokers.com/en/trading/orders/pegged-to-stock.php)
+- [IBKR Order Types](https://www.interactivebrokers.com/campus/ibkr-api-page/order-types/)


### PR DESCRIPTION
Deployment + docs for the IBKR IB-Gateway (ib_async) route.

- `deploy/ib-gateway/`: dockerized `gnzsnz/ib-gateway` (IBC + Xvfb + socat) as a **private** Render service (`render.yaml` pserv), `docker-compose.yml` for local paper testing, `.env.example`, `README`.
- `docs/ibkr-setup.md`: secrets table (gateway + worker/api), always-PEG-STK + conditional-cancel behavior, **session handling** (DAY orders; conditional cancel is intraday-only, not an overnight stop; open/close buffers; half-days), paper-first go-live, and the **2FA operational risk** called out.
- `CLAUDE.md`: IBKR section linking the doc.

Part of the IBKR IB-Gateway live-options work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)