### PR TITLE
Trade sell-alert check + scheduled Telegram notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ market-data-service/build/
 
 # Local Netlify folder
 .netlify
+
+# local trade-alert state
+data/watchlist_trades.json
+data/trade_sell_check.log

--- a/data/watchlist_trades.example.json
+++ b/data/watchlist_trades.example.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Copy to data/watchlist_trades.json (gitignored) and edit. current_value is updated manually; the underlying price is fetched live each run.",
+  "trades": [
+    {
+      "id": "avgo-465c-0612",
+      "underlying": "AVGO",
+      "option_type": "call",
+      "strike": 465,
+      "expiration": "2026-06-12",
+      "contracts": 1,
+      "added_date": "2026-06-01",
+      "cost_per_contract": 19.00,
+      "breakeven": 484.00,
+      "current_value": 35.05,
+      "peak_value": 35.05,
+      "rules": {
+        "take_profit_pct": 100,
+        "trailing_stop_pct": 20,
+        "underlying_below_breakeven": true,
+        "dte_warn": 2
+      }
+    }
+  ]
+}

--- a/deploy/launchd/README.md
+++ b/deploy/launchd/README.md
@@ -1,0 +1,43 @@
+# Trade sell-alert scheduled job (macOS launchd)
+
+Runs `scripts/trade_sell_check.py` on a schedule and pushes a Telegram check-in
+for each logged trade, flagging any that hit a sell rule.
+
+## What it does
+- Reads `data/watchlist_trades.json` (copy from `data/watchlist_trades.example.json`).
+- Fetches the live underlying price (stooq, no auth).
+- Evaluates each trade's `rules`: `take_profit_pct`, `trailing_stop_pct`,
+  `underlying_below_breakeven`, `dte_warn`.
+- Sends the result to Telegram via the bot token + chat id.
+
+## Telegram credentials
+The script resolves, in order:
+1. `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` from the environment, else
+2. the running `claude-code-telegram` bot's `.env`
+   (`~/claude-code-telegram-homely_infra_bot/.env`) for the token, and its first
+   `ALLOWED_USERS` id as the chat.
+
+## Schedule
+`com.jasonzb.trade-sell-check.plist` runs **Sunday 10:00** (weekly review) and
+**weekdays 15:45** local time (pre-close). Edit `StartCalendarInterval` to taste.
+
+## Install
+```bash
+cp deploy/launchd/com.jasonzb.trade-sell-check.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.jasonzb.trade-sell-check.plist
+# run once now to verify:
+launchctl start com.jasonzb.trade-sell-check
+# logs:
+tail -f data/trade_sell_check.log
+```
+
+## Uninstall
+```bash
+launchctl unload ~/Library/LaunchAgents/com.jasonzb.trade-sell-check.plist
+rm ~/Library/LaunchAgents/com.jasonzb.trade-sell-check.plist
+```
+
+## Test without sending
+```bash
+python3 scripts/trade_sell_check.py --dry-run
+```

--- a/deploy/launchd/com.jasonzb.trade-sell-check.plist
+++ b/deploy/launchd/com.jasonzb.trade-sell-check.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonzb.trade-sell-check</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/python3</string>
+        <string>/Users/jasonzb/Desktop/apollo/gamma/allocation-engine-2.0/scripts/trade_sell_check.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/jasonzb/Desktop/apollo/gamma/allocation-engine-2.0</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/jasonzb/Desktop/apollo/gamma/allocation-engine-2.0/data/trade_sell_check.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/jasonzb/Desktop/apollo/gamma/allocation-engine-2.0/data/trade_sell_check.log</string>
+
+    <!-- Sunday 10:00 weekly check-in + weekdays 15:45 (local time) pre-close -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>0</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>15</integer><key>Minute</key><integer>45</integer></dict>
+    </array>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/trade_sell_check.py
+++ b/scripts/trade_sell_check.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Scheduled sell-alert check for logged option trades -> Telegram.
+
+Reads a logged-trades file, refreshes the underlying price (no-auth, via stooq),
+evaluates each trade's sell rules, and sends a Telegram check-in to the
+configured chat. Designed to run unattended from launchd/cron.
+
+Telegram delivery reuses the same bot the rest of the stack uses:
+  - TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID from the environment, OR
+  - falls back to the running claude-code-telegram bot's .env + ALLOWED_USERS.
+
+Sell rules (per trade, in the JSON `rules` block):
+  take_profit_pct          alert when total return >= this %
+  trailing_stop_pct        alert when option value falls this % from its peak
+  underlying_below_breakeven  alert when the underlying trades below breakeven
+  dte_warn                 alert when days-to-expiration <= this
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from urllib.request import urlopen
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRADES_FILE = Path(os.getenv("TRADES_FILE", REPO_ROOT / "data" / "watchlist_trades.json"))
+BOT_ENV_FALLBACK = Path.home() / "claude-code-telegram-homely_infra_bot" / ".env"
+DEFAULT_CHAT_ID = "5921617034"
+
+
+# -- config -----------------------------------------------------------------
+
+def _read_env_file(path: Path, key: str) -> str:
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
+def _telegram_creds() -> tuple[str, str]:
+    token = os.getenv("TELEGRAM_BOT_TOKEN") or _read_env_file(BOT_ENV_FALLBACK, "TELEGRAM_BOT_TOKEN")
+    chat = (
+        os.getenv("TELEGRAM_CHAT_ID")
+        or _read_env_file(BOT_ENV_FALLBACK, "ALLOWED_USERS").split(",")[0].strip()
+        or DEFAULT_CHAT_ID
+    )
+    return token, chat
+
+
+# -- prices -----------------------------------------------------------------
+
+def fetch_underlying_price(symbol: str) -> float | None:
+    """Last price for a US ticker via stooq CSV (no auth)."""
+    url = f"https://stooq.com/q/l/?s={symbol.lower()}.us&f=sd2t2ohlcvn&h&e=csv"
+    try:
+        with urlopen(url, timeout=10) as resp:
+            rows = list(csv.DictReader(io.StringIO(resp.read().decode())))
+        if rows:
+            close = rows[0].get("Close")
+            if close and close not in ("N/D", "N/A"):
+                return float(close)
+    except Exception:
+        pass
+    return None
+
+
+# -- evaluation -------------------------------------------------------------
+
+def evaluate(trade: dict, underlying_price: float | None) -> tuple[list[str], dict]:
+    """Return (sell_signals, context) for one trade."""
+    rules = trade.get("rules", {})
+    cost = float(trade.get("cost_per_contract", 0))
+    value = trade.get("current_value")
+    value = float(value) if value is not None else None
+    peak = float(trade.get("peak_value") or value or 0)
+    breakeven = float(trade.get("breakeven", 0))
+
+    exp = datetime.strptime(trade["expiration"], "%Y-%m-%d").date()
+    dte = (exp - date.today()).days
+
+    signals: list[str] = []
+
+    if value is not None and cost > 0:
+        ret_pct = (value - cost) / cost * 100
+        tp = rules.get("take_profit_pct")
+        if tp is not None and ret_pct >= float(tp):
+            signals.append(f"🎯 TAKE PROFIT: +{ret_pct:.0f}% ≥ target +{float(tp):.0f}%")
+        trail = rules.get("trailing_stop_pct")
+        if trail is not None and peak > 0 and value <= peak * (1 - float(trail) / 100):
+            drop = (peak - value) / peak * 100
+            signals.append(f"📉 TRAILING STOP: down {drop:.0f}% from peak ${peak:.2f} (trail {trail}%)")
+    else:
+        ret_pct = None
+
+    if rules.get("underlying_below_breakeven") and underlying_price is not None and breakeven:
+        if underlying_price < breakeven:
+            signals.append(f"⚠️ BELOW BREAKEVEN: {trade['underlying']} ${underlying_price:.2f} < ${breakeven:.2f}")
+
+    dte_warn = rules.get("dte_warn")
+    if dte_warn is not None and dte <= int(dte_warn):
+        signals.append(f"⏳ TIME STOP: {dte} day(s) to expiration ≤ {dte_warn}")
+
+    return signals, {"dte": dte, "ret_pct": ret_pct, "value": value, "cost": cost}
+
+
+def format_message(trade: dict, underlying_price: float | None, signals: list[str], ctx: dict) -> str:
+    sym = trade["underlying"]
+    label = f"{sym} ${trade['strike']:g}{trade['option_type'][0].upper()} (exp {trade['expiration']})"
+    up = f"${underlying_price:.2f}" if underlying_price is not None else "n/a"
+    be = trade.get("breakeven")
+    lines = [f"📊 Trade check-in — {label}"]
+    lines.append(f"{sym}: {up}" + (f"  ·  breakeven ${be:.2f}" if be else ""))
+    if ctx["value"] is not None:
+        ret = f" ({ctx['ret_pct']:+.0f}%)" if ctx["ret_pct"] is not None else ""
+        lines.append(f"Option: ${ctx['value']:.2f} (added ${ctx['cost']:.2f}){ret}  ·  as of last update")
+    lines.append(f"DTE: {ctx['dte']}")
+    lines.append("")
+    if signals:
+        lines.append("Signals:")
+        lines.extend(f"  {s}" for s in signals)
+    else:
+        lines.append("✅ Holding — no sell triggers")
+    return "\n".join(lines)
+
+
+# -- telegram ---------------------------------------------------------------
+
+def send_telegram(text: str) -> bool:
+    import requests  # local import so --dry-run works without the dep installed
+    token, chat = _telegram_creds()
+    if not token or not chat:
+        print("[telegram] missing TELEGRAM_BOT_TOKEN / chat id — not sending", file=sys.stderr)
+        return False
+    resp = requests.post(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        json={"chat_id": chat, "text": text, "disable_web_page_preview": True},
+        timeout=10,
+    )
+    ok = resp.ok and resp.json().get("ok", False)
+    print(f"[telegram] sent={ok} status={resp.status_code}")
+    return ok
+
+
+# -- main -------------------------------------------------------------------
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    data = json.loads(TRADES_FILE.read_text())
+    trades = data.get("trades", [])
+    if not trades:
+        print("No trades logged.")
+        return 0
+
+    blocks: list[str] = []
+    for trade in trades:
+        underlying = fetch_underlying_price(trade["underlying"])
+        signals, ctx = evaluate(trade, underlying)
+        blocks.append(format_message(trade, underlying, signals, ctx))
+
+    message = "\n\n".join(blocks)
+    print(message)
+    if dry_run:
+        print("\n[dry-run] not sending to Telegram")
+        return 0
+    return 0 if send_telegram(message) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a scheduled sell-alert check for logged option trades, delivered to Telegram.

- `scripts/trade_sell_check.py` — reads `data/watchlist_trades.json`, fetches the live underlying price (stooq, no auth), evaluates per-trade rules (`take_profit_pct`, `trailing_stop_pct`, `underlying_below_breakeven`, `dte_warn`), and pushes a Telegram check-in for any that trigger. `--dry-run` prints without sending. Telegram creds from env or the running `claude-code-telegram` bot's `.env`.
- `deploy/launchd/` — macOS launchd job (Sunday 10:00 weekly + weekdays 15:45 pre-close) + install README.
- `data/watchlist_trades.example.json` — sample; the live `data/watchlist_trades.json` is gitignored.

Verified end-to-end: dry-run + a real Telegram send (`sent=True`). First live run flagged AVGO below its $484 breakeven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)