### PR TITLE
Add Java email-connector for EmailRowObject classification + response routing

### DIFF
--- a/email-connector/.gitignore
+++ b/email-connector/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.class

--- a/email-connector/README.md
+++ b/email-connector/README.md
@@ -1,0 +1,50 @@
+# email-connector (Java)
+
+A Java connector for `EmailRowObject` — an email + a classifier layer (intent,
+message history, next step) + an action layer keyed by a deterministic
+`interaction_id`. It reads/writes the **same Redis keys** the Python allocation
+engine uses, so either language can produce or consume rows.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `EmailRowObject`, `ThreadContext` | domain model (records, immutable) |
+| `EmailIntent`, `NextStep`, `ResponseStatus`, `Responder` | classifier/lifecycle enums |
+| `EmailClassifier` + `RuleBasedClassifier` | the classifier layer (pluggable; swap in Claude later) |
+| `RedisConnection` | **the connection** — pooled Jedis from `REDIS_HOST`/`REDIS_PASSWORD` or `REDIS_URL` |
+| `EmailRowConnector` | **the connector** — store + stream adapter (ingest / load / consume) |
+| `ResponderRouter` | the firing path (interface or agent) |
+
+## Redis contract (shared with Python)
+
+```
+emails          hash    rowId        → EmailRowObject JSON (snake_case)
+email.inbound   stream  XADD         → {row_id, interaction_id, intent, next_step}
+fired:<ixn>     string  SET NX EX    → distributed dedup on interaction_id
+```
+
+JSON is snake_case with ISO-8601 instants, matching the Python `to_redis()`
+output, so `EmailRowObject.fromJson(...)` round-trips rows written by either side.
+
+## Flow
+
+```
+ingest()  →  email.inbound stream  →  consume()  →  ResponderRouter.fire()
+   ▲                                      │
+classify (intent, history, next_step)     └─ SET NX on interaction_id → idempotent
+```
+
+Delivery is **at-least-once** (rows stay pending until `XACK`); the deterministic
+`interaction_id` makes a duplicate a no-op — the second consumer loses the
+`SET NX` race. See the parent design notes for the single-box (in-memory
+`BlockingQueue` + `ConcurrentHashMap`) vs multi-box (this) tradeoff.
+
+## Run
+
+```bash
+cd email-connector
+mvn -q compile exec:java            # offline demo if Redis unset; full path if set
+mvn -q test                         # round-trip + idempotency tests
+REDIS_HOST=localhost mvn -q exec:java
+```

--- a/email-connector/pom.xml
+++ b/email-connector/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.apollo</groupId>
+  <artifactId>email-connector</artifactId>
+  <version>0.1.0</version>
+  <packaging>jar</packaging>
+
+  <!--
+    Java connector for EmailRowObject. Reads/writes the same Redis keys the
+    Python allocation engine uses (`emails` hash, `email.inbound` stream), so
+    both languages can interoperate on the same rows. JSON is snake_case to
+    match the Python `to_redis()` output.
+  -->
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jackson.version>2.17.2</jackson.version>
+    <jedis.version>5.1.5</jedis.version>
+  </properties>
+
+  <dependencies>
+    <!-- Redis client (mirrors redis-py usage on the Python side) -->
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>${jedis.version}</version>
+    </dependency>
+
+    <!-- JSON (snake_case + java.time, to round-trip with Python dataclasses) -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <!-- preserve parameter names so Jackson can bind record components -->
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <mainClass>com.apollo.email.Main</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/email-connector/src/main/java/com/apollo/email/EmailClassifier.java
+++ b/email-connector/src/main/java/com/apollo/email/EmailClassifier.java
@@ -1,0 +1,13 @@
+package com.apollo.email;
+
+/**
+ * The classifier layer: takes a raw row + its message history and writes the
+ * four derived fields (intent, confidence, thread context, next step) via
+ * {@link EmailRowObject#withClassification}.
+ *
+ * <p>Pluggable on purpose — start rule-based, swap in a Claude-backed
+ * implementation later without touching storage or routing.
+ */
+public interface EmailClassifier {
+    EmailRowObject classify(EmailRowObject row, ThreadContext history);
+}

--- a/email-connector/src/main/java/com/apollo/email/EmailIntent.java
+++ b/email-connector/src/main/java/com/apollo/email/EmailIntent.java
@@ -1,0 +1,37 @@
+package com.apollo.email;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** What the inbound email is asking for — the primary classifier flag. */
+public enum EmailIntent {
+    REPLY_NEEDED("reply_needed"),
+    ACTION_REQUEST("action_request"),
+    MEETING_REQUEST("meeting_request"),
+    INFO_ONLY("info_only"),
+    ESCALATION("escalation"),
+    AUTOMATED("automated"),
+    SPAM("spam"),
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    EmailIntent(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static EmailIntent from(String v) {
+        for (EmailIntent e : values()) {
+            if (e.value.equals(v)) {
+                return e;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/EmailRowConnector.java
+++ b/email-connector/src/main/java/com/apollo/email/EmailRowConnector.java
@@ -1,0 +1,177 @@
+package com.apollo.email;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.resps.StreamEntry;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.XReadGroupParams;
+
+/**
+ * The connector. Bridges {@link EmailRowObject} to the same Redis keys the
+ * Python engine uses, so either language can produce or consume rows:
+ *
+ * <pre>
+ *   emails          hash    rowId          → EmailRowObject JSON
+ *   emails  field   _meta                  → {updated_at, last_row_id}
+ *   email.inbound   stream  XADD           → {row_id, interaction_id, intent, next_step}
+ *   fired:&lt;ixn&gt;       string  SET NX EX      → distributed dedup on interaction_id
+ * </pre>
+ *
+ * <p>Producer side: {@link #ingest}. Consumer side: {@link #consume} reads the
+ * stream as a group (one consumer per box), claims each interaction with
+ * {@code SET NX}, fires via the {@link ResponderRouter}, and acks — at-least-once
+ * delivery made idempotent by the deterministic interaction id.
+ */
+public final class EmailRowConnector {
+
+    public static final String EMAILS_HASH = "emails";
+    public static final String META_FIELD = "_meta";
+    public static final String INBOUND_STREAM = "email.inbound";
+    public static final String DEFAULT_GROUP = "responders";
+    private static final String FIRED_PREFIX = "fired:";
+    private static final int FIRED_TTL_SEC = 86_400;
+
+    private final RedisConnection conn;
+    private final String group;
+    private volatile boolean running;
+
+    public EmailRowConnector(RedisConnection conn) {
+        this(conn, DEFAULT_GROUP);
+    }
+
+    public EmailRowConnector(RedisConnection conn, String group) {
+        this.conn = conn;
+        this.group = group;
+    }
+
+    // ── Producer side ────────────────────────────────────────────────────
+
+    /** Persist a classified row and publish it to the inbound stream. */
+    public void ingest(EmailRowObject row) {
+        try (Jedis j = conn.jedis()) {
+            save(j, row);
+            if (row.nextStep() != NextStep.NO_ACTION) {
+                Map<String, String> fields = new LinkedHashMap<>();
+                fields.put("row_id", row.rowId());
+                fields.put("interaction_id", row.interactionId());
+                fields.put("intent", row.intent().value());
+                fields.put("next_step", row.nextStep().value());
+                j.xadd(INBOUND_STREAM, StreamEntryID.NEW_ENTRY, fields);
+            }
+        }
+    }
+
+    public EmailRowObject load(String rowId) {
+        try (Jedis j = conn.jedis()) {
+            String raw = j.hget(EMAILS_HASH, rowId);
+            return raw == null ? null : EmailRowObject.fromJson(raw);
+        }
+    }
+
+    private void save(Jedis j, EmailRowObject row) {
+        j.hset(EMAILS_HASH, row.rowId(), row.toJson());
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("updated_at", Instant.now().toString());
+        meta.put("last_row_id", row.rowId());
+        j.hset(EMAILS_HASH, META_FIELD, Json.write(meta));
+    }
+
+    // ── Consumer side ────────────────────────────────────────────────────
+
+    /** Create the consumer group if absent (idempotent). */
+    public void ensureGroup() {
+        try (Jedis j = conn.jedis()) {
+            try {
+                j.xgroupCreate(INBOUND_STREAM, group, new StreamEntryID("0-0"), true);
+            } catch (JedisDataException e) {
+                if (!String.valueOf(e.getMessage()).contains("BUSYGROUP")) {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Block until stopped, reading the stream as {@code consumerName} and firing
+     * each row through {@code router}. Idempotent across boxes via {@code SET NX}
+     * on the interaction id; rows are acked whether we win the claim or not, and
+     * a failed send releases the claim so a retry can re-win.
+     */
+    public void consume(String consumerName, ResponderRouter router) {
+        ensureGroup();
+        running = true;
+        while (running) {
+            runOnce(consumerName, router, 16, 5_000);
+        }
+    }
+
+    public void stop() {
+        running = false;
+    }
+
+    /** One read batch. Returns the number of stream entries processed. */
+    public int runOnce(String consumerName, ResponderRouter router, int count, int blockMs) {
+        try (Jedis j = conn.jedis()) {
+            var streams = Map.of(INBOUND_STREAM, StreamEntryID.UNRECEIVED_ENTRY);
+            List<Map.Entry<String, List<StreamEntry>>> batch = j.xreadGroup(
+                    group, consumerName,
+                    XReadGroupParams.xReadGroupParams().count(count).block(blockMs),
+                    streams);
+            if (batch == null || batch.isEmpty()) {
+                return 0;
+            }
+            int processed = 0;
+            for (var stream : batch) {
+                for (StreamEntry entry : stream.getValue()) {
+                    handleEntry(j, entry, router);
+                    j.xack(INBOUND_STREAM, group, entry.getID());
+                    processed++;
+                }
+            }
+            return processed;
+        }
+    }
+
+    private void handleEntry(Jedis j, StreamEntry entry, ResponderRouter router) {
+        String rowId = entry.getFields().get("row_id");
+        if (rowId == null) {
+            return;
+        }
+        String raw = j.hget(EMAILS_HASH, rowId);
+        if (raw == null) {
+            return;
+        }
+        EmailRowObject row = EmailRowObject.fromJson(raw);
+
+        if (row.nextStep() == NextStep.NO_ACTION) {
+            save(j, row.withResponse(ResponseStatus.SKIPPED, null, Map.of()));
+            return;
+        }
+
+        // Distributed dedup: whoever wins the SET NX fires; others skip.
+        String firedKey = FIRED_PREFIX + row.interactionId();
+        String won = j.set(firedKey, consumerTag(), SetParams.setParams().nx().ex(FIRED_TTL_SEC));
+        if (won == null) {
+            return; // another box already owns this interaction
+        }
+
+        try {
+            Map<String, Object> result = router.fire(row);
+            save(j, row.withResponse(ResponseStatus.SENT, Responder.AGENT, result));
+        } catch (Exception e) {
+            j.del(firedKey); // release the claim so a retry can re-win
+            Map<String, Object> err = Map.of("error", String.valueOf(e.getMessage()));
+            save(j, row.withResponse(ResponseStatus.FAILED, Responder.AGENT, err));
+        }
+    }
+
+    private static String consumerTag() {
+        return "responder-" + Thread.currentThread().getName();
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/EmailRowObject.java
+++ b/email-connector/src/main/java/com/apollo/email/EmailRowObject.java
@@ -1,0 +1,107 @@
+package com.apollo.email;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An email message carried through three layers: the raw email + payload, a
+ * derived classifier layer, and an action layer mutated by the responder.
+ *
+ * <p>Immutable (a record): classification and response updates return a new
+ * instance via {@link #withClassification} / {@link #withResponse}. JSON
+ * round-trips with the Python {@code EmailRowObject} dataclass (snake_case).
+ */
+public record EmailRowObject(
+        // ── RAW ──────────────────────────────────────────────────────────
+        String rowId,
+        String threadId,
+        String messageId,
+        String inReplyTo,
+        String sender,
+        List<String> recipients,
+        String subject,
+        String body,
+        Instant receivedAt,
+        Map<String, Object> payload,
+        // ── CLASSIFIERS (derived, re-computable) ─────────────────────────
+        EmailIntent intent,
+        double intentConfidence,
+        ThreadContext threadContext,
+        NextStep nextStep,
+        String interactionId,
+        int classifierVersion,
+        Instant classifiedAt,
+        // ── ACTION (mutated by responder) ────────────────────────────────
+        ResponseStatus responseStatus,
+        Responder responder,
+        Map<String, Object> responsePayload) {
+
+    public static final int CLASSIFIER_VERSION = 1;
+
+    /**
+     * Deterministic id = thread + intent. The same conversational intent
+     * collapses to one interaction, giving natural dedup / idempotency across
+     * boxes (the dedup key is the id itself, not a per-process map).
+     */
+    public static String deriveInteractionId(String threadId, EmailIntent intent) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] d = md.digest((threadId + ":" + intent.value()).getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder("ixn_");
+            for (int i = 0; i < 8; i++) {              // 8 bytes → 16 hex chars
+                sb.append(String.format("%02x", d[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-1 unavailable", e);
+        }
+    }
+
+    /** Build the RAW layer with classifier/action fields at their defaults. */
+    public static EmailRowObject raw(
+            String rowId, String threadId, String messageId, String inReplyTo,
+            String sender, List<String> recipients, String subject, String body,
+            Instant receivedAt, Map<String, Object> payload) {
+        return new EmailRowObject(
+                rowId, threadId, messageId, inReplyTo, sender,
+                recipients == null ? List.of() : recipients, subject, body, receivedAt,
+                payload == null ? Map.of() : payload,
+                EmailIntent.UNKNOWN, 0.0, null, NextStep.NO_ACTION, "",
+                CLASSIFIER_VERSION, null,
+                ResponseStatus.PENDING, null, Map.of());
+    }
+
+    /** Overlay the classifier layer; derives interactionId from thread+intent. */
+    public EmailRowObject withClassification(
+            EmailIntent intent, double confidence, ThreadContext ctx, NextStep step) {
+        return new EmailRowObject(
+                rowId, threadId, messageId, inReplyTo, sender, recipients, subject,
+                body, receivedAt, payload,
+                intent, confidence, ctx, step, deriveInteractionId(threadId, intent),
+                CLASSIFIER_VERSION, Instant.now(),
+                responseStatus, responder, responsePayload);
+    }
+
+    /** Overlay the action layer after the responder fires. */
+    public EmailRowObject withResponse(
+            ResponseStatus status, Responder by, Map<String, Object> resultPayload) {
+        return new EmailRowObject(
+                rowId, threadId, messageId, inReplyTo, sender, recipients, subject,
+                body, receivedAt, payload,
+                intent, intentConfidence, threadContext, nextStep, interactionId,
+                classifierVersion, classifiedAt,
+                status, by, resultPayload == null ? Map.of() : resultPayload);
+    }
+
+    public String toJson() {
+        return Json.write(this);
+    }
+
+    public static EmailRowObject fromJson(String raw) {
+        return Json.read(raw, EmailRowObject.class);
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/Json.java
+++ b/email-connector/src/main/java/com/apollo/email/Json.java
@@ -1,0 +1,47 @@
+package com.apollo.email;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+/**
+ * Shared {@link ObjectMapper}, configured to match the Python side's
+ * {@code to_redis()} output:
+ * <ul>
+ *   <li>snake_case property names (Java {@code rowId} &harr; JSON {@code row_id})</li>
+ *   <li>{@link java.time.Instant} as ISO-8601 strings, not epoch numbers</li>
+ *   <li>nulls retained, so Python {@code cls(**d)} sees every field</li>
+ * </ul>
+ */
+public final class Json {
+
+    public static final ObjectMapper MAPPER = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .addModule(new ParameterNamesModule())
+            .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
+
+    private Json() {}
+
+    public static String write(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("JSON serialize failed", e);
+        }
+    }
+
+    public static <T> T read(String raw, Class<T> type) {
+        try {
+            return MAPPER.readValue(raw, type);
+        } catch (Exception e) {
+            throw new IllegalStateException("JSON deserialize failed: " + raw, e);
+        }
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/Main.java
+++ b/email-connector/src/main/java/com/apollo/email/Main.java
@@ -1,0 +1,58 @@
+package com.apollo.email;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End-to-end demo. Classifies a sample email, then:
+ *   - if Redis is configured, ingests it and drains one batch through a stub
+ *     responder (the multi-box path);
+ *   - otherwise just prints the classified row JSON (works offline).
+ */
+public final class Main {
+
+    public static void main(String[] args) {
+        EmailClassifier classifier = new RuleBasedClassifier();
+
+        EmailRowObject raw = EmailRowObject.raw(
+                "msg_1001", "thread_42", "<abc@mail.gmail.com>", null,
+                "alice@example.com", List.of("ops@apollo.dev"),
+                "Can you approve the allocation change?",
+                "Hi — could you please review and approve the change ASAP? Thanks.",
+                Instant.now(), Map.of("labels", List.of("INBOX", "IMPORTANT")));
+
+        EmailRowObject classified = classifier.classify(raw, ThreadContext.fresh("thread_42"));
+
+        System.out.println("intent=" + classified.intent().value()
+                + " confidence=" + classified.intentConfidence()
+                + " next_step=" + classified.nextStep().value()
+                + " interaction_id=" + classified.interactionId());
+        System.out.println("row JSON: " + classified.toJson());
+
+        try (RedisConnection conn = RedisConnection.fromEnv()) {
+            if (!conn.isConfigured()) {
+                System.out.println("[redis] not configured — skipping ingest/consume demo");
+                return;
+            }
+            EmailRowConnector connector = new EmailRowConnector(conn);
+            connector.ingest(classified);
+            System.out.println("[redis] ingested " + classified.rowId());
+
+            // Stub responder stands in for the interface / agent firing path.
+            ResponderRouter stub = row -> {
+                System.out.println("[respond] firing for interaction " + row.interactionId()
+                        + " (" + row.nextStep().value() + ")");
+                return Map.of("sent_message_id", "<reply-" + row.rowId() + ">");
+            };
+            int n = connector.runOnce("box-1", stub, 16, 2_000);
+            System.out.println("[redis] processed " + n + " row(s)");
+
+            EmailRowObject after = connector.load(classified.rowId());
+            System.out.println("[redis] status=" + after.responseStatus().value()
+                    + " responder=" + (after.responder() == null ? "-" : after.responder().value()));
+        }
+    }
+
+    private Main() {}
+}

--- a/email-connector/src/main/java/com/apollo/email/NextStep.java
+++ b/email-connector/src/main/java/com/apollo/email/NextStep.java
@@ -1,0 +1,35 @@
+package com.apollo.email;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** What the routing layer decided to do — drives the responder. */
+public enum NextStep {
+    SEND_REPLY("send_reply"),
+    DRAFT_REPLY("draft_reply"),
+    SCHEDULE("schedule"),
+    FORWARD("forward"),
+    HUMAN_REVIEW("human_review"),
+    NO_ACTION("no_action");
+
+    private final String value;
+
+    NextStep(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static NextStep from(String v) {
+        for (NextStep e : values()) {
+            if (e.value.equals(v)) {
+                return e;
+            }
+        }
+        return NO_ACTION;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/RedisConnection.java
+++ b/email-connector/src/main/java/com/apollo/email/RedisConnection.java
@@ -1,0 +1,101 @@
+package com.apollo.email;
+
+import java.net.URI;
+import java.time.Duration;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * The connection. Owns a pooled Jedis client built from the same environment
+ * the Python engine uses (see {@code app/redis_store.py::_get_client}):
+ *
+ * <ol>
+ *   <li>{@code REDIS_HOST} (+ optional {@code :port}) and {@code REDIS_PASSWORD}</li>
+ *   <li>else {@code REDIS_URL}</li>
+ *   <li>else not configured &rarr; {@link #isConfigured()} is false</li>
+ * </ol>
+ *
+ * <p>Pooled because the connector fans out across worker threads/virtual
+ * threads — each borrows a resource with {@link #jedis()} in try-with-resources.
+ */
+public final class RedisConnection implements AutoCloseable {
+
+    private static final int DEFAULT_PORT = 6379;
+
+    private final JedisPool pool;
+
+    private RedisConnection(JedisPool pool) {
+        this.pool = pool;
+    }
+
+    /** Build from env, or return a not-configured instance (pool == null). */
+    public static RedisConnection fromEnv() {
+        return new RedisConnection(buildPool(System.getenv()));
+    }
+
+    /** Build from an explicit map (handy for tests). */
+    public static RedisConnection from(java.util.Map<String, String> env) {
+        return new RedisConnection(buildPool(env));
+    }
+
+    private static JedisPool buildPool(java.util.Map<String, String> env) {
+        JedisPoolConfig cfg = new JedisPoolConfig();
+        cfg.setMaxTotal(16);
+        cfg.setMaxIdle(8);
+        cfg.setMinIdle(1);
+        cfg.setTestOnBorrow(true);
+
+        String host = trimToNull(env.get("REDIS_HOST"));
+        if (host != null) {
+            int port = DEFAULT_PORT;
+            int colon = host.lastIndexOf(':');
+            if (colon > -1) {
+                try {
+                    port = Integer.parseInt(host.substring(colon + 1));
+                    host = host.substring(0, colon);
+                } catch (NumberFormatException ignored) {
+                    // leave host/port as-is, matching the Python fallback
+                }
+            }
+            String password = trimToNull(env.get("REDIS_PASSWORD"));
+            return new JedisPool(cfg, host, port, (int) Duration.ofSeconds(5).toMillis(), password);
+        }
+
+        String url = trimToNull(env.get("REDIS_URL"));
+        if (url != null) {
+            return new JedisPool(cfg, URI.create(url), (int) Duration.ofSeconds(5).toMillis());
+        }
+
+        return null; // not configured
+    }
+
+    public boolean isConfigured() {
+        return pool != null;
+    }
+
+    /** Borrow a connection from the pool. Close it (try-with-resources) to return it. */
+    public Jedis jedis() {
+        if (pool == null) {
+            throw new IllegalStateException(
+                    "Redis not configured (set REDIS_HOST/REDIS_PASSWORD or REDIS_URL)");
+        }
+        return pool.getResource();
+    }
+
+    @Override
+    public void close() {
+        if (pool != null) {
+            pool.close();
+        }
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/Responder.java
+++ b/email-connector/src/main/java/com/apollo/email/Responder.java
@@ -1,0 +1,32 @@
+package com.apollo.email;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Who fires the response. */
+public enum Responder {
+    INTERFACE("interface"),
+    AGENT("agent"),
+    HUMAN("human");
+
+    private final String value;
+
+    Responder(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static Responder from(String v) {
+        for (Responder e : values()) {
+            if (e.value.equals(v)) {
+                return e;
+            }
+        }
+        return null;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/ResponderRouter.java
+++ b/email-connector/src/main/java/com/apollo/email/ResponderRouter.java
@@ -1,0 +1,14 @@
+package com.apollo.email;
+
+import java.util.Map;
+
+/**
+ * The firing path selected per row. An implementation actually sends the
+ * reply / schedules / forwards — via the interface (human-in-the-loop) or an
+ * autonomous agent. Returns a result payload stored on the row's action layer
+ * (e.g. {@code {"sent_message_id": "..."}}).
+ */
+@FunctionalInterface
+public interface ResponderRouter {
+    Map<String, Object> fire(EmailRowObject row) throws Exception;
+}

--- a/email-connector/src/main/java/com/apollo/email/ResponseStatus.java
+++ b/email-connector/src/main/java/com/apollo/email/ResponseStatus.java
@@ -1,0 +1,34 @@
+package com.apollo.email;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Lifecycle of the outbound interaction keyed by interaction_id. */
+public enum ResponseStatus {
+    PENDING("pending"),
+    DRAFTED("drafted"),
+    SENT("sent"),
+    FAILED("failed"),
+    SKIPPED("skipped");
+
+    private final String value;
+
+    ResponseStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ResponseStatus from(String v) {
+        for (ResponseStatus e : values()) {
+            if (e.value.equals(v)) {
+                return e;
+            }
+        }
+        return PENDING;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/RuleBasedClassifier.java
+++ b/email-connector/src/main/java/com/apollo/email/RuleBasedClassifier.java
@@ -1,0 +1,68 @@
+package com.apollo.email;
+
+import java.util.Locale;
+
+/**
+ * A cheap keyword classifier so the pipeline runs end-to-end without an LLM.
+ * {@code nextStep} is a deterministic policy map over {@code intent}, so a
+ * future Claude classifier only has to nail intent + confidence while routing
+ * stays auditable.
+ */
+public final class RuleBasedClassifier implements EmailClassifier {
+
+    @Override
+    public EmailRowObject classify(EmailRowObject row, ThreadContext history) {
+        String text = (row.subject() + " " + row.body()).toLowerCase(Locale.ROOT);
+        String from = row.sender() == null ? "" : row.sender().toLowerCase(Locale.ROOT);
+
+        EmailIntent intent;
+        double confidence;
+
+        if (from.contains("no-reply") || from.contains("noreply") || from.contains("notifications@")) {
+            intent = EmailIntent.AUTOMATED;
+            confidence = 0.95;
+        } else if (containsAny(text, "unsubscribe", "viagra", "winner", "lottery")) {
+            intent = EmailIntent.SPAM;
+            confidence = 0.8;
+        } else if (containsAny(text, "urgent", "asap", "immediately", "outage", "down")) {
+            intent = EmailIntent.ESCALATION;
+            confidence = 0.7;
+        } else if (containsAny(text, "meet", "calendar", "schedule", "available", "invite")) {
+            intent = EmailIntent.MEETING_REQUEST;
+            confidence = 0.75;
+        } else if (containsAny(text, "please", "can you", "could you", "request", "need")) {
+            intent = EmailIntent.ACTION_REQUEST;
+            confidence = 0.65;
+        } else if (text.contains("?")) {
+            intent = EmailIntent.REPLY_NEEDED;
+            confidence = 0.6;
+        } else {
+            intent = EmailIntent.INFO_ONLY;
+            confidence = 0.5;
+        }
+
+        ThreadContext ctx = history != null ? history : ThreadContext.fresh(row.threadId());
+        return row.withClassification(intent, confidence, ctx, routeFor(intent));
+    }
+
+    /** Policy map: intent → next step. Deterministic and easy to audit. */
+    public static NextStep routeFor(EmailIntent intent) {
+        return switch (intent) {
+            case REPLY_NEEDED -> NextStep.DRAFT_REPLY;
+            case ACTION_REQUEST -> NextStep.DRAFT_REPLY;
+            case MEETING_REQUEST -> NextStep.SCHEDULE;
+            case ESCALATION -> NextStep.HUMAN_REVIEW;
+            case INFO_ONLY, AUTOMATED, SPAM -> NextStep.NO_ACTION;
+            case UNKNOWN -> NextStep.HUMAN_REVIEW;
+        };
+    }
+
+    private static boolean containsAny(String haystack, String... needles) {
+        for (String n : needles) {
+            if (haystack.contains(n)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/email-connector/src/main/java/com/apollo/email/ThreadContext.java
+++ b/email-connector/src/main/java/com/apollo/email/ThreadContext.java
@@ -1,0 +1,31 @@
+package com.apollo.email;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Message history — the "previous threads" classifier. Captures the
+ * conversation a row belongs to so the responder has context.
+ *
+ * @param threadId     provider thread id (e.g. Gmail threadId)
+ * @param priorRowIds  earlier rows in the thread, oldest &rarr; newest
+ * @param messageCount total messages seen in the thread
+ * @param summary      rolling summary of the conversation so far
+ * @param lastOutboundAt when we last replied (null if never)
+ */
+public record ThreadContext(
+        String threadId,
+        List<String> priorRowIds,
+        int messageCount,
+        String summary,
+        Instant lastOutboundAt) {
+
+    public ThreadContext {
+        priorRowIds = priorRowIds == null ? List.of() : List.copyOf(priorRowIds);
+    }
+
+    /** An empty context for the first message in a thread. */
+    public static ThreadContext fresh(String threadId) {
+        return new ThreadContext(threadId, List.of(), 0, "", null);
+    }
+}

--- a/email-connector/src/test/java/com/apollo/email/EmailRowObjectTest.java
+++ b/email-connector/src/test/java/com/apollo/email/EmailRowObjectTest.java
@@ -1,0 +1,57 @@
+package com.apollo.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class EmailRowObjectTest {
+
+    private EmailRowObject sample() {
+        return EmailRowObject.raw(
+                "msg_1", "thread_1", "<m1@x>", null,
+                "bob@example.com", List.of("ops@apollo.dev"),
+                "Please review", "Could you review this ASAP?",
+                Instant.parse("2026-06-18T12:00:00Z"),
+                Map.of("k", "v"));
+    }
+
+    @Test
+    void jsonRoundTrips() {
+        EmailRowObject row = new RuleBasedClassifier()
+                .classify(sample(), ThreadContext.fresh("thread_1"));
+        EmailRowObject back = EmailRowObject.fromJson(row.toJson());
+        assertEquals(row, back);
+    }
+
+    @Test
+    void jsonUsesSnakeCaseForPythonCompat() {
+        String json = sample().toJson();
+        assertTrue(json.contains("\"row_id\""), json);
+        assertTrue(json.contains("\"interaction_id\""), json);
+        assertTrue(json.contains("\"next_step\""), json);
+    }
+
+    @Test
+    void interactionIdIsDeterministicPerThreadAndIntent() {
+        String a = EmailRowObject.deriveInteractionId("thread_1", EmailIntent.REPLY_NEEDED);
+        String b = EmailRowObject.deriveInteractionId("thread_1", EmailIntent.REPLY_NEEDED);
+        String c = EmailRowObject.deriveInteractionId("thread_1", EmailIntent.MEETING_REQUEST);
+        assertEquals(a, b);                 // same thread+intent → same id (dedup)
+        assertNotEquals(a, c);              // different intent → different interaction
+        assertTrue(a.startsWith("ixn_"));
+        assertEquals("ixn_".length() + 16, a.length());
+    }
+
+    @Test
+    void routingIsDeterministicPolicyMap() {
+        assertEquals(NextStep.SCHEDULE, RuleBasedClassifier.routeFor(EmailIntent.MEETING_REQUEST));
+        assertEquals(NextStep.HUMAN_REVIEW, RuleBasedClassifier.routeFor(EmailIntent.ESCALATION));
+        assertEquals(NextStep.NO_ACTION, RuleBasedClassifier.routeFor(EmailIntent.SPAM));
+    }
+}


### PR DESCRIPTION
## What

A self-contained Java/Maven module (`email-connector/`) that models an **EmailRowObject** — an email plus a **classifier layer** (intent, message history, next step) and an **action layer** keyed by a deterministic `interaction_id`. The connector reads/writes the **same Redis keys the Python engine uses**, so either language can produce or consume rows.

## Layers

```
RAW         row_id, thread_id, headers, body, payload{}
CLASSIFIER  intent · intent_confidence · thread_context (message history) · next_step · interaction_id
ACTION      response_status · responder (interface|agent) · response_payload
```

`interaction_id = sha1(thread_id + intent)` — the same conversational intent collapses to one interaction, giving natural dedup/idempotency (the dedup key is the id itself, not a per-process map).

## Pieces

| File | Role |
|------|------|
| `RedisConnection` | **the connection** — pooled Jedis from `REDIS_HOST`/`REDIS_PASSWORD`, `REDIS_URL` fallback (mirrors Python `_get_client()`) |
| `EmailRowConnector` | **the connector** — store + stream adapter: `ingest` / `load` / `consume` |
| `EmailClassifier` + `RuleBasedClassifier` | classifier layer, pluggable (swap in Claude later) |
| `ResponderRouter` | the firing path — interface (human) or agent |

## Redis contract (shared with Python)

```
emails          hash    rowId        → EmailRowObject JSON (snake_case)
email.inbound   stream  XADD         → {row_id, interaction_id, intent, next_step}
fired:<ixn>     string  SET NX EX    → distributed dedup on interaction_id
```

Consume loop = `XREADGROUP` (at-least-once) + `SET NX` on `interaction_id` + `XACK`, with claim-release on failure so retries re-win. JSON is snake_case + ISO-8601 to round-trip with the Python `to_redis()` format — a row classified in Java can be fired by Python and vice-versa.

## Verification

- `mvn test` → **4/4 pass** (JSON round-trip, snake_case keys, interaction_id determinism, route policy map)
- `mvn exec:java` offline → classifies, emits Python-compatible JSON, skips Redis path cleanly when unconfigured

## Notes

- New module only — no changes to existing Python code.
- Build needs a JDK 21+ and Maven (`brew install maven`); `target/` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)