### PR TITLE
Engine: submit live option orders, gated to safe RTH window

### DIFF
--- a/app/engine.py
+++ b/app/engine.py
@@ -7,6 +7,7 @@ import logging
 
 from app.brokers.base import BrokerClient
 from app.enums import OrderSide, RiskEventType
+from app.market_calendar import is_tradeable
 from app.risk.events import RiskEvent
 from app.risk.observer import RiskSubject
 from app.risk.rebalancer_observer import RebalancerObserver
@@ -330,24 +331,108 @@ class AllocationEngine:
         )
         return to_submit, stale_ids
 
+    def _now_et(self):
+        """Current time in US/Eastern (zoneinfo, falling back to pytz)."""
+        from datetime import datetime
+        try:
+            from zoneinfo import ZoneInfo
+            return datetime.now(ZoneInfo("America/New_York"))
+        except Exception:  # pragma: no cover - exotic envs without tzdata
+            import pytz
+            return datetime.now(pytz.timezone("America/New_York"))
+
+    def _option_session_buffers(self, open_buffer_min, close_buffer_min):
+        """Resolve open/close buffers from explicit args, else app config, else defaults."""
+        if open_buffer_min is not None and close_buffer_min is not None:
+            return open_buffer_min, close_buffer_min
+        ob, cb = 2, 5
+        try:
+            from flask import current_app
+            cfg = current_app.config
+            ob = cfg.get("IBKR_OPEN_BUFFER_MIN", ob)
+            cb = cfg.get("IBKR_CLOSE_BUFFER_MIN", cb)
+        except Exception:
+            pass
+        return (
+            open_buffer_min if open_buffer_min is not None else ob,
+            close_buffer_min if close_buffer_min is not None else cb,
+        )
+
     def _execute_option_orders(
-        self, orders: list[dict], cancel_ids: list[str]
+        self,
+        orders: list[dict],
+        cancel_ids: list[str],
+        *,
+        now_et=None,
+        open_buffer_min=None,
+        close_buffer_min=None,
     ):
-        """Log option order actions. Execution not yet implemented — always dry-run."""
+        """Submit option orders, gated to the safe RTH window.
+
+        Cancellation is logged-only (consistent with the equity ``_execute``).
+        For live submission the trading window is enforced via
+        :func:`market_calendar.is_tradeable` — outside RTH (or inside the
+        open/close buffers, on weekends/holidays/half-days) nothing is submitted,
+        which also avoids churning DAY orders near the close. Optional per-order
+        fields (``peg_delta``, ``cancel_if_underlying_above/below``) are passed
+        through to the broker untouched.
+        """
         if cancel_ids:
             log.info("[OPTIONS] Found %d stale option order(s): %s", len(cancel_ids), cancel_ids)
 
+        if not orders:
+            return []
+
+        # Session gate (live only — dry-run still logs for visibility).
+        if not self.dry_run:
+            ob, cb = self._option_session_buffers(open_buffer_min, close_buffer_min)
+            now = now_et or self._now_et()
+            allowed, reason = is_tradeable(now, open_buffer_min=ob, close_buffer_min=cb)
+            if not allowed:
+                log.info("[OPTIONS] submission skipped — %s", reason)
+                return []
+
+        cap = getattr(self, "max_option_order_qty", None) or self.max_order_qty
+        results = []
         for order in orders:
-            log.info(
-                "[OPTIONS DRY RUN] Would submit: %s %s %s %.2f %s qty=%g @ %s",
-                order.get("side", "?"),
-                order.get("chain_symbol", "?"),
-                order.get("option_type", "?"),
-                float(order.get("strike", 0)),
-                order.get("expiration", "?"),
-                float(order.get("quantity", 0)),
-                f"${order['limit_price']:,.2f}" if order.get("limit_price") else "MKT",
-            )
+            qty = float(order.get("quantity", 0))
+            if qty > cap:
+                log.warning(
+                    "Option order capped: %s %s qty %g -> %d",
+                    order.get("side", "?"), order.get("chain_symbol", "?"), qty, cap,
+                )
+                order["quantity"] = cap
+
+            if self.dry_run:
+                log.info(
+                    "[OPTIONS DRY RUN] Would submit: %s %s %s %.2f %s qty=%g @ %s",
+                    order.get("side", "?"),
+                    order.get("chain_symbol", "?"),
+                    order.get("option_type", "?"),
+                    float(order.get("strike", 0)),
+                    order.get("expiration", "?"),
+                    float(order.get("quantity", 0)),
+                    f"${order['limit_price']:,.2f}" if order.get("limit_price") else "MKT",
+                )
+            elif hasattr(self.trader, "submit_option_order"):
+                result = self.trader.submit_option_order(order)
+                log.info(
+                    "[OPTIONS] Submitted %s %s %s %.2f %s qty=%g -> %s",
+                    order.get("side", "?"),
+                    order.get("chain_symbol", "?"),
+                    order.get("option_type", "?"),
+                    float(order.get("strike", 0)),
+                    order.get("expiration", "?"),
+                    float(order.get("quantity", 0)),
+                    result,
+                )
+                results.append(result)
+            else:
+                log.warning(
+                    "[OPTIONS] broker %s has no submit_option_order — skipping",
+                    type(self.trader).__name__,
+                )
+        return results
 
     # -- equity execution ----------------------------------------------------
 

--- a/app/market_calendar.py
+++ b/app/market_calendar.py
@@ -1,0 +1,204 @@
+"""Market-session helper for gating live order submission to safe RTH windows.
+
+The single public entry point is :func:`is_tradeable`, which decides whether a
+given Eastern-Time instant falls inside the tradeable window for US equity /
+listed-options regular trading hours (RTH), accounting for weekends, holidays,
+and early-close half-days (1:00 PM ET).
+
+`now_et` is an injectable parameter so callers control the clock — the module
+keeps no hidden state and is fully deterministic under test.
+
+Calendar source preference:
+1. ``pandas_market_calendars`` (XNYS) when importable — authoritative holidays
+   and half-days.
+2. A self-contained ``datetime`` fallback covering regular RTH, weekends, and
+   the common US market holidays + half-days. The fallback only inspects the
+   local wall-clock date, so it works even without ``pytz`` installed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+
+log = logging.getLogger(__name__)
+
+# Regular trading hours in ET.
+_RTH_OPEN = _dt.time(9, 30)
+_RTH_CLOSE = _dt.time(16, 0)
+# Early-close (half-day) close in ET.
+_HALF_DAY_CLOSE = _dt.time(13, 0)
+
+try:  # pragma: no cover - exercised only when the dep is installed
+    import pandas_market_calendars as _mcal
+
+    _XNYS = _mcal.get_calendar("XNYS")
+except Exception:  # pragma: no cover - fallback path
+    _mcal = None
+    _XNYS = None
+
+
+def _nth_weekday(year: int, month: int, weekday: int, n: int) -> _dt.date:
+    """Return the date of the ``n``-th ``weekday`` (Mon=0) in ``month``/``year``."""
+    first = _dt.date(year, month, 1)
+    offset = (weekday - first.weekday()) % 7
+    return first + _dt.timedelta(days=offset + 7 * (n - 1))
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> _dt.date:
+    """Return the date of the last ``weekday`` (Mon=0) in ``month``/``year``."""
+    if month == 12:
+        nxt = _dt.date(year + 1, 1, 1)
+    else:
+        nxt = _dt.date(year, month + 1, 1)
+    last = nxt - _dt.timedelta(days=1)
+    return last - _dt.timedelta(days=(last.weekday() - weekday) % 7)
+
+
+def _observed(d: _dt.date) -> _dt.date:
+    """Apply the US weekend-observation rule to a fixed-date holiday."""
+    if d.weekday() == 5:  # Saturday -> observed Friday
+        return d - _dt.timedelta(days=1)
+    if d.weekday() == 6:  # Sunday -> observed Monday
+        return d + _dt.timedelta(days=1)
+    return d
+
+
+def _good_friday(year: int) -> _dt.date:
+    """Compute Good Friday (anonymous Gregorian / Meeus algorithm for Easter)."""
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    m = (32 + 2 * e + 2 * i - h - k) % 7
+    n = (a + 11 * h + 22 * m) // 451
+    month = (h + m - 7 * n + 114) // 31
+    day = ((h + m - 7 * n + 114) % 31) + 1
+    easter = _dt.date(year, month, day)
+    return easter - _dt.timedelta(days=2)
+
+
+def _full_holidays(year: int) -> set[_dt.date]:
+    """US market full-closure holidays for a given year (fallback calendar)."""
+    return {
+        _observed(_dt.date(year, 1, 1)),    # New Year's Day
+        _nth_weekday(year, 1, 0, 3),        # MLK Day (3rd Mon Jan)
+        _nth_weekday(year, 2, 0, 3),        # Presidents' Day (3rd Mon Feb)
+        _good_friday(year),                 # Good Friday
+        _last_weekday(year, 5, 0),          # Memorial Day (last Mon May)
+        _observed(_dt.date(year, 6, 19)),   # Juneteenth
+        _observed(_dt.date(year, 7, 4)),    # Independence Day
+        _nth_weekday(year, 9, 0, 1),        # Labor Day (1st Mon Sep)
+        _nth_weekday(year, 11, 3, 4),       # Thanksgiving (4th Thu Nov)
+        _observed(_dt.date(year, 12, 25)),  # Christmas
+    }
+
+
+def _half_days(year: int) -> set[_dt.date]:
+    """US market early-close half-days for a given year (fallback calendar)."""
+    days: set[_dt.date] = set()
+    # Day after Thanksgiving (Black Friday).
+    days.add(_nth_weekday(year, 11, 3, 4) + _dt.timedelta(days=1))
+    # Christmas Eve, when it falls on a weekday and Christmas is on the 25th.
+    xmas_eve = _dt.date(year, 12, 24)
+    if xmas_eve.weekday() < 5:
+        days.add(xmas_eve)
+    # July 3rd, when it falls on a weekday and the 4th is the observed holiday.
+    july3 = _dt.date(year, 7, 3)
+    if july3.weekday() < 5 and _observed(_dt.date(year, 7, 4)) == _dt.date(year, 7, 4):
+        days.add(july3)
+    return days
+
+
+def _session_bounds_fallback(d: _dt.date) -> tuple[_dt.time, _dt.time] | None:
+    """Return (open, close) ET times for a date, or None if the market is closed."""
+    if d.weekday() >= 5:
+        return None
+    if d in _full_holidays(d.year):
+        return None
+    if d in _half_days(d.year):
+        return _RTH_OPEN, _HALF_DAY_CLOSE
+    return _RTH_OPEN, _RTH_CLOSE
+
+
+def _session_bounds_mcal(d: _dt.date) -> tuple[_dt.time, _dt.time] | None:
+    """Return (open, close) ET times for a date using pandas_market_calendars."""
+    sched = _XNYS.schedule(start_date=d.isoformat(), end_date=d.isoformat())
+    if sched.empty:
+        return None
+    et = "America/New_York"
+    open_ts = sched.iloc[0]["market_open"].tz_convert(et)
+    close_ts = sched.iloc[0]["market_close"].tz_convert(et)
+    return open_ts.time(), close_ts.time()
+
+
+def is_tradeable(
+    now_et: _dt.datetime,
+    *,
+    open_buffer_min: int,
+    close_buffer_min: int,
+) -> tuple[bool, str]:
+    """Decide whether ``now_et`` is inside the tradeable RTH window.
+
+    Args:
+        now_et: The current instant expressed in US/Eastern. May be naive (assumed
+            ET) or tz-aware — only the local wall-clock date/time is used.
+        open_buffer_min: Minutes after the session open before submission is allowed.
+        close_buffer_min: Minutes before the session close after which submission
+            is blocked (prevents close-buffer DAY-order resubmission churn).
+
+    Returns:
+        ``(allowed, reason)`` — ``allowed`` is True only inside
+        ``[open + open_buffer_min, close - close_buffer_min]``; ``reason`` always
+        explains the decision.
+    """
+    d = now_et.date()
+
+    if _XNYS is not None:
+        try:
+            bounds = _session_bounds_mcal(d)
+        except Exception:
+            log.exception("pandas_market_calendars lookup failed — using fallback")
+            bounds = _session_bounds_fallback(d)
+    else:
+        bounds = _session_bounds_fallback(d)
+
+    if bounds is None:
+        return False, f"market closed on {d.isoformat()} (weekend/holiday)"
+
+    open_t, close_t = bounds
+    open_dt = _dt.datetime.combine(d, open_t)
+    close_dt = _dt.datetime.combine(d, close_t)
+    window_start = open_dt + _dt.timedelta(minutes=open_buffer_min)
+    window_end = close_dt - _dt.timedelta(minutes=close_buffer_min)
+
+    # Compare on naive wall-clock ET to stay independent of tzinfo presence.
+    now_naive = now_et.replace(tzinfo=None)
+    now_hm = now_naive.time().isoformat(timespec="minutes")
+
+    if now_naive < open_dt:
+        return False, f"pre-open: {now_hm} ET < open {open_t.isoformat(timespec='minutes')}"
+    if now_naive >= close_dt:
+        return False, f"post-close: {now_hm} ET >= close {close_t.isoformat(timespec='minutes')}"
+    if now_naive < window_start:
+        return False, (
+            f"inside open buffer ({open_buffer_min}m): {now_hm} ET "
+            f"< {window_start.time().isoformat(timespec='minutes')}"
+        )
+    if now_naive >= window_end:
+        return False, (
+            f"inside close buffer ({close_buffer_min}m): {now_hm} ET "
+            f">= {window_end.time().isoformat(timespec='minutes')}"
+        )
+
+    return True, (
+        f"tradeable: {now_hm} ET inside "
+        f"[{window_start.time().isoformat(timespec='minutes')}, "
+        f"{window_end.time().isoformat(timespec='minutes')}]"
+    )

--- a/tests/test_engine_option_exec.py
+++ b/tests/test_engine_option_exec.py
@@ -1,0 +1,103 @@
+"""Tests for engine option-order execution + market-session gating."""
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine import AllocationEngine
+from app.market_calendar import is_tradeable
+
+
+# 2026-06-02 is a Tuesday (normal trading day). 2026-06-06 is a Saturday.
+TRADEABLE = dt.datetime(2026, 6, 2, 11, 0)     # mid-session
+PRE_OPEN = dt.datetime(2026, 6, 2, 9, 0)
+POST_CLOSE = dt.datetime(2026, 6, 2, 16, 30)
+OPEN_BUFFER = dt.datetime(2026, 6, 2, 9, 31)    # open 9:30 + 2m buffer -> blocked until 9:32
+CLOSE_BUFFER = dt.datetime(2026, 6, 2, 15, 57)  # close 16:00 - 5m buffer -> blocked from 15:55
+WEEKEND = dt.datetime(2026, 6, 6, 11, 0)
+
+
+def _engine(dry_run):
+    return AllocationEngine(trader=MagicMock(), runtime=MagicMock(), dry_run=dry_run)
+
+
+def _order(**over):
+    o = {
+        "chain_symbol": "SPY", "option_type": "put", "strike": 400.0,
+        "expiration": "2026-06-19", "side": "BUY", "quantity": 1, "limit_price": 1.25,
+    }
+    o.update(over)
+    return o
+
+
+# -- market_calendar.is_tradeable -----------------------------------------------
+
+@pytest.mark.parametrize("now,expected", [
+    (TRADEABLE, True),
+    (PRE_OPEN, False),
+    (POST_CLOSE, False),
+    (OPEN_BUFFER, False),
+    (CLOSE_BUFFER, False),
+    (WEEKEND, False),
+])
+def test_is_tradeable(now, expected):
+    allowed, reason = is_tradeable(now, open_buffer_min=2, close_buffer_min=5)
+    assert allowed is expected
+    assert reason  # always explains
+
+
+# -- dry-run vs live ------------------------------------------------------------
+
+def test_dry_run_does_not_submit():
+    eng = _engine(dry_run=True)
+    eng._execute_option_orders([_order()], [], now_et=TRADEABLE,
+                               open_buffer_min=2, close_buffer_min=5)
+    eng.trader.submit_option_order.assert_not_called()
+
+
+def test_live_submits_each_order_in_rth():
+    eng = _engine(dry_run=False)
+    eng.trader.submit_option_order.return_value = {"id": "1", "symbol": "SPY", "status": "Submitted"}
+    eng._execute_option_orders([_order(), _order(chain_symbol="QQQ")], [],
+                               now_et=TRADEABLE, open_buffer_min=2, close_buffer_min=5)
+    assert eng.trader.submit_option_order.call_count == 2
+
+
+def test_live_caps_quantity_and_preserves_peg_cancel_fields():
+    eng = _engine(dry_run=False)
+    eng.max_option_order_qty = 10
+    eng.trader.submit_option_order.return_value = {"id": "1", "symbol": "SPY", "status": "ok"}
+    eng._execute_option_orders(
+        [_order(quantity=999, peg_delta=0.3, cancel_if_underlying_below=390.0,
+                cancel_if_underlying_above=420.0)],
+        [], now_et=TRADEABLE, open_buffer_min=2, close_buffer_min=5,
+    )
+    (passed,), _ = eng.trader.submit_option_order.call_args
+    assert passed["quantity"] == 10                       # capped
+    assert passed["peg_delta"] == 0.3                     # preserved
+    assert passed["cancel_if_underlying_below"] == 390.0  # preserved
+    assert passed["cancel_if_underlying_above"] == 420.0
+
+
+@pytest.mark.parametrize("now", [PRE_OPEN, POST_CLOSE, OPEN_BUFFER, CLOSE_BUFFER, WEEKEND])
+def test_live_skips_outside_window(now):
+    eng = _engine(dry_run=False)
+    eng._execute_option_orders([_order()], [], now_et=now,
+                               open_buffer_min=2, close_buffer_min=5)
+    eng.trader.submit_option_order.assert_not_called()
+
+
+def test_broker_without_method_is_skipped(caplog):
+    eng = _engine(dry_run=False)
+    del eng.trader.submit_option_order  # broker doesn't support option orders
+    # Should not raise; just warn and skip.
+    eng._execute_option_orders([_order()], [], now_et=TRADEABLE,
+                               open_buffer_min=2, close_buffer_min=5)
+
+
+def test_stale_cancel_is_logged_only():
+    eng = _engine(dry_run=False)
+    eng._execute_option_orders([], ["stale-1", "stale-2"], now_et=TRADEABLE,
+                               open_buffer_min=2, close_buffer_min=5)
+    eng.trader.cancel_order.assert_not_called()


### PR DESCRIPTION
Makes the engine actually place option orders (previously it only logged a dry-run) and gates submission to a safe regular-trading-hours window.

- `_execute_option_orders` now submits via `broker.submit_option_order` when `DRY_RUN=false` (broker-agnostic `hasattr` guard), enforces an option qty cap, and passes `peg_delta` / `cancel_if_underlying_above|below` through to the broker untouched.
- New `app/market_calendar.py` `is_tradeable()` — ET RTH window with open/close buffers, weekends, holidays, and half-days (`pandas_market_calendars` when installed, self-contained `datetime` fallback otherwise).
- Outside the tradeable window submission is skipped (also prevents close-buffer DAY-order churn). Stale-order cancellation stays logged-only. Clock + buffers are injectable → deterministic tests.
- Tests: 16 cases (RTH allow, pre-open/post-close/open-buffer/close-buffer/weekend skip, qty cap + field preservation, broker-without-method skip, logged-only cancel).

Part of the IBKR IB-Gateway live-options work. Supersedes the engine change in the now-closed CP-Web-API set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)