### PR TITLE
Add ib_async IBKR client (always PEG STK options + conditional cancel)

### DIFF
--- a/app/brokers/ibkr/__init__.py
+++ b/app/brokers/ibkr/__init__.py
@@ -1,0 +1,5 @@
+"""Interactive Brokers (IB Gateway via ib_async) broker package."""
+
+from app.brokers.ibkr.client import IBKRTrader
+
+__all__ = ["IBKRTrader"]

--- a/app/brokers/ibkr/client.py
+++ b/app/brokers/ibkr/client.py
@@ -1,0 +1,282 @@
+"""IBKRTrader — BrokerClient over ib_async / IB Gateway.
+
+Options are ALWAYS placed as Pegged-to-Stock (``PEG STK``) orders, with an
+optional conditional cancel (cancel the working order if the underlying trades
+above/below a threshold). All IB calls are marshalled onto the session's
+dedicated event-loop thread (see :class:`IBSession`).
+"""
+
+import logging
+
+from app.brokers.base import BrokerClient
+from app.brokers.ibkr import contracts as C
+from app.brokers.ibkr import orders as O
+from app.brokers.ibkr import positions as P
+from app.brokers.ibkr.session import IBSession
+
+log = logging.getLogger(__name__)
+
+
+class IBKRTrader(BrokerClient):
+    def __init__(
+        self,
+        account_id: str,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 4002,
+        client_id: int = 1,
+        paper: bool = True,
+        peg_delta_default: float = 0.5,
+        max_option_order_qty: int = 50,
+        session: IBSession | None = None,
+    ):
+        self.account_id = account_id
+        self.paper = paper
+        self.peg_delta_default = float(peg_delta_default)
+        self.max_option_order_qty = int(max_option_order_qty)
+        self._session = session or IBSession(host=host, port=port, client_id=client_id)
+
+    # -- account / positions ------------------------------------------------
+
+    def account(self) -> dict:
+        try:
+            return self._session.run(self._account_async())
+        except Exception:
+            log.exception("[ibkr] account() failed")
+            return {"equity": 0.0, "cash": 0.0, "buying_power": 0.0, "portfolio_value": 0.0}
+
+    async def _account_async(self) -> dict:
+        ib = self._session.ib
+        rows = await ib.accountSummaryAsync(self.account_id or "")
+        return P.map_account_summary(rows)
+
+    def positions(self) -> list[dict]:
+        try:
+            return self._session.run(self._positions_async())
+        except Exception:
+            log.exception("[ibkr] positions() failed")
+            return []
+
+    async def _positions_async(self) -> list[dict]:
+        ib = self._session.ib
+        items = ib.portfolio()
+        return [m for m in (P.map_position(i) for i in (items or [])) if m]
+
+    def options_positions(self) -> list[dict]:
+        try:
+            return self._session.run(self._options_positions_async())
+        except Exception:
+            log.exception("[ibkr] options_positions() failed")
+            return []
+
+    async def _options_positions_async(self) -> list[dict]:
+        ib = self._session.ib
+        out = []
+        for item in (ib.portfolio() or []):
+            contract = getattr(item, "contract", None)
+            if contract is None or getattr(contract, "secType", "") != "OPT":
+                continue
+            ticker = None
+            try:
+                tickers = await ib.reqTickersAsync(contract)
+                ticker = tickers[0] if tickers else None
+            except Exception:
+                ticker = None
+            mapped = P.map_option_position(item, ticker)
+            if mapped:
+                out.append(mapped)
+        return out
+
+    # -- orders (read) ------------------------------------------------------
+
+    def open_orders(self) -> list[dict]:
+        try:
+            return self._session.run(self._open_orders_async())
+        except Exception:
+            log.exception("[ibkr] open_orders() failed")
+            return []
+
+    async def _open_orders_async(self) -> list[dict]:
+        ib = self._session.ib
+        trades = await ib.reqOpenOrdersAsync()
+        result = []
+        for t in (trades or []):
+            contract = getattr(t, "contract", None)
+            if contract is not None and getattr(contract, "secType", "") == "OPT":
+                continue  # equity open orders only here
+            result.append(P.map_open_trade(t))
+        return result
+
+    def options_orders(self, limit: int = 50, open_only: bool = False) -> list[dict]:
+        try:
+            return self._session.run(self._options_orders_async(limit, open_only))
+        except Exception:
+            log.exception("[ibkr] options_orders() failed")
+            return []
+
+    _OPEN_STATES = {"PreSubmitted", "Submitted", "PendingSubmit", "ApiPending"}
+
+    async def _options_orders_async(self, limit: int, open_only: bool) -> list[dict]:
+        ib = self._session.ib
+        trades = ib.trades()
+        result = []
+        for t in (trades or []):
+            contract = getattr(t, "contract", None)
+            if contract is None or getattr(contract, "secType", "") != "OPT":
+                continue
+            status = getattr(getattr(t, "orderStatus", None), "status", "")
+            if open_only and status not in self._OPEN_STATES:
+                continue
+            result.append(P.map_option_trade(t))
+            if len(result) >= limit:
+                break
+        return result
+
+    # -- equity order submission -------------------------------------------
+
+    def submit_order(self, order: dict) -> dict | None:
+        try:
+            return self._session.run(self._submit_order_async(order))
+        except Exception:
+            log.exception("[ibkr] submit_order failed: %s", order)
+            return None
+
+    async def _submit_order_async(self, order: dict) -> dict | None:
+        ib = self._session.ib
+        symbol = order["symbol"]
+        qualified = await ib.qualifyContractsAsync(C.build_stock(symbol))
+        if not qualified:
+            log.error("[ibkr] could not qualify %s", symbol)
+            return None
+        contract = qualified[0]
+        ib_order = O.build_equity_order(
+            order["side"], float(order["quantity"]),
+            order.get("order_type", "MKT"), order.get("limit_price"),
+        )
+        trade = ib.placeOrder(contract, ib_order)
+        return self._trade_result(trade, symbol)
+
+    # -- option order submission (ALWAYS PEG STK) --------------------------
+
+    def submit_option_order(self, order: dict) -> dict | None:
+        try:
+            return self._session.run(self._submit_option_order_async(order))
+        except Exception:
+            log.exception("[ibkr] submit_option_order failed: %s", order)
+            return None
+
+    async def _submit_option_order_async(self, order: dict) -> dict | None:
+        ib = self._session.ib
+        chain_symbol = order["chain_symbol"]
+        option_type = order["option_type"]
+        side = order["side"]
+        qty = float(order["quantity"])
+
+        # 1. Qualify the option contract.
+        opt = C.build_option(chain_symbol, order["expiration"],
+                             float(order["strike"]), option_type)
+        q = await ib.qualifyContractsAsync(opt)
+        if not q:
+            log.error("[ibkr] could not qualify option %s", order)
+            return None
+        opt = q[0]
+
+        # 2. Resolve the peg delta: per-order -> live greek -> default.
+        delta = order.get("peg_delta")
+        if delta is None:
+            delta = await self._option_greek_delta(opt)
+        if delta is None:
+            delta = self.peg_delta_default
+        signed = O.signed_delta(option_type, delta)
+
+        # 3. Starting price: explicit limit -> option NBBO midpoint.
+        starting = order.get("limit_price")
+        if starting is None:
+            starting = await self._option_midpoint(opt)
+
+        # 4. Optional cancel-on-cross conditions on the underlying.
+        conditions, cancel_flag = [], False
+        above = order.get("cancel_if_underlying_above")
+        below = order.get("cancel_if_underlying_below")
+        if above is not None or below is not None:
+            sq = await ib.qualifyContractsAsync(C.build_stock(chain_symbol))
+            conid = getattr(sq[0], "conId", 0) if sq else 0
+            conditions, cancel_flag = O.build_price_conditions(conid, above, below)
+
+        # 5. Place the PEG STK order; fall back to LMT if the exchange rejects it.
+        peg = O.build_peg_stk_order(side, qty, signed, starting, conditions, cancel_flag)
+        trade = ib.placeOrder(opt, peg)
+        if O.order_is_rejected(trade):
+            log.warning("[ibkr] PEG STK rejected for %s — falling back to LMT @ %s",
+                        chain_symbol, starting)
+            fb = O.build_limit_fallback(side, qty, starting or 0.0, conditions, cancel_flag)
+            trade = ib.placeOrder(opt, fb)
+        return self._trade_result(trade, chain_symbol)
+
+    async def _option_greek_delta(self, contract):
+        try:
+            tickers = await self._session.ib.reqTickersAsync(contract)
+            mg = getattr(tickers[0], "modelGreeks", None) if tickers else None
+            if mg is not None and getattr(mg, "delta", None) is not None:
+                return abs(float(mg.delta))
+        except Exception:
+            log.debug("[ibkr] greek delta unavailable; using default", exc_info=True)
+        return None
+
+    async def _option_midpoint(self, contract):
+        try:
+            tickers = await self._session.ib.reqTickersAsync(contract)
+            if tickers:
+                mid = tickers[0].midpoint()
+                if mid is not None and mid == mid and mid > 0:  # not NaN, positive
+                    return float(mid)
+        except Exception:
+            log.debug("[ibkr] option midpoint unavailable", exc_info=True)
+        return None
+
+    @staticmethod
+    def _trade_result(trade, symbol: str) -> dict | None:
+        order = getattr(trade, "order", None)
+        status = getattr(trade, "orderStatus", None)
+        if order is None:
+            return None
+        return {
+            "id": str(getattr(order, "orderId", "")),
+            "symbol": symbol,
+            "status": getattr(status, "status", "") if status else "",
+        }
+
+    # -- cancellation -------------------------------------------------------
+
+    def cancel_order(self, order_id: str) -> None:
+        try:
+            self._session.run(self._cancel_order_async(order_id))
+        except Exception:
+            log.exception("[ibkr] cancel_order %s failed", order_id)
+
+    async def _cancel_order_async(self, order_id: str):
+        ib = self._session.ib
+        for t in (ib.openTrades() or []):
+            order = getattr(t, "order", None)
+            if order is not None and str(getattr(order, "orderId", "")) == str(order_id):
+                ib.cancelOrder(order)
+                return
+        log.warning("[ibkr] cancel_order: no open trade with id %s", order_id)
+
+    def cancel_all(self) -> None:
+        try:
+            self._session.run(self._cancel_all_async())
+        except Exception:
+            log.exception("[ibkr] cancel_all failed")
+
+    async def _cancel_all_async(self):
+        self._session.ib.reqGlobalCancel()
+
+    # -- auth status --------------------------------------------------------
+
+    def auth_status(self) -> dict:
+        return {
+            "connected": self._session.is_connected(),
+            "paper": self.paper,
+            "account_id": self.account_id,
+        }

--- a/app/brokers/ibkr/contracts.py
+++ b/app/brokers/ibkr/contracts.py
@@ -1,0 +1,44 @@
+"""Contract construction and qualification helpers for IBKR."""
+
+import logging
+from datetime import datetime
+
+from ib_async import Option, Stock
+
+log = logging.getLogger(__name__)
+
+
+def to_ib_expiration(expiration: str) -> str:
+    """Convert an ISO ``YYYY-MM-DD`` expiration to IB's ``YYYYMMDD`` format."""
+    return datetime.strptime(expiration, "%Y-%m-%d").strftime("%Y%m%d")
+
+
+def option_right(option_type: str) -> str:
+    """Map ``'call'``/``'put'`` to IB's ``'C'``/``'P'`` right code."""
+    ot = (option_type or "").strip().lower()
+    if ot in ("call", "c"):
+        return "C"
+    if ot in ("put", "p"):
+        return "P"
+    raise ValueError(f"Unknown option_type: {option_type!r}")
+
+
+def build_option(chain_symbol: str, expiration: str, strike: float,
+                 option_type: str, exchange: str = "SMART") -> Option:
+    """Build an (unqualified) :class:`ib_async.Option` contract.
+
+    ``expiration`` is the ISO ``YYYY-MM-DD`` form; it is converted to IB's
+    ``YYYYMMDD`` here.
+    """
+    return Option(
+        chain_symbol,
+        to_ib_expiration(expiration),
+        float(strike),
+        option_right(option_type),
+        exchange,
+    )
+
+
+def build_stock(symbol: str, exchange: str = "SMART", currency: str = "USD") -> Stock:
+    """Build an (unqualified) :class:`ib_async.Stock` contract."""
+    return Stock(symbol, exchange, currency)

--- a/app/brokers/ibkr/orders.py
+++ b/app/brokers/ibkr/orders.py
@@ -1,0 +1,105 @@
+"""Order builders for IBKR — always Pegged-to-Stock for options.
+
+These are pure constructors (no network / event loop) so they unit-test with
+plain assertions. The orchestration that qualifies contracts, fetches greeks
+and places the order lives in :mod:`app.brokers.ibkr.client`.
+"""
+
+import logging
+
+from ib_async import Order
+from ib_async.order import PriceCondition
+
+log = logging.getLogger(__name__)
+
+PEG_STK = "PEG STK"
+# Order states that mean the PEG STK order did not take — trigger the LMT fallback.
+_REJECTED_STATES = {"rejected", "inactive"}
+
+
+def signed_delta(option_type: str, delta: float) -> float:
+    """PEG STK delta convention: positive for calls, negative for puts.
+
+    ``delta`` is supplied as a magnitude; its sign is derived from the right.
+    """
+    mag = abs(float(delta))
+    return mag if (option_type or "").strip().lower().startswith("c") else -mag
+
+
+def build_price_conditions(underlying_conid: int, above=None, below=None):
+    """Build PriceCondition(s) on the underlying for a cancel-on-cross order.
+
+    Returns ``(conditions, conditions_cancel_order)``. When both bounds are
+    given the conditions are OR-joined so the order cancels when the underlying
+    leaves the ``[below, above]`` band.
+    """
+    conditions = []
+    if above is not None:
+        conditions.append(
+            PriceCondition(conId=int(underlying_conid), exch="SMART",
+                           isMore=True, price=float(above))
+        )
+    if below is not None:
+        conditions.append(
+            PriceCondition(conId=int(underlying_conid), exch="SMART",
+                           isMore=False, price=float(below))
+        )
+    if len(conditions) > 1:
+        for c in conditions:
+            c.conjunction = "o"  # OR — cancel if outside the band
+    return conditions, bool(conditions)
+
+
+def build_peg_stk_order(action: str, quantity: float, delta: float,
+                        starting_price=None, conditions=None,
+                        conditions_cancel: bool = False) -> Order:
+    """Build a Pegged-to-Stock (``PEG STK``) option order (DAY)."""
+    o = Order()
+    o.orderType = PEG_STK
+    o.action = (action or "").upper()
+    o.totalQuantity = float(quantity)
+    o.delta = float(delta)
+    if starting_price is not None:
+        o.startingPrice = float(starting_price)
+    o.tif = "DAY"
+    if conditions:
+        o.conditions = list(conditions)
+        o.conditionsCancelOrder = bool(conditions_cancel)
+    return o
+
+
+def build_limit_fallback(action: str, quantity: float, limit_price: float,
+                         conditions=None, conditions_cancel: bool = False) -> Order:
+    """Fallback LMT order at the peg starting price when an exchange rejects PEG STK."""
+    o = Order()
+    o.orderType = "LMT"
+    o.action = (action or "").upper()
+    o.totalQuantity = float(quantity)
+    o.lmtPrice = float(limit_price or 0.0)
+    o.tif = "DAY"
+    if conditions:
+        o.conditions = list(conditions)
+        o.conditionsCancelOrder = bool(conditions_cancel)
+    return o
+
+
+def build_equity_order(action: str, quantity: float, order_type: str = "MKT",
+                       limit_price=None) -> Order:
+    """Build a simple equity MKT/LMT order."""
+    o = Order()
+    o.action = (action or "").upper()
+    o.totalQuantity = float(quantity)
+    o.tif = "DAY"
+    if (order_type or "").upper() == "LMT" and limit_price is not None:
+        o.orderType = "LMT"
+        o.lmtPrice = float(limit_price)
+    else:
+        o.orderType = "MKT"
+    return o
+
+
+def order_is_rejected(trade) -> bool:
+    """True if a placed Trade came back rejected/inactive (PEG STK unsupported)."""
+    status = getattr(trade, "orderStatus", None)
+    s = (getattr(status, "status", "") or "").strip().lower() if status else ""
+    return s in _REJECTED_STATES

--- a/app/brokers/ibkr/positions.py
+++ b/app/brokers/ibkr/positions.py
@@ -1,0 +1,249 @@
+"""Pure mapping functions: IBKR objects -> standardized engine dict shapes.
+
+These are deliberately free of any network/event-loop concerns so they can be
+unit-tested with plain MagicMock objects.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+
+def _f(value, default: float = 0.0) -> float:
+    """Best-effort float coercion."""
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# -- account ----------------------------------------------------------------
+
+def map_account_summary(rows) -> dict:
+    """Map ``ib.accountSummary()`` rows to ``{equity, cash, buying_power,
+    portfolio_value}``.
+
+    Each row is an ``AccountValue``-like object with ``.tag`` and ``.value``.
+    """
+    by_tag: dict[str, str] = {}
+    for row in (rows or []):
+        tag = getattr(row, "tag", None)
+        if tag is not None:
+            by_tag[tag] = getattr(row, "value", None)
+
+    return {
+        "equity": _f(by_tag.get("NetLiquidation")),
+        "cash": _f(by_tag.get("TotalCashValue")),
+        "buying_power": _f(by_tag.get("BuyingPower")),
+        "portfolio_value": _f(by_tag.get("GrossPositionValue")),
+    }
+
+
+# -- equity positions --------------------------------------------------------
+
+def map_position(item) -> dict | None:
+    """Map an ``ib.portfolio()`` item (PortfolioItem) to the standardized
+    equity position dict, or ``None`` if it isn't a stock / is flat."""
+    contract = getattr(item, "contract", None)
+    if contract is None:
+        return None
+    sec_type = getattr(contract, "secType", "")
+    if sec_type != "STK":
+        return None
+
+    qty = _f(getattr(item, "position", 0))
+    if qty == 0:
+        return None
+
+    avg_entry = _f(getattr(item, "averageCost", 0))
+    market_value = _f(getattr(item, "marketValue", 0))
+    unrealized_pl = _f(getattr(item, "unrealizedPNL", 0))
+    cost_basis = avg_entry * qty
+    unrealized_pl_pct = (unrealized_pl / cost_basis) if cost_basis else 0.0
+
+    return {
+        "symbol": getattr(contract, "symbol", ""),
+        "qty": qty,
+        "side": "long" if qty > 0 else "short",
+        "market_value": round(market_value, 2),
+        "avg_entry": round(avg_entry, 4),
+        "unrealized_pl": round(unrealized_pl, 2),
+        "unrealized_pl_pct": round(unrealized_pl_pct, 4),
+    }
+
+
+# -- open orders -------------------------------------------------------------
+
+def map_open_trade(trade) -> dict:
+    """Map an ``ib.openTrades()`` Trade to the standardized open-order dict."""
+    order = getattr(trade, "order", None)
+    contract = getattr(trade, "contract", None)
+    status = getattr(trade, "orderStatus", None)
+
+    lmt = _f(getattr(order, "lmtPrice", 0)) if order else 0.0
+    aux = _f(getattr(order, "auxPrice", 0)) if order else 0.0
+
+    return {
+        "id": str(getattr(order, "orderId", "")) if order else "",
+        "symbol": getattr(contract, "symbol", "") if contract else "",
+        "side": (getattr(order, "action", "") if order else "").upper(),
+        "qty": _f(getattr(order, "totalQuantity", 0)) if order else 0.0,
+        "type": getattr(order, "orderType", "") if order else "",
+        "limit_price": lmt if lmt else None,
+        "stop_price": aux if aux else None,
+        "status": getattr(status, "status", "") if status else "",
+    }
+
+
+# -- options positions -------------------------------------------------------
+
+def _dte(expiration_iso: str) -> int:
+    if not expiration_iso:
+        return 0
+    try:
+        exp = datetime.strptime(expiration_iso, "%Y-%m-%d").date()
+        return (exp - datetime.now(timezone.utc).date()).days
+    except (ValueError, TypeError):
+        return 0
+
+
+def _ib_exp_to_iso(ib_exp: str) -> str:
+    """Convert IB ``YYYYMMDD`` to ISO ``YYYY-MM-DD`` (best-effort)."""
+    if not ib_exp:
+        return ""
+    try:
+        return datetime.strptime(ib_exp, "%Y%m%d").strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return ib_exp
+
+
+def map_option_position(item, ticker=None) -> dict | None:
+    """Map an ``ib.portfolio()`` OPT item (+ optional live ticker for greeks)
+    to the standardized options-position dict, or ``None`` if not an option /
+    is flat."""
+    contract = getattr(item, "contract", None)
+    if contract is None:
+        return None
+    if getattr(contract, "secType", "") != "OPT":
+        return None
+
+    qty = _f(getattr(item, "position", 0))
+    if qty == 0:
+        return None
+
+    right = (getattr(contract, "right", "") or "").upper()
+    option_type = "call" if right.startswith("C") else "put" if right.startswith("P") else ""
+    expiration = _ib_exp_to_iso(getattr(contract, "lastTradeDateOrContractMonth", ""))
+    strike = _f(getattr(contract, "strike", 0))
+    multiplier = _f(getattr(contract, "multiplier", 100)) or 100.0
+
+    avg_cost = _f(getattr(item, "averageCost", 0))
+    # IB averageCost for options is per-contract (already times multiplier);
+    # normalize to per-share avg price for the standardized shape.
+    avg_price = (avg_cost / multiplier) if multiplier else avg_cost
+
+    greeks = {"delta": None, "gamma": None, "theta": None, "vega": None, "iv": None}
+    mark_price = avg_price
+    underlying_price = None
+    if ticker is not None:
+        mg = getattr(ticker, "modelGreeks", None)
+        if mg is not None:
+            for g in ("delta", "gamma", "theta", "vega"):
+                val = getattr(mg, g, None)
+                if val is not None:
+                    greeks[g] = round(_f(val), 6)
+            iv = getattr(mg, "impliedVol", None)
+            if iv is not None:
+                greeks["iv"] = round(_f(iv), 6)
+            undp = getattr(mg, "undPrice", None)
+            if undp is not None:
+                underlying_price = round(_f(undp), 4)
+        mp = getattr(ticker, "marketPrice", None)
+        try:
+            mp_val = mp() if callable(mp) else mp
+            if mp_val is not None and _f(mp_val) > 0:
+                mark_price = _f(mp_val)
+        except Exception:
+            pass
+
+    cost_basis = qty * avg_price * multiplier
+    current_value = qty * mark_price * multiplier
+    unrealized_pl = current_value - cost_basis
+
+    return {
+        "chain_symbol": getattr(contract, "symbol", ""),
+        "option_type": option_type,
+        "position_type": "long" if qty > 0 else "short",
+        "strike": strike,
+        "expiration": expiration,
+        "dte": _dte(expiration),
+        "quantity": qty,
+        "avg_price": round(avg_price, 4),
+        "mark_price": round(mark_price, 4),
+        "multiplier": multiplier,
+        "cost_basis": round(cost_basis, 2),
+        "current_value": round(current_value, 2),
+        "unrealized_pl": round(unrealized_pl, 2),
+        "unrealized_pl_pct": round(unrealized_pl / cost_basis, 4) if cost_basis else 0.0,
+        "underlying_price": underlying_price,
+        "greeks": greeks,
+    }
+
+
+# -- options orders ----------------------------------------------------------
+
+def map_option_trade(trade) -> dict:
+    """Map an option ``Trade`` to the standardized options-order dict."""
+    order = getattr(trade, "order", None)
+    contract = getattr(trade, "contract", None)
+    status = getattr(trade, "orderStatus", None)
+
+    qty = _f(getattr(order, "totalQuantity", 0)) if order else 0.0
+    action = (getattr(order, "action", "") if order else "").upper()
+    direction = "debit" if action == "BUY" else "credit" if action == "SELL" else ""
+    lmt = _f(getattr(order, "lmtPrice", 0)) if order else 0.0
+    state = getattr(status, "status", "") if status else ""
+
+    right = (getattr(contract, "right", "") or "").upper() if contract else ""
+    option_type = "call" if right.startswith("C") else "put" if right.startswith("P") else ""
+    expiration = _ib_exp_to_iso(
+        getattr(contract, "lastTradeDateOrContractMonth", "") if contract else ""
+    )
+    chain_symbol = getattr(contract, "symbol", "") if contract else ""
+    strike = _f(getattr(contract, "strike", 0)) if contract else 0.0
+
+    position_effect = "open"
+    if order is not None:
+        oca = getattr(order, "openClose", "") or ""
+        if oca.upper().startswith("C"):
+            position_effect = "close"
+
+    legs = [{
+        "side": action,
+        "position_effect": position_effect,
+        "quantity": qty,
+        "strike": strike,
+        "expiration": expiration,
+        "option_type": option_type,
+        "chain_symbol": chain_symbol,
+    }] if contract is not None else []
+
+    return {
+        "order_id": str(getattr(order, "orderId", "")) if order else "",
+        "state": state,
+        "quantity": qty,
+        "price": lmt if lmt else 0.0,
+        "premium": round(lmt * qty * 100, 2) if lmt else 0.0,
+        "processed_premium": 0.0,
+        "direction": direction,
+        "order_type": getattr(order, "orderType", "") if order else "",
+        "trigger": "immediate",
+        "time_in_force": getattr(order, "tif", "") if order else "",
+        "opening_strategy": "",
+        "created_at": "",
+        "updated_at": "",
+        "legs": legs,
+    }

--- a/app/brokers/ibkr/session.py
+++ b/app/brokers/ibkr/session.py
@@ -1,0 +1,151 @@
+"""IB Gateway session manager.
+
+``ib_async`` is asyncio-based and its event loop is bound to a single thread.
+The allocation engine runs in a background thread, and Flask request threads
+also call the broker. To make every public broker call thread-safe we run the
+``IB`` client on a dedicated background thread with its own asyncio event loop,
+started lazily here. Public broker methods marshal their coroutines onto that
+loop with :func:`asyncio.run_coroutine_threadsafe`.
+"""
+
+import asyncio
+import logging
+import threading
+
+from ib_async import IB
+
+log = logging.getLogger(__name__)
+
+# Default time (seconds) to wait for any marshalled coroutine to complete.
+DEFAULT_CALL_TIMEOUT = 30.0
+# Time (seconds) to wait for the initial connection to the gateway.
+CONNECT_TIMEOUT = 20.0
+
+
+class IBSession:
+    """Owns the dedicated asyncio loop/thread and the ``IB`` connection.
+
+    Thread-safety model:
+      * A single background thread runs the asyncio event loop.
+      * The ``IB`` client lives entirely on that loop.
+      * ``run(coro)`` schedules a coroutine on the loop from any thread and
+        blocks the caller until it completes (or times out).
+      * ``ensure_auth()`` lazily starts the loop/thread and connects, and
+        reconnects transparently if the connection drops.
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 4002,
+        client_id: int = 1,
+        *,
+        connect_timeout: float = CONNECT_TIMEOUT,
+    ):
+        self.host = host
+        self.port = port
+        self.client_id = client_id
+        self.connect_timeout = connect_timeout
+
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ib: IB | None = None
+        # Guards loop/thread/connection startup so concurrent callers don't
+        # race to create two loops or two connections.
+        self._lock = threading.RLock()
+
+    # -- loop / thread lifecycle -------------------------------------------
+
+    def _start_loop(self):
+        """Start the dedicated asyncio loop on a background thread (idempotent)."""
+        if self._loop is not None and self._thread is not None and self._thread.is_alive():
+            return
+
+        ready = threading.Event()
+
+        def _run_loop():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+            ready.set()
+            loop.run_forever()
+
+        self._thread = threading.Thread(
+            target=_run_loop, name="ibkr-event-loop", daemon=True
+        )
+        self._thread.start()
+        ready.wait()
+        log.info("[ibkr] event loop thread started")
+
+    def run(self, coro, timeout: float = DEFAULT_CALL_TIMEOUT):
+        """Run a coroutine on the dedicated loop from any thread and block.
+
+        Ensures the loop/connection are up first.
+        """
+        self.ensure_auth()
+        return self._run_nowait(coro, timeout)
+
+    def _run_nowait(self, coro, timeout: float = DEFAULT_CALL_TIMEOUT):
+        """Run a coroutine on the loop without triggering ensure_auth.
+
+        Used internally during connection setup to avoid recursion.
+        """
+        assert self._loop is not None
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    # -- connection --------------------------------------------------------
+
+    def _on_disconnected(self):
+        log.warning("[ibkr] disconnected from gateway")
+
+    async def _connect(self):
+        if self._ib is None:
+            self._ib = IB()
+            self._ib.disconnectedEvent += self._on_disconnected
+        if self._ib.isConnected():
+            return
+        log.info(
+            "[ibkr] connecting to gateway %s:%s clientId=%s",
+            self.host, self.port, self.client_id,
+        )
+        await self._ib.connectAsync(
+            self.host, self.port, clientId=self.client_id,
+            timeout=self.connect_timeout,
+        )
+        log.info("[ibkr] connected to gateway")
+
+    def ensure_auth(self):
+        """Lazily start the loop/thread, connect, and reconnect if dropped."""
+        with self._lock:
+            self._start_loop()
+            ib = self._ib
+            if ib is not None and ib.isConnected():
+                return
+            # (Re)connect on the dedicated loop.
+            self._run_nowait(self._connect(), timeout=self.connect_timeout + 5)
+
+    @property
+    def ib(self) -> IB:
+        """The connected ``IB`` client (call :meth:`ensure_auth` first)."""
+        if self._ib is None:
+            raise RuntimeError("IB session not started — call ensure_auth() first")
+        return self._ib
+
+    def is_connected(self) -> bool:
+        return self._ib is not None and self._ib.isConnected()
+
+    def disconnect(self):
+        """Disconnect and stop the loop (best-effort)."""
+        with self._lock:
+            if self._ib is not None and self._loop is not None:
+                try:
+                    self._run_nowait(self._async_disconnect(), timeout=10)
+                except Exception:
+                    log.exception("[ibkr] error during disconnect")
+            if self._loop is not None:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+
+    async def _async_disconnect(self):
+        if self._ib is not None and self._ib.isConnected():
+            self._ib.disconnect()

--- a/tests/test_ibkr_client.py
+++ b/tests/test_ibkr_client.py
@@ -1,0 +1,203 @@
+"""Tests for the ib_async IBKR client — focus on always-PEG-STK + conditional cancel."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.brokers.ibkr import orders as O
+from app.brokers.ibkr import positions as P
+from app.brokers.ibkr.client import IBKRTrader
+
+
+# -- fakes ----------------------------------------------------------------------
+
+class FakeSession:
+    """Runs broker coroutines synchronously against a mock IB object."""
+
+    def __init__(self, ib):
+        self.ib = ib
+
+    def ensure_auth(self):
+        pass
+
+    def is_connected(self):
+        return True
+
+    def run(self, coro, timeout=30):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+
+def _trade(order_id=1, status="Submitted"):
+    return SimpleNamespace(
+        order=SimpleNamespace(orderId=order_id),
+        orderStatus=SimpleNamespace(status=status),
+    )
+
+
+def _make_ib(*, delta=None, midpoint=2.0, place_return=None, place_side_effect=None):
+    ib = MagicMock()
+    ib.qualifyContractsAsync = AsyncMock(return_value=[SimpleNamespace(conId=111)])
+    mg = SimpleNamespace(delta=delta) if delta is not None else None
+    ticker = SimpleNamespace(modelGreeks=mg, midpoint=lambda: midpoint)
+    ib.reqTickersAsync = AsyncMock(return_value=[ticker])
+    if place_side_effect is not None:
+        ib.placeOrder = MagicMock(side_effect=place_side_effect)
+    else:
+        ib.placeOrder = MagicMock(return_value=place_return or _trade())
+    return ib
+
+
+def _trader(ib):
+    return IBKRTrader("DU123", session=FakeSession(ib))
+
+
+def _opt_order(**over):
+    o = {
+        "chain_symbol": "SPY", "option_type": "call", "strike": 500.0,
+        "expiration": "2026-06-19", "side": "BUY", "quantity": 1,
+    }
+    o.update(over)
+    return o
+
+
+# -- pure builders --------------------------------------------------------------
+
+def test_signed_delta_sign_by_right():
+    assert O.signed_delta("call", 0.4) == 0.4
+    assert O.signed_delta("put", 0.4) == -0.4
+    assert O.signed_delta("put", -0.4) == -0.4  # magnitude is normalized first
+
+
+def test_build_peg_stk_order_shape():
+    o = O.build_peg_stk_order("BUY", 3, 0.5, starting_price=1.25)
+    assert o.orderType == "PEG STK"
+    assert o.action == "BUY"
+    assert o.totalQuantity == 3
+    assert o.delta == 0.5
+    assert o.startingPrice == 1.25
+    assert o.tif == "DAY"
+
+
+def test_build_price_conditions_band():
+    conds, cancel = O.build_price_conditions(111, above=520.0, below=480.0)
+    assert cancel is True
+    assert len(conds) == 2
+    assert conds[0].isMore is True and conds[0].price == 520.0
+    assert conds[1].isMore is False and conds[1].price == 480.0
+    assert all(c.conjunction == "o" for c in conds)  # OR-joined band
+
+
+def test_build_price_conditions_single():
+    conds, cancel = O.build_price_conditions(111, below=480.0)
+    assert cancel is True and len(conds) == 1 and conds[0].isMore is False
+
+
+def test_order_is_rejected():
+    assert O.order_is_rejected(_trade(status="Rejected")) is True
+    assert O.order_is_rejected(_trade(status="Inactive")) is True
+    assert O.order_is_rejected(_trade(status="Submitted")) is False
+
+
+# -- submit_option_order (the core feature) ------------------------------------
+
+def test_submit_option_order_always_peg_stk_signed_delta():
+    ib = _make_ib()
+    res = _trader(ib).submit_option_order(_opt_order(option_type="put", peg_delta=0.33))
+    assert res == {"id": "1", "symbol": "SPY", "status": "Submitted"}
+    (_, placed_order) = ib.placeOrder.call_args[0]
+    assert placed_order.orderType == "PEG STK"
+    assert placed_order.delta == -0.33  # put -> negative
+
+
+def test_submit_option_order_uses_live_greek_then_default():
+    # greek available -> used
+    ib = _make_ib(delta=-0.6)
+    _trader(ib).submit_option_order(_opt_order(option_type="put"))
+    assert ib.placeOrder.call_args[0][1].delta == -0.6  # abs(0.6) signed for put
+
+    # greek unavailable -> peg_delta_default (0.5), signed for call
+    ib2 = _make_ib(delta=None)
+    _trader(ib2).submit_option_order(_opt_order(option_type="call"))
+    assert ib2.placeOrder.call_args[0][1].delta == 0.5
+
+
+def test_submit_option_order_attaches_cancel_conditions():
+    ib = _make_ib()
+    _trader(ib).submit_option_order(
+        _opt_order(cancel_if_underlying_above=520.0, cancel_if_underlying_below=480.0)
+    )
+    placed = ib.placeOrder.call_args[0][1]
+    assert placed.conditionsCancelOrder is True
+    assert len(placed.conditions) == 2
+
+
+def test_submit_option_order_peg_rejection_falls_back_to_limit():
+    ib = _make_ib(place_side_effect=[_trade(status="Rejected"), _trade(order_id=2, status="Submitted")])
+    res = _trader(ib).submit_option_order(_opt_order(limit_price=1.5))
+    assert ib.placeOrder.call_count == 2
+    assert ib.placeOrder.call_args_list[1][0][1].orderType == "LMT"
+    assert res["id"] == "2"
+
+
+def test_submit_option_order_returns_none_on_qualify_failure():
+    ib = _make_ib()
+    ib.qualifyContractsAsync = AsyncMock(return_value=[])  # cannot qualify
+    assert _trader(ib).submit_option_order(_opt_order()) is None
+
+
+def test_submit_option_order_returns_none_on_exception():
+    ib = _make_ib()
+    ib.placeOrder = MagicMock(side_effect=RuntimeError("boom"))
+    assert _trader(ib).submit_option_order(_opt_order(peg_delta=0.3)) is None
+
+
+# -- equity + auth --------------------------------------------------------------
+
+def test_submit_equity_order():
+    ib = _make_ib()
+    res = _trader(ib).submit_order(
+        {"symbol": "AAPL", "side": "BUY", "quantity": 10, "order_type": "MKT"}
+    )
+    assert res["symbol"] == "AAPL"
+    assert ib.placeOrder.call_args[0][1].orderType == "MKT"
+
+
+def test_auth_status():
+    st = _trader(_make_ib()).auth_status()
+    assert st == {"connected": True, "paper": True, "account_id": "DU123"}
+
+
+# -- mappers --------------------------------------------------------------------
+
+def test_map_account_summary():
+    rows = [
+        SimpleNamespace(tag="NetLiquidation", value="1000"),
+        SimpleNamespace(tag="TotalCashValue", value="400"),
+        SimpleNamespace(tag="BuyingPower", value="2000"),
+        SimpleNamespace(tag="GrossPositionValue", value="600"),
+    ]
+    assert P.map_account_summary(rows) == {
+        "equity": 1000.0, "cash": 400.0, "buying_power": 2000.0, "portfolio_value": 600.0,
+    }
+
+
+def test_map_option_position():
+    contract = SimpleNamespace(
+        secType="OPT", symbol="SPY", right="C", strike=500.0,
+        lastTradeDateOrContractMonth="20260619", multiplier="100",
+    )
+    item = SimpleNamespace(contract=contract, position=2, averageCost=250.0,
+                           marketValue=600.0, unrealizedPNL=100.0)
+    m = P.map_option_position(item, ticker=None)
+    assert m["chain_symbol"] == "SPY"
+    assert m["option_type"] == "call"
+    assert m["strike"] == 500.0
+    assert m["expiration"] == "2026-06-19"
+    assert m["avg_price"] == 2.5   # 250 / 100 multiplier
+    assert m["quantity"] == 2


### PR DESCRIPTION
The core IBKR broker for the IB-Gateway route: `IBKRTrader(BrokerClient)` over `ib_async`.

**Options are always placed as Pegged-to-Stock (`PEG STK`)**, with optional conditional cancel.

- `session.py` — dedicated asyncio loop/thread, lazy connect + reconnect, thread-safe coroutine marshalling (engine thread + Flask threads).
- `contracts.py` — Option/Stock builders, ISO→IB date, call/put→C/P.
- `orders.py` — always-PEG-STK builder, **signed delta (+call/−put)**, underlying `PriceCondition` band with `conditionsCancelOrder`, LMT fallback, equity order.
- `positions.py` — pure IB→standardized dict mappers (account, positions, open/option orders, option positions incl. greeks).
- `client.py` — `submit_option_order` resolves delta (per-order `peg_delta` → live greek → `IBKR_PEG_DELTA_DEFAULT`), starting price (limit → NBBO mid), attaches cancel-on-cross conditions, places PEG STK, falls back to LMT on rejection; returns `{id,symbol,status}` or `None`.

Tests (15) mock the `IB` object (no socket) and assert: orderType is always `PEG STK` with correctly-signed delta, `peg_delta` override, cancel conditions + `conditionsCancelOrder`, LMT fallback, `None` on failure, equity submit, and the mappers. Full suite: 50 passed.

`requirements.txt` (`ib_async`) is added by the config PR (#82) to avoid a conflict. Constructor takes explicit args; the registry PR (#81) wires it from config.

Supersedes the closed CP-Web-API client (#80) — this is the PEG-STK-capable Gateway version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)