### PR TITLE
Add Flushing (Queens) craigslist for-sale crawler

### DIFF
--- a/scripts/craigslist_crawl.py
+++ b/scripts/craigslist_crawl.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Flushing (Queens) craigslist crawler.
+
+Pulls for-sale listings from the craigslist Queens subarea (`que`, which covers
+Flushing) across a set of search terms and writes a deduped snapshot to JSON +
+markdown. Uses the server-rendered static search page, so no JS/API decoding is
+needed.
+
+Usage:
+    python scripts/craigslist_crawl.py
+    python scripts/craigslist_crawl.py --queries hardware tools --out /tmp/cl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from urllib.parse import quote_plus
+
+import requests
+from bs4 import BeautifulSoup
+
+BASE = "https://newyork.craigslist.org/search/que/sss"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+# "hardware and other etc" — for-sale terms relevant to the Flushing hunt.
+DEFAULT_QUERIES = [
+    "hardware",
+    "tools",
+    "electronics",
+    "computer",
+    "appliances",
+]
+
+
+def fetch(query: str) -> str:
+    url = f"{BASE}?query={quote_plus(query)}"
+    resp = requests.get(url, headers={"User-Agent": UA}, timeout=25)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse(html: str, query: str) -> list[dict]:
+    soup = BeautifulSoup(html, "html.parser")
+    out = []
+    for li in soup.select("li.cl-static-search-result"):
+        a = li.find("a")
+        if not a or not a.get("href"):
+            continue
+        href = a["href"]
+        pid = href.rstrip("/").split("/")[-1].removesuffix(".html")
+        # URL shape: .../que/<cat>/d/<slug>/<pid>.html
+        parts = href.split("/")
+        cat = parts[4] if len(parts) > 4 else ""
+        title = (li.get("title") or "").strip()
+        price_el = li.select_one(".price")
+        loc_el = li.select_one(".location")
+        out.append(
+            {
+                "pid": pid,
+                "title": title,
+                "price": price_el.get_text(strip=True) if price_el else "",
+                "location": loc_el.get_text(strip=True) if loc_el else "",
+                "category": cat,
+                "url": href,
+                "matched_query": query,
+            }
+        )
+    return out
+
+
+def crawl(queries: list[str], delay: float = 1.0) -> list[dict]:
+    by_pid: dict[str, dict] = {}
+    for q in queries:
+        try:
+            rows = parse(fetch(q), q)
+        except requests.RequestException as e:
+            print(f"  ! {q}: {e}", file=sys.stderr)
+            continue
+        new = 0
+        for r in rows:
+            if r["pid"] not in by_pid:
+                by_pid[r["pid"]] = r
+                new += 1
+        print(f"  {q}: {len(rows)} results ({new} new)")
+        time.sleep(delay)
+    return sorted(by_pid.values(), key=lambda r: (r["category"], r["title"].lower()))
+
+
+def write_markdown(listings: list[dict], path: Path) -> None:
+    lines = [
+        "# Flushing (Queens) Craigslist — for-sale snapshot",
+        "",
+        f"**{len(listings)} unique listings** across queries: "
+        + ", ".join(f"`{q}`" for q in DEFAULT_QUERIES),
+        "",
+        "| Price | Title | Cat | Location | Link |",
+        "|------:|-------|-----|----------|------|",
+    ]
+    for r in listings:
+        title = r["title"].replace("|", "\\|")
+        lines.append(
+            f"| {r['price'] or '—'} | {title} | {r['category']} | "
+            f"{r['location'] or '—'} | [link]({r['url']}) |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--queries", nargs="+", default=DEFAULT_QUERIES)
+    ap.add_argument(
+        "--out",
+        default=str(Path(__file__).parent / "craigslist_flushing"),
+        help="output path prefix (writes <prefix>_listings.json and .md)",
+    )
+    args = ap.parse_args()
+
+    print(f"Crawling Queens craigslist for {len(args.queries)} queries...")
+    listings = crawl(args.queries)
+
+    out = Path(args.out)
+    json_path = out.with_name(out.name + "_listings.json")
+    md_path = out.with_name(out.name + "_listings.md")
+    json_path.write_text(json.dumps(listings, indent=2), encoding="utf-8")
+    write_markdown(listings, md_path)
+
+    print(f"\nWrote {len(listings)} listings:")
+    print(f"  {json_path}")
+    print(f"  {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/craigslist_flushing_listings.json
+++ b/scripts/craigslist_flushing_listings.json
@@ -1,0 +1,12791 @@
+[
+  {
+    "pid": "7941912503",
+    "title": "$100...POWERFUL WINDOW AIR CONDITIONER FOR SALE MUST GO !!  ASAP MOVIN",
+    "price": "$100",
+    "location": "ROCKAWAY PARK",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rockaway-park-100powerful-window-air/7941912503.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930650399",
+    "title": "(Instant Pot) PRESTO  Pressure cooker 7-in 1; $249.99; Sale only",
+    "price": "$179",
+    "location": "queens ny",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-instant-pot-presto/7930650399.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7915203692",
+    "title": "0.90 Cubic Feet Magic Chef Portable Washer",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-090-cubic-feet-magic-chef/7915203692.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941061394",
+    "title": "1 Air Conditioner Units AC - 5000 btu good condition",
+    "price": "$50",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-air-conditioner-units/7941061394.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921114715",
+    "title": "1 glass door refrigerator",
+    "price": "$849",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-glass-door-refrigerator/7921114715.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942376980",
+    "title": "10 inch table saw",
+    "price": "$150",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-10-inch-table-saw/7942376980.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940841947",
+    "title": "10000 BTU windows air conditioner",
+    "price": "$80",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-btu-windows-air-conditioner/7940841947.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942903298",
+    "title": "2 Cemetery Plots King David Memorial/Rose Hill Gardens Putnam Valley 10579",
+    "price": "$6,000",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/dewey-cemetery-plots-king-david/7942903298.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941892448",
+    "title": "2 speakers for computer",
+    "price": "$30",
+    "location": "Kew Gardens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/kew-gardens-speakers-for-computer/7941892448.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7936547099",
+    "title": "2 Washing Machine/Dishwasher Hoses",
+    "price": "$15",
+    "location": "Forest Hills, NY 11375",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-washing-machine-dishwasher/7936547099.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942724559",
+    "title": "24 INCH FRONT LOAD WASHER",
+    "price": "$400",
+    "location": "woodside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-24-inch-front-load-washer/7942724559.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921104424",
+    "title": "42\" Deli case curve glass -",
+    "price": "$1,399",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-42-deli-case-curve-glass/7921104424.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943847060",
+    "title": "48\" refrigerator bakery case",
+    "price": "$0",
+    "location": "Jackson Heights",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/east-elmhurst-48-refrigerator-bakery/7943847060.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7928197271",
+    "title": "800 Series Bosch",
+    "price": "$350",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-800-series-bosch/7928197271.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935027823",
+    "title": "A Sharp Air Conditioner 8000 BTU",
+    "price": "$200",
+    "location": "Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/elmhurst-sharp-air-conditioner-8000-btu/7935027823.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913387471",
+    "title": "A/C FRIGIDAIRE 10,000 BTU WINDOW UNIT AIR COND ( BRAND NEW )",
+    "price": "$0",
+    "location": "Nassau County L.I /. Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/lynbrook-c-frigidaire-btu-window-unit/7913387471.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944142514",
+    "title": "AC 6000 BTU | Midea",
+    "price": "$25",
+    "location": "Richmond Hill",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/richmond-hill-ac-6000-btu-midea/7944142514.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939177632",
+    "title": "AC Air conditioner for sale great working condition",
+    "price": "$25",
+    "location": "Floral park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/glen-oaks-ac-air-conditioner-for-sale/7939177632.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649927",
+    "title": "air condition/heater, 2-in-1; its portable; Priced $699.99; Last Price",
+    "price": "$299",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-air-condition-heater-in/7930649927.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641307",
+    "title": "Air conditioner  whirlpool: priced $299.99",
+    "price": "$199",
+    "location": "queens ny",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-air-conditioner/7930641307.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943365391",
+    "title": "Air Conditioner 12000 BTU Hisense AC",
+    "price": "$400",
+    "location": "Park Slope Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-air-conditioner-btu-hisense-ac/7943365391.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943051854",
+    "title": "Air conditioner portable",
+    "price": "$60",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-air-conditioner-portable/7943051854.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943848609",
+    "title": "Air Conditioners",
+    "price": "$35",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-air-conditioners/7943848609.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943655678",
+    "title": "Air Cooler",
+    "price": "$50",
+    "location": "Whitestone     NY",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-air-cooler/7943655678.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7908978848",
+    "title": "AIR PURIFIER",
+    "price": "$60",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-air-purifier/7908978848.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943283323",
+    "title": "Air-Conditioner",
+    "price": "$159",
+    "location": "Corona",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/corona-air-conditioner/7943283323.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930640448",
+    "title": "all Appliances and Furniture must Go Inventory Sale; ASAP",
+    "price": "$0",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-all-appliances-and/7930640448.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7906726424",
+    "title": "American Eagle AE-G12N Bench Model Meat Grinder For Commercial Kitchen",
+    "price": "$700",
+    "location": "little neck",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/little-neck-american-eagle-ae-g12n/7906726424.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921094592",
+    "title": "Aquasana AQ-5300R Claryum 3-stage Under Sink Water Filter Replacement",
+    "price": "$45",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-aquasana-aq-5300r-claryum/7921094592.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940849849",
+    "title": "ArcticKing Window Air Conditioner  5,000 BTU",
+    "price": "$75",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/arcticking-window-air-conditioner-5000/7940849849.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937644260",
+    "title": "Batman Alarm Clock, New in Box",
+    "price": "$20",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-batman-alarm-clock-new/7937644260.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939913969",
+    "title": "BEAUTIFUL LOOMY BLOOM TRANSFORMABLE TABLE LAMP TENERGY",
+    "price": "$30",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-beautiful-loomy-bloom/7939913969.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930718574",
+    "title": "Bella Cucina X Large Electric Griddle NEW in Box \ud83d\udd25",
+    "price": "$25",
+    "location": "Forest Hills, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-bella-cucina-large-electric/7930718574.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914540178",
+    "title": "BELLA PRO SERIES 4.2-QT. MANUAL AIR FRYER | 90161 | BLACK | NEW",
+    "price": "$39",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-bella-pro-series-42-qt/7914540178.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942274268",
+    "title": "Bella Waffle Maker (New without box)",
+    "price": "$15",
+    "location": "Rego Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-bella-waffle-maker-new/7942274268.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943133392",
+    "title": "Bertazoni KV30 Pro 1X",
+    "price": "$599",
+    "location": "Bayside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-bertazoni-kv30-pro-1x/7943133392.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921050326",
+    "title": "Beverage air 5 ft salad refrigerator",
+    "price": "$1,199",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-beverage-air-ft-salad/7921050326.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921107288",
+    "title": "Beverage air refrigerator glass door",
+    "price": "$899",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-beverage-air-refrigerator-glass/7921107288.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943378874",
+    "title": "Big Capacity Slow Cooker",
+    "price": "$25",
+    "location": "Lower East Side",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-big-capacity-slow-cooker/7943378874.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943932440",
+    "title": "Big Green Egg Large with Table",
+    "price": "$2,000",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-big-green-egg-large/7943932440.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938613335",
+    "title": "BLACK and DECKER 0.9 Cu. Ft. Portable Washer, 6.6 lb Washing Machine",
+    "price": "$200",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-black-and-decker-09-cu/7938613335.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935035038",
+    "title": "Blaux Portable AC F832 with 3 Speed Fan & lonizer.",
+    "price": "$50",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-blaux-portable-ac-f832-with/7935035038.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649493",
+    "title": "Blender with Auto-iQ\u2122:  Priced $399.99; Sale Only",
+    "price": "$249",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-blender-with-auto-iq/7930649493.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649540",
+    "title": "Blender with Auto-iQ\u2122:  Priced $399.99; Sale Only",
+    "price": "$249",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-blender-with-auto-iq/7930649540.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930648983",
+    "title": "Blood Presssure Monitor",
+    "price": "$79",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-blood-presssure-monitor/7930648983.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7927160295",
+    "title": "BMW 2023 X5 M50i rear bumper reinforcement impact bar re-bar",
+    "price": "$100",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-bmw-2023-x5-m50i-rear/7927160295.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7908567923",
+    "title": "Book case",
+    "price": "$69",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-book-case/7908567923.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943398963",
+    "title": "Bosch 800 Series 18\u201d ADA Compact Top Control 42dBA Dishwasher",
+    "price": "$1,000",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-bosch-800-series-18-ada/7943398963.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7933990764",
+    "title": "Brand NEW - Hamilton Beach Air Fryer Toaster Oven",
+    "price": "$40",
+    "location": "Bayside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-brand-new-hamilton-beach-air/7933990764.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939912916",
+    "title": "BRAND NEW IN BOX MISEN 10\" STAINLESS STEEL FRYING PAN",
+    "price": "$60",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-brand-new-in-box-misen-10/7939912916.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936542807",
+    "title": "BrassCraft Gas Connector",
+    "price": "$10",
+    "location": "Forest Hills, NY 11375",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-brasscraft-gas-connector/7936542807.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939092308",
+    "title": "Brondell Heated Multi Function Round Toilet Bidet Seat - Orig $249",
+    "price": "$100",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-brondell-heated-multi/7939092308.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942718603",
+    "title": "Brookstone Reto Popcorn Maker Machine",
+    "price": "$10",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-brookstone-reto-popcorn-maker/7942718603.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943917681",
+    "title": "Bullet Express System with Bonus Juicer Express",
+    "price": "$60",
+    "location": "Howard Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/howard-beach-bullet-express-system-with/7943917681.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7916199784",
+    "title": "CARPIGIANI Soft Serve Ice Cream Maker Machine with 2 Flavors and a Twi",
+    "price": "$10,000",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-carpigiani-soft-serve-ice-cream/7916199784.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921937834",
+    "title": "CARPIGIANI Soft Serve Ice Cream Maker Machine with 2 Flavors and a Twi",
+    "price": "$10,000",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-carpigiani-soft-serve-ice-cream/7921937834.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649574",
+    "title": "Ceiling light Pendant; Brand New! Packed!",
+    "price": "$99",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-ceiling-light-pendant/7930649574.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918563653",
+    "title": "Chargeable LED Table Lamp USB/ 3 Color/ Stepless Dimmable Desk Lamp",
+    "price": "$15",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-chargeable-led-table-lamp/7918563653.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7917824823",
+    "title": "ChillWell Deluxe Portable Model 18009 Two (2) Pack - New",
+    "price": "$75",
+    "location": "Jamaica estates",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-chillwell-deluxe-portable-model/7917824823.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7917466820",
+    "title": "CHROME TOASTER",
+    "price": "$25",
+    "location": "SEQ",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-chrome-toaster/7917466820.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649361",
+    "title": "coffee grinder; Black n Decker; Priced $29.99; Sale only",
+    "price": "$19",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-coffee-grinder-black/7930649361.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943861995",
+    "title": "COMFEE' 1.6 Cu.ft Portable Washing",
+    "price": "$175",
+    "location": "Roosevelt Island",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-comfee-16-cuft-portable-washing/7943861995.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922555557",
+    "title": "Comfort Zone 4\" personal fan",
+    "price": "$5",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-comfort-zone-personal-fan/7922555557.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921112055",
+    "title": "Commercial 6 ft deli case remote (no compressor)-",
+    "price": "$1,199",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-commercial-ft-deli-case-remote/7921112055.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7910177358",
+    "title": "Commercial microwave oven",
+    "price": "$249",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-commercial-microwave-oven/7910177358.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936220157",
+    "title": "commercial refrigerator",
+    "price": "$1,499",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-commercial-refrigerator/7936220157.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942676647",
+    "title": "Commercial Washer and dryer",
+    "price": "$700",
+    "location": "east elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/east-elmhurst-commercial-washer-and/7942676647.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649427",
+    "title": "Computer Desk/Cart;Compact;Gently use, $49.99 ;  today only",
+    "price": "$29",
+    "location": "si hablamos espa\u00f1ol e ingles",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-computer-desk/7930649427.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7909434254",
+    "title": "Computer Monitor Wall Mount",
+    "price": "$25",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-computer-monitor-wall-mount/7909434254.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930641014",
+    "title": "Conair Garment Steamer for Clothes, reduced price to $79.99 for today",
+    "price": "$99",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-conair-garment-steamer/7930641014.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7929935594",
+    "title": "Cordless Dyson Gen5 Detect Vacuum Cleaner Rechargeable",
+    "price": "$299",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-cordless-dyson-gen5-detect/7929935594.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943257015",
+    "title": "Crepe Maker",
+    "price": "$25",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-crepe-maker/7943257015.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930640811",
+    "title": "Crystal budoir lamps Brand New 2 available; each",
+    "price": "$59",
+    "location": "jackson hts",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-crystal-budoir-lamps/7930640811.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649886",
+    "title": "Crystal lamps each $79.99; sale only",
+    "price": "$39",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-crystal-lamps-each-7999/7930649886.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7916603723",
+    "title": "Cuckoo pressure rice cooker",
+    "price": "$100",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-cuckoo-pressure-rice-cooker/7916603723.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930640900",
+    "title": "Cuisinart  Ice Cream Maker: Brand New, Packed; Priced $149.99; Sale",
+    "price": "$129",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-cuisinart-ice-cream/7930640900.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920841368",
+    "title": "Cuisinart Automatic Frozen Yogurt Ice & Sorbet Cream Maker",
+    "price": "$40",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-automatic-frozen/7920841368.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920842285",
+    "title": "Cuisinart Citrus Juicer",
+    "price": "$15",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-citrus-juicer/7920842285.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7927073841",
+    "title": "Cuisinart Espresso Machine & Frother - Good condition ($216 New) - Moving Sale -",
+    "price": "$80",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-cuisinart-espresso-machine/7927073841.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913903442",
+    "title": "Cuisinart Ice Cream/Yogurt Maker - Brand new",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/howard-beach-cuisinart-ice-cream-yogurt/7913903442.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920609804",
+    "title": "cuisinart PowerBlend Duet parts",
+    "price": "$15",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-powerblend-duet/7920609804.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935018610",
+    "title": "Curtain Installation Kit 3127A20074X for Window AC",
+    "price": "$40",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-curtain-installation-kit/7935018610.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7907254583",
+    "title": "Danby Designer Countertop Compact Refrigerator",
+    "price": "$100",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/woodhaven-danby-designer-countertop/7907254583.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7932963229",
+    "title": "Deep fryer 4 burners PITCO",
+    "price": "$550",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-deep-fryer-burners-pitco/7932963229.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921108337",
+    "title": "Deli case refrigerator 3 Ft",
+    "price": "$1,299",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-deli-case-refrigerator-ft/7921108337.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7917842715",
+    "title": "DeLonghi oscillating Ceramic heater",
+    "price": "$10",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-delonghi-oscillating/7917842715.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921075786",
+    "title": "Dough mixer, Thunderbird, 20 quarts made in USA",
+    "price": "$2,199",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-dough-mixer-thunderbird-20/7921075786.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7907928121",
+    "title": "Dryer Screen Lint Filter Whirlpool, Kenmore, Maytag..... (Made In USA)",
+    "price": "$30",
+    "location": "Queens, Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-dryer-screen-lint-filter/7907928121.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920211623",
+    "title": "Dynex LCD TV 27 inches NOT A SMART TV",
+    "price": "$40",
+    "location": "Flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-dynex-lcd-tv-27-inches-not/7920211623.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942675657",
+    "title": "Dyson v15s Detect Submarine",
+    "price": "$650",
+    "location": "Atlantic Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/atlantic-beach-dyson-v15s-detect/7942675657.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939736171",
+    "title": "Electric fireplace space heater",
+    "price": "$55",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-electric-fireplace-space/7939736171.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942650231",
+    "title": "Electric Knife Sharpener, Presto 08800 EverSharp 2-Stage System",
+    "price": "$35",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-electric-knife-sharpener/7942650231.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936538198",
+    "title": "Electrolux Deep Clean Power Head Brush",
+    "price": "$100",
+    "location": "Forest Hills, NY 11375",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-electrolux-deep-clean/7936538198.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939896093",
+    "title": "EXCELLENT - DASH QUARTZ EXPRES TOASTER OVEN",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-excellent-dash-quartz-expres/7939896093.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939925484",
+    "title": "EXCELLENT DYSON CYCLONE V10 ANIMAL+ CORDLESS  VACUUM PERFECT CONDITION",
+    "price": "$200",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-excellent-dyson-cyclone-v10/7939925484.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943753298",
+    "title": "excellent sewing machine",
+    "price": "$110",
+    "location": "woodside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/woodside-excellent-sewing-machine/7943753298.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930646492",
+    "title": "fabric steam ironing, brand new packed; Priced $279.99; Sale Today ONL",
+    "price": "$129",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-fabric-steam-ironing/7930646492.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943601868",
+    "title": "Fan",
+    "price": "$15",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-fan/7943601868.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940406593",
+    "title": "Fan",
+    "price": "$30",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-fan/7940406593.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943196950",
+    "title": "Fans/Vacuum cleaner/Garbage pail & more",
+    "price": "$0",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-fans-vacuum-cleaner-garbage/7943196950.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912159395",
+    "title": "fireplace",
+    "price": "$100",
+    "location": "Freeport",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/freeport-fireplace/7912159395.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943588580",
+    "title": "For sale mini washer",
+    "price": "$250",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-for-sale-mini-washer/7943588580.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942531700",
+    "title": "FREE 21\" Frigidaire Gas Range - Oven Not Working - Handyman Special",
+    "price": "$0",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/kew-gardens-free-21-frigidaire-gas/7942531700.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921077865",
+    "title": "freezer True 3 doors stainless steel",
+    "price": "$3,999",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-freezer-true-doors-stainless/7921077865.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942228186",
+    "title": "FRIDGIDAIR electric stove *BRAND NEW*",
+    "price": "$599",
+    "location": "New York",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-fridgidair-electric-stove/7942228186.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942134719",
+    "title": "Friedrich Air Conditioner A/C 8,000 BTU",
+    "price": "$160",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-friedrich-air-conditioner/7942134719.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940850145",
+    "title": "Friedrich Air Conditioner AC 10,000 BTU",
+    "price": "$180",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-friedrich-air-conditioner/7940850145.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937424558",
+    "title": "Friedrich Kuhl 8000 btu - Smart AC- Commercial-Grade - Whisper-Quiet",
+    "price": "$700",
+    "location": "College Point",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/college-point-friedrich-kuhl-8000-btu/7937424558.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943265262",
+    "title": "Friedrich window / wall air conditioner 12000btu",
+    "price": "$300",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-friedrich-window-wall-air/7943265262.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943559698",
+    "title": "Frigidaire 10,500 BTU In-Wall Window Air Conditioner",
+    "price": "$200",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-frigidaire-btu-in-wall-window/7943559698.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930267674",
+    "title": "Frigidaire 36 inches",
+    "price": "$500",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-frigidaire-36-inches/7930267674.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941311670",
+    "title": "Frigidaire 8,000 BTU Window Conditioner",
+    "price": "$255",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-frigidaire-8000-btu-window/7941311670.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914359910",
+    "title": "Frigidaire Mini Skin-care Personal Fridge",
+    "price": "$79",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7914359910.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909740246",
+    "title": "Frigidaire Mini Skin-care Personal Fridge-BRAND NEW",
+    "price": "$68",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7909740246.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7924033520",
+    "title": "Frigidaire Mini Skin-care Personal Fridge-BRAND NEW",
+    "price": "$74",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7924033520.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913095934",
+    "title": "Frigidaire Mini Skin-care Personal Fridge-BRAND NEW",
+    "price": "$79",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7913095934.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943051133",
+    "title": "Frigidaire Refrigerator",
+    "price": "$0",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-frigidaire-refrigerator/7943051133.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939016719",
+    "title": "Frigidaire Side-By-Side Refrigerator",
+    "price": "$450",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-side-by-side/7939016719.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944186147",
+    "title": "Frigidaire Window air conditioner",
+    "price": "$200",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-frigidaire-window-air/7944186147.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7931554244",
+    "title": "Gaggenau Range Hood",
+    "price": "$1,500",
+    "location": "Rego Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-gaggenau-range-hood/7931554244.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930483855",
+    "title": "gas stove -2 burners-",
+    "price": "$550",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-gas-stove-burners/7930483855.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912082338",
+    "title": "gas stove -2 burners-",
+    "price": "$550",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-gas-stove-burners/7912082338.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7928808298",
+    "title": "GE 350 SQ FT 8500 BTU SMART PORTABLE AIR CONDITIONER | APLS08WWB",
+    "price": "$249",
+    "location": "or Best Offer",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-ge-350-sq-ft-8500-btu/7928808298.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7906451929",
+    "title": "GE 350 SQ FT 8500 BTU SMART PORTABLE AIR CONDITIONER | APLS08WWB",
+    "price": "$249",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-ge-350-sq-ft-8500-btu/7906451929.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935014485",
+    "title": "GE 350-sq ft Window Air Conditioner with Remote (115-Volt, 8000-BTU)",
+    "price": "$280",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-ge-350-sq-ft-window-air/7935014485.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7910773589",
+    "title": "GE 5000 BTU Air Conditioner",
+    "price": "$70",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-ge-5000-btu-air-conditioner/7910773589.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944124856",
+    "title": "GE AIR CONDITIONER -  GOOD CONDITION - $60 OBO - AHP06LZQ2",
+    "price": "$60",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-ge-air-conditioner-good/7944124856.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942766884",
+    "title": "GE Air Conditioner 8200 BTU",
+    "price": "$120",
+    "location": "New York",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-ge-air-conditioner-8200-btu/7942766884.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943986057",
+    "title": "GE Air Conditioner for Sale - 10,100 BTU",
+    "price": "$250",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-ge-air-conditioner-for/7943986057.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943980262",
+    "title": "GE Electric Stacked Laundry/ Top load Washer and",
+    "price": "$500",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-ge-electric-stacked-laundry-top/7943980262.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7934563302",
+    "title": "GE Profile Series 18\" Built In Dishwasher",
+    "price": "$500",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-ge-profile-series-18-built-in/7934563302.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941937302",
+    "title": "GE washer/dryer",
+    "price": "$700",
+    "location": "New York",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-ge-washer-dryer/7941937302.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941232384",
+    "title": "General Electric Dryer",
+    "price": "$300",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-general-electric-dryer/7941232384.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922293561",
+    "title": "Hamilton Beach Dough & Bread Maker",
+    "price": "$65",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/queens-village-hamilton-beach-dough/7922293561.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941177225",
+    "title": "Hamilton Beach Icecream Maker 4 Quart - Like New",
+    "price": "$50",
+    "location": "Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/elmhurst-hamilton-beach-icecream-maker/7941177225.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909740365",
+    "title": "Hamilton Beach TrueAir Air Purifier",
+    "price": "$26",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7909740365.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913099300",
+    "title": "Hamilton Beach TrueAir Air Purifier",
+    "price": "$29",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7913099300.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909747788",
+    "title": "Hamilton Beach TrueAir Air Purifier",
+    "price": "$29",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7909747788.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913099642",
+    "title": "Hamilton Beach TrueAir Air Purifier",
+    "price": "$29",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7913099642.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942011009",
+    "title": "HAPPY FATHER's DAY - KEURIG K2.0-500  COFFEE MAKER & COFFEE PODS",
+    "price": "$25",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-happy-fathers-day-keurig/7942011009.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921111405",
+    "title": "Heavy duty, curve glass deli case 48\"",
+    "price": "$1,500",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-heavy-duty-curve-glass-deli/7921111405.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930645169",
+    "title": "HeavyDuty Sewing Machine; Price $399.99; on sale only",
+    "price": "$299",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-heavyduty-sewing/7930645169.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930640610",
+    "title": "HeavyDuty Sewing Machine; Price $399.99; on sale only",
+    "price": "$299",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-heavyduty-sewing/7930640610.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937804582",
+    "title": "Hisense Portable Room Air Conditioner 8500 BTU.",
+    "price": "$150",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-hisense-portable-room-air/7937804582.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918879448",
+    "title": "Hobart bandsaw meat bone fish",
+    "price": "$2,000",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-hobart-bandsaw-meat/7918879448.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909301831",
+    "title": "Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW",
+    "price": "$159",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909301831.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909748077",
+    "title": "Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW",
+    "price": "$159",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909748077.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930309214",
+    "title": "Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW",
+    "price": "$175",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7930309214.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909742562",
+    "title": "Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW",
+    "price": "$135",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909742562.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914741912",
+    "title": "Hoover Steam Cleaner Carpet Cleaner Shampooer",
+    "price": "$99",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-hoover-steam-cleaner-carpet/7914741912.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914740589",
+    "title": "Hoover Windtunnel Self-propelled Bagless Upright Vacuum Cleaner",
+    "price": "$99",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-hoover-windtunnel-self/7914740589.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912836803",
+    "title": "HP LaserJet Pro 400 MFP M425dn",
+    "price": "$80",
+    "location": "Woodhaven",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/woodhaven-hp-laserjet-pro-400-mfp-m425dn/7912836803.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938055988",
+    "title": "huge samsung stainless steelwide 36 width",
+    "price": "$900",
+    "location": "Glendale",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-huge-samsung-stainless/7938055988.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641885",
+    "title": "Ice Cream Maker: Brand New, Packed; Priced $149.99; Sale only",
+    "price": "$79",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-ice-cream-maker-brand/7930641885.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649156",
+    "title": "Ice Cream Maker; Was $99.99; Today only",
+    "price": "$79",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-ice-cream-maker-was/7930649156.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943657757",
+    "title": "ice machine",
+    "price": "$200",
+    "location": "Jackson Heights",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/east-elmhurst-ice-machine/7943657757.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943856274",
+    "title": "ice machine",
+    "price": "$200",
+    "location": "Jackson Heights",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/east-elmhurst-ice-machine/7943856274.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942377467",
+    "title": "Ikea Pahl desk with add-on unit, 3 staged height",
+    "price": "$29",
+    "location": "Lic",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-ikea-pahl-desk-with/7942377467.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943441905",
+    "title": "Ikea twin size mattress 6\u201d",
+    "price": "$29",
+    "location": "Lic",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-ikea-twin-size/7943441905.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943697912",
+    "title": "ilco tubular key cutting machine minus cutter",
+    "price": "$350",
+    "location": "Bayside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-ilco-tubular-key-cutting/7943697912.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940216052",
+    "title": "iRobot Roomba Max 705 Combo Robot + AutoWash Dock - Black Edition - Sealed",
+    "price": "$199",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-irobot-roomba-max-705-combo/7940216052.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938031177",
+    "title": "iRobot Roomba Max 705 Combo Robot + AutoWash Dock - Black Edition - Sealed",
+    "price": "$199",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-irobot-roomba-max-705-combo/7938031177.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942459978",
+    "title": "KENMORE COMMERCIAL COIN WASHER",
+    "price": "$250",
+    "location": "Howard Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/howard-beach-kenmore-commercial-coin/7942459978.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7913903178",
+    "title": "Keurig K10 (Red)",
+    "price": "$40",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-keurig-k10-red/7913903178.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942562474",
+    "title": "Koto electric hotpot",
+    "price": "$44",
+    "location": "Flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-koto-electric-hotpot/7942562474.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944138978",
+    "title": "KRUPS GX5000 Electric Burr Coffee Grinder - 45 Settings",
+    "price": "$20",
+    "location": "Broad Channel",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-krups-gx5000-electric-burr/7944138978.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918986875",
+    "title": "Lean Mean Fat Grilling Machine & cookbook",
+    "price": "$10",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-lean-mean-fat-grilling/7918986875.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940453678",
+    "title": "LG 8,000 BTU Window Air Conditioner",
+    "price": "$120",
+    "location": "Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/elmhurst-lg-8000-btu-window-air/7940453678.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943671201",
+    "title": "LG 8000 BTU air conditioner for sale",
+    "price": "$150",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-lg-8000-btu-air-conditioner-for/7943671201.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943940538",
+    "title": "LG air conditioner",
+    "price": "$100",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-lg-air-conditioner/7943940538.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935098491",
+    "title": "LG front-load washer and gas dryer set",
+    "price": "$400",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-lg-front-load-washer-and-gas/7935098491.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942909934",
+    "title": "LG LW5016 Window Air Conditioner",
+    "price": "$100",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-lg-lw5016-window-air/7942909934.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939090075",
+    "title": "LG MICROWAVE - BRAND NEW",
+    "price": "$150",
+    "location": "Long Island City",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-lg-microwave-brand-new/7939090075.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943480864",
+    "title": "LG Portable Air Conditioner Brand New Model LP0818WNR 8000 BTU",
+    "price": "$175",
+    "location": "Forest Hills, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-lg-portable-air/7943480864.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937865089",
+    "title": "LG smart washing machine front load with steam",
+    "price": "$399",
+    "location": "Maspeth",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-lg-smart-washing-machine-front/7937865089.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942237622",
+    "title": "LG TV   good condition",
+    "price": "$120",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-lg-tv-good-condition/7942237622.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943631648",
+    "title": "LG wall air conditioner",
+    "price": "$325",
+    "location": "Rockaway Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rockaway-park-lg-wall-air-conditioner/7943631648.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943948120",
+    "title": "LG Washing Machine",
+    "price": "$400",
+    "location": "Far Rockaway",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-lg-washing-machine/7943948120.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641253",
+    "title": "Light Ceiling Pendant: Fallsbrook; Priced $149.99; Sale Only",
+    "price": "$69",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-light-ceiling-pendant/7930641253.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641446",
+    "title": "Light Ceiling Pendant: Fallsbrook; Priced $149.99; Sale Only",
+    "price": "$69",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-light-ceiling-pendant/7930641446.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921483925",
+    "title": "Like new patty warmer 36\" w x (17 \" d bottom 13\" d top ) \u00d7 25 \" h.",
+    "price": "$449",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-like-new-patty-warmer-36-x-17/7921483925.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921078828",
+    "title": "Low boy refrigerator with shelve 4 ft",
+    "price": "$1,399",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-low-boy-refrigerator-with/7921078828.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921109279",
+    "title": "Marble Curve Glass Deli Case Refrigerator 5 FT",
+    "price": "$2,499",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-marble-curve-glass-deli-case/7921109279.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943414432",
+    "title": "Marvel Professional 23-Bottle Wine Cellar",
+    "price": "$1",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-marvel-professional-23-bottle/7943414432.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921091336",
+    "title": "Master-Bilt dipping freezer ( Ice cream cabinet)",
+    "price": "$1,599",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-master-bilt-dipping-freezer-ice/7921091336.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941029591",
+    "title": "MAYTAG \"PERFORMA\" APARTMENT SIZE FRIDGE (27.5\" wide)",
+    "price": "$400",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-maytag-performa-apartment-size/7941029591.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7924833196",
+    "title": "Maytag Atlantis MAV9750AWQ Washer Parts - Motor, Water Pumps, Electronics",
+    "price": "$50",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-maytag-atlantis-mav9750awq/7924833196.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914533197",
+    "title": "Melitta Aroma Enhance 10-Cup White Thermal Carafe Drip Coffee Maker",
+    "price": "$75",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-melitta-aroma-enhance-10/7914533197.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914833329",
+    "title": "Melitta Aroma Tocco | Thermal Drip - Programmable Coffee Machine",
+    "price": "$49",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/hollis-melitta-aroma-tocco-thermal-drip/7914833329.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914534738",
+    "title": "Melitta Vision 12-Cup Drip Coffee Maker, Automatic Programmable, 96oz",
+    "price": "$149",
+    "location": "or Best Offer",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-melitta-vision-12-cup-drip/7914534738.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938407681",
+    "title": "Mets Commemorative Hall of Fame Pin, Valentine Mazzilli",
+    "price": "$25",
+    "location": "Floral Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/floral-park-mets-commemorative-hall-of/7938407681.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939832048",
+    "title": "Microwave",
+    "price": "$60",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/maspeth-microwave/7939832048.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943503219",
+    "title": "Microwave",
+    "price": "$50",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-microwave/7943503219.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943925566",
+    "title": "Midea 10000 BTU Air-conditioner with bracket and remote",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-midea-btu-air-conditioner-with/7943925566.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943740897",
+    "title": "Mini Fridge W/ Freezer",
+    "price": "$50",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-mini-fridge-freezer/7943740897.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943943704",
+    "title": "Mini Two Door Refrigerator",
+    "price": "$115",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-mini-two-door-refrigerator/7943943704.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942902438",
+    "title": "Multipurpose Cordless Pet Grooming Tool: Vacuum, Brush/Comb for Dog/Cat Hair Rem",
+    "price": "$50",
+    "location": "College Point",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/college-point-multipurpose-cordless-pet/7942902438.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943421338",
+    "title": "NEW 8000 BTU Window Air Conditioner with Dehumidifier, 3 Fan Speeds",
+    "price": "$300",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-new-8000-btu-window-air/7943421338.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923172965",
+    "title": "New Dyson Gen5 Detect Cordless Rechargeable HEPA Vacuum Cleaner",
+    "price": "$399",
+    "location": "Woodhaven",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/woodhaven-new-dyson-gen5-detect/7923172965.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923173248",
+    "title": "New Dyson Gen5 Outsize Cordless Rechargeable HEPA Vacuum Cleaner",
+    "price": "$299",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-new-dyson-gen5-outsize/7923173248.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7928876986",
+    "title": "NEW gas grill, stainless steel burner",
+    "price": "$375",
+    "location": "Flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/fresh-meadows-new-gas-grill-stainless/7928876986.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938185370",
+    "title": "New LG Room AC 10000BTU with Window mounting bracket",
+    "price": "$300",
+    "location": "Hollis Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/oakland-gardens-new-lg-room-ac-10000btu/7938185370.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939895431",
+    "title": "NEW NEVER USED MIHIGH PORTABLE INDOOR INFRARED SAUNA BLANKET",
+    "price": "$150",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-new-never-used-mihigh-portable/7939895431.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918747371",
+    "title": "New two 15 inches Mac book pro covers for less.",
+    "price": "$30",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-new-two-15-inches-mac-book/7918747371.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914538594",
+    "title": "NEWAIR 90-CAN FREESTANDING MINI FRIDGE | AB-850 NEW",
+    "price": "$199",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/saint-albans-newair-90-can-freestanding/7914538594.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641190",
+    "title": "Ninja IQ one touch intelligence; Priced $299.99;  Sale only for",
+    "price": "$249",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-ninja-iq-one-touch/7930641190.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920609188",
+    "title": "Norelco Headgroom Pro",
+    "price": "$55",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-norelco-headgroom-pro/7920609188.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943358218",
+    "title": "Nutribullet RX Blade Removal Tool",
+    "price": "$4",
+    "location": "Broad Channel",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-nutribullet-rx-blade/7943358218.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7910261427",
+    "title": "Onkyo subwoofer and receiver -",
+    "price": "$99",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-onkyo-subwoofer-and-receiver/7910261427.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943865865",
+    "title": "ONLY $300 AIR CONDITIONER BRAND NEW",
+    "price": "$300",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-only-300-air-conditioner/7943865865.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943756062",
+    "title": "Open box, unused LG 8500 BTU window AC",
+    "price": "$400",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-open-box-unused-lg-8500-btu/7943756062.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943476446",
+    "title": "Oreck Magnesium upright vacuum cleaner (delivery extra)",
+    "price": "$70",
+    "location": "woodside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/woodside-oreck-magnesium-upright-vacuum/7943476446.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942947143",
+    "title": "Oven for sale",
+    "price": "$650",
+    "location": "Jamaica Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-oven-for-sale/7942947143.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921088366",
+    "title": "Oven half side",
+    "price": "$1,399",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-oven-half-side/7921088366.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912338571",
+    "title": "Panini Press Indoor Grill",
+    "price": "$25",
+    "location": "far rockaway",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-panini-press-indoor-grill/7912338571.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942274391",
+    "title": "Parini Sunny Side 6 Egg Cooker",
+    "price": "$15",
+    "location": "Rego Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-parini-sunny-side-egg-cooker/7942274391.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930650264",
+    "title": "Perfect Slicer;",
+    "price": "$15",
+    "location": "si hablamos espa\u00f1ol e ingles",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-perfect-slicer/7930650264.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649199",
+    "title": "Perfect Slicer;",
+    "price": "$15",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-perfect-slicer/7930649199.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649854",
+    "title": "Personal Home Nebulizer; Brand New! Packed!  Last Price Sale",
+    "price": "$49",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-personal-home-nebulizer/7930649854.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939481163",
+    "title": "Personal Home Nebulizer; sale only",
+    "price": "$49",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-personal-home-nebulizer/7939481163.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936422968",
+    "title": "plate warmer",
+    "price": "$550",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-plate-warmer/7936422968.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944133653",
+    "title": "Portable ac",
+    "price": "$249",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-portable-ac/7944133653.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941893891",
+    "title": "Portable AC",
+    "price": "$200",
+    "location": "Glendale",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-portable-ac/7941893891.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942292666",
+    "title": "Portable Air Conditioner 8000 BTU",
+    "price": "$320",
+    "location": "GLENDALE",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-portable-air-conditioner-8000/7942292666.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7927680181",
+    "title": "Portable Air Conditioner clean - FRIEDRICH - 8k BTU",
+    "price": "$280",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-portable-air-conditioner-clean/7927680181.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938405979",
+    "title": "Portable TV DVD Player with built in Digital Tuner, in box",
+    "price": "$65",
+    "location": "Floral Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/floral-park-portable-tv-dvd-player-with/7938405979.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922641951",
+    "title": "Power Air Fryer, Vegetable Cutter, Nextgrill BBQ Utensils",
+    "price": "$50",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-power-air-fryer-vegetable/7922641951.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943283052",
+    "title": "Power Generator 7.5 HP",
+    "price": "$625",
+    "location": "Corona",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/corona-power-generator-75-hp/7943283052.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935374023",
+    "title": "Pre-owned Frigidaire 8,000 BTU Window Air Conditioner",
+    "price": "$125",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-frigidaire-8000-btu/7935374023.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923017601",
+    "title": "Pre-owned GE 6,000 BTU Window Mounted Air Conditioner",
+    "price": "$125",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-ge-6000-btu-window/7923017601.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923018831",
+    "title": "Pre-owned GE 8,000 BTU Window Air Conditioner",
+    "price": "$175",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-ge-8000-btu-window/7923018831.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923017370",
+    "title": "Pre-owned LG 6,000 BTU Window Mounted Air Conditioner",
+    "price": "$125",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-lg-6000-btu-window/7923017370.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935394505",
+    "title": "Pre-owned LG 6,000 BTU Window Mounted Air Conditioner",
+    "price": "$90",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-lg-6000-btu-window/7935394505.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923018470",
+    "title": "Pre-owned Panasonic 9,800 BTU Window Air Conditioner",
+    "price": "$195",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-panasonic-9800-btu/7923018470.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7917630620",
+    "title": "Pre-owned Panasonic NC-EH22PC Water Boiler 2.3-Quart with Temperature",
+    "price": "$50",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-panasonic-nc-eh22pc/7917630620.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7923021147",
+    "title": "Pre-owned Whirlpool 5,000 BTU Window Air Conditioner",
+    "price": "$85",
+    "location": "Rego Park, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-whirlpool-5000-btu/7923021147.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930955490",
+    "title": "Premier 24\" Gas Stove USED LIGHTLY",
+    "price": "$500",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-premier-24-gas-stove-used/7930955490.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649281",
+    "title": "PRESTIGE; Priced $249.99 Sale only",
+    "price": "$199",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-prestige-priced-sale/7930649281.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930718493",
+    "title": "Presto Electric Griddle NEW in Box \ud83d\udd25",
+    "price": "$20",
+    "location": "Forest Hills, Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/rego-park-presto-electric-griddle-new/7930718493.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930648907",
+    "title": "PRESTO; Priced $299.99; Last price for Sale today is only",
+    "price": "$199",
+    "location": "si hablamos espa\u00f1ol e ingles",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-presto-priced-last/7930648907.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942216743",
+    "title": "PRICE FLEXIBLE Breville Barista Express",
+    "price": "$300",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-price-flexible-breville-barista/7942216743.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943045016",
+    "title": "PTAC air conditioner",
+    "price": "$450",
+    "location": "nyc",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-ptac-air-conditioner/7943045016.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920460897",
+    "title": "Rare Vintage Snapon Tools Stickers Patches Pins Catalogs Models",
+    "price": "$2,345",
+    "location": "little neck",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bartlesville-rare-vintage-snapon-tools/7920460897.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7928187372",
+    "title": "Rational Combioven Oven W Stand SCCWE62 with Stand",
+    "price": "$5,000",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-rational-combioven-oven-stand/7928187372.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912366044",
+    "title": "refridgerator",
+    "price": "$50",
+    "location": "Freeport",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/freeport-refridgerator/7912366044.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7924337998",
+    "title": "refridgerator dorm size",
+    "price": "$50",
+    "location": "Freeport",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/freeport-refridgerator-dorm-size/7924337998.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912974980",
+    "title": "refridgerator dorm size",
+    "price": "$50",
+    "location": "Freeport",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/freeport-refridgerator-dorm-size/7912974980.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7912425531",
+    "title": "refridgerator/freezer across top",
+    "price": "$50",
+    "location": "Freeport",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/freeport-refridgerator-freezer-across/7912425531.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7931836305",
+    "title": "refrigerator",
+    "price": "$1,499",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-refrigerator/7931836305.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943508270",
+    "title": "Refrigerator for sale",
+    "price": "$200",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/corona-refrigerator-for-sale/7943508270.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7927541164",
+    "title": "REFRIGERATOR FOR SALE 24 INCHES WIDE 60 INCHES HEIGHT",
+    "price": "$180",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/corona-refrigerator-for-sale-24-inches/7927541164.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921093176",
+    "title": "Refrigerator Imbera 1 glass door",
+    "price": "$1,099",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-refrigerator-imbera-glass-door/7921093176.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921113446",
+    "title": "Refrigerator, round cold drinks, led light. with wheels.",
+    "price": "$199",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-refrigerator-round-cold-drinks/7921113446.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942278679",
+    "title": "Rehome frenchie",
+    "price": "$0",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-rehome-frenchie/7942278679.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943239138",
+    "title": "Retractable Sun Shading Blinds 49.21x22.83 in. for Household / CARS",
+    "price": "$10",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-retractable-sun-shading/7943239138.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940309458",
+    "title": "Rival GCRVSW-100 Steam Wave Iron",
+    "price": "$8",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-rival-gcrvsw-100-steam-wave/7940309458.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938029928",
+    "title": "Roborock Saros 10R Robot Vacuum with Multifunctional Dock 4.0 - New and Sealed!",
+    "price": "$199",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-roborock-saros-10r-robot/7938029928.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940079576",
+    "title": "Roborock Saros 10R Robot Vacuum with Multifunctional Dock 4.0 - New and Sealed!",
+    "price": "$199",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-roborock-saros-10r-robot/7940079576.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942384018",
+    "title": "Room and board drawer/shelf/night stand combo for kids",
+    "price": "$29",
+    "location": "Lic",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-room-and-board-drawer/7942384018.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922184473",
+    "title": "Rotary Fan, Antique Retro Collectible, All Metal, Green, Works",
+    "price": "$20",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-rotary-fan-antique-retro/7922184473.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943915012",
+    "title": "Samson \"Silent\" 6 Tray All Stainless Steel Dehydrator",
+    "price": "$40",
+    "location": "Sunnyside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-samson-silent-tray-all/7943915012.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918337014",
+    "title": "SAMSUNG 32 inches LCD TV  NOT A SMART TV",
+    "price": "$50",
+    "location": "flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-samsung-32-inches-lcd-tv-not/7918337014.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914336239",
+    "title": "Samsung 5.4 cu. ft. Smart Top Load Washer",
+    "price": "$900",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-samsung-54-cu-ft-smart-top/7914336239.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914336343",
+    "title": "Samsung 7.4 cu. ft. Smart Vented Electric Dryer",
+    "price": "$900",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-samsung-74-cu-ft-smart/7914336343.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943358368",
+    "title": "Samsung BluRay Disc Player BD-E5400",
+    "price": "$50",
+    "location": "Broad Channel",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/far-rockaway-samsung-bluray-disc-player/7943358368.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7910262139",
+    "title": "Samsung natural gas dryer in excellent conditions",
+    "price": "$499",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-samsung-natural-gas-dryer-in/7910262139.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941273828",
+    "title": "Samsung WV60M9900AV/A56.0 cu ft. Smart Washer with Flexwash in Black Stainless S",
+    "price": "$150",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-samsung-wv60m9900av-a560-cu/7941273828.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939925270",
+    "title": "SET OF SIX (6) BEAUTIFUL ALUMINUM AND GLASS CANDLE HOLDERS CANDELABRAS",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-set-of-six-beautiful-aluminum/7939925270.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7940891606",
+    "title": "Shark Vertex AZ1500WM",
+    "price": "$250",
+    "location": "Jackson Heights",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-shark-vertex-az1500wm/7940891606.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944120123",
+    "title": "Sharp Frigidaire",
+    "price": "$500",
+    "location": "Flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/college-point-sharp-frigidaire/7944120123.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930914064",
+    "title": "Sharpening/Honing Steel KK9990 9\"- Kershaw Taskmaster 2",
+    "price": "$15",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-sharpening-honing-steel-kk/7930914064.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930649745",
+    "title": "Singer Sewing Machine; Heavy Duty; priced $399.99; sale only",
+    "price": "$249",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-singer-sewing-machine/7930649745.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942723505",
+    "title": "Slide in self cleaning gas range",
+    "price": "$190",
+    "location": "woodside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/sunnyside-slide-in-self-cleaning-gas/7942723505.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909641846",
+    "title": "Slow Cooker Hamilton Beach, NEW",
+    "price": "$20",
+    "location": "Floral Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/floral-park-slow-cooker-hamilton-beach/7909641846.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943804616",
+    "title": "Slow cooker unopened Slow cooker",
+    "price": "$45",
+    "location": "New York",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/new-york-slow-cooker-unopened-slow/7943804616.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938512528",
+    "title": "Slow Cooker, Hamilton Beach Brand New",
+    "price": "$20",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-slow-cooker-hamilton/7938512528.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930643813",
+    "title": "small  appliances",
+    "price": "$0",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-small-appliances/7930643813.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7920838566",
+    "title": "sodastream FIZZI",
+    "price": "$18",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-sodastream-fizzi/7920838566.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7929359551",
+    "title": "Soft Serve Ice Cream Gelato Maker by Carpigiani",
+    "price": "$10,000",
+    "location": "Bayside",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/bayside-soft-serve-ice-cream-gelato/7929359551.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936234900",
+    "title": "Solar Swimming Pool Thermometer Floating",
+    "price": "$15",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-solar-swimming-pool/7936234900.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930644026",
+    "title": "Space Heater;  priced $129.99; This Tuesday Only $79.99",
+    "price": "$99",
+    "location": "reasonably negotiable; phone number please:by appt Only",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-space-heater-priced/7930644026.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7915397281",
+    "title": "Space-Heater 1500w brand new",
+    "price": "$10",
+    "location": "Rockaway Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/arverne-space-heater-1500w-brand-new/7915397281.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930641076",
+    "title": "Stand Mixer; Priced $99.99; reasonably negotiable",
+    "price": "$99",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-stand-mixer-priced-9999/7930641076.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942458475",
+    "title": "Stove for Sale",
+    "price": "$50",
+    "location": "Howard Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/howard-beach-stove-for-sale/7942458475.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7930155485",
+    "title": "stove gas stock pot 2 burner",
+    "price": "$550",
+    "location": "East Elmhurst",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jackson-heights-stove-gas-stock-pot/7930155485.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944189781",
+    "title": "Submersive pump",
+    "price": "$250",
+    "location": "Flushing",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/flushing-submersive-pump/7944189781.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7914833602",
+    "title": "SUMMIT SCR114L 14 Inch Reversible Compact Refrigerator BROKEN",
+    "price": "$149",
+    "location": "READ CAREFULLY. NEEDS REPAIR",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/hollis-summit-scr114l-14-inch/7914833602.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937964096",
+    "title": "Sunbeam 700W Countertop Microwave (Model SBM7700W) \u2013 White",
+    "price": "$30",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-sunbeam-700w-countertop/7937964096.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7924762288",
+    "title": "Tazpi TW-E30 Range Hood Wall Mount 30\" 1200 CFM, Ducted/Ductless NIB",
+    "price": "$275",
+    "location": "Kew Gardens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/kew-gardens-tazpi-tw-e30-range-hood/7924762288.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939913012",
+    "title": "THREE (3) BRAND NEW IN BOX MISEN 18\" 5PLY STAINLESS ROASTING PAN",
+    "price": "$275",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-three-brand-new-in-box-misen-18/7939913012.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939912771",
+    "title": "THREE (3) MADE IN CARBON STEEL NONSTICK FRYING PAN SET",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-three-made-in-carbon-steel/7939912771.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939912315",
+    "title": "THREE (3) OUR PLACE NONSTICK SHEETPAN STOVETOP GRIDDLE SETS MATS",
+    "price": "$275",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-three-our-place-nonstick/7939912315.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922293449",
+    "title": "Tokina 500mm F8 rmc for Nikon F mount.",
+    "price": "$99",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/queens-village-tokina-500mm-f8-rmc-for/7922293449.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944066040",
+    "title": "Towel Warmer - NEW IN BOX",
+    "price": "$90",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-towel-warmer-new-in-box/7944066040.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942158063",
+    "title": "Traeger Pro 780 Wifi Smoker",
+    "price": "$400",
+    "location": "Arverne",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/arverne-traeger-pro-780-wifi-smoker/7942158063.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939896235",
+    "title": "TUSHY Classic 3.0 Bidet Toilet Seat Attachment (Self Cleaning)",
+    "price": "$70",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-tushy-classic-30-bidet-toilet/7939896235.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942614906",
+    "title": "TV for sale - Hisense, 50 inch screen, 4K UHD Smart Google TV",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-tv-for-sale-hisense-50-inch/7942614906.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943840033",
+    "title": "Twin size bed warmer",
+    "price": "$19",
+    "location": "Lic",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-twin-size-bed-warmer/7943840033.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7919086417",
+    "title": "Twin size head board",
+    "price": "$25",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-twin-size-head-board/7919086417.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939914069",
+    "title": "TWO BEAUTIFUL LAMPS - DESK LAMP BEDROOM LAMP LIGHT",
+    "price": "$20",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-two-beautiful-lamps-desk-lamp/7939914069.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7932551907",
+    "title": "Two Large Lilac Bush and Tree Plants - Exquisite Fragrance",
+    "price": "$50",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-two-large-lilac-bush-and-tree/7932551907.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921110492",
+    "title": "Two pull out glass doors freezer/ refrigerator",
+    "price": "$2,199",
+    "location": "Jamaica",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-two-pull-out-glass-doors/7921110492.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936164592",
+    "title": "Upright Vacuum Cleaner by Dyson",
+    "price": "$180",
+    "location": "Forest Hills, NY",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-upright-vacuum-cleaner-by/7936164592.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7926197568",
+    "title": "Used AC unit for sale for medium room",
+    "price": "$1",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-used-ac-unit-for-sale-for/7926197568.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7926192095",
+    "title": "Used AC unit for small room for sale",
+    "price": "$1",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-used-ac-unit-for-small-room-for/7926192095.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944179805",
+    "title": "Used window A/C(Multiple pieces)",
+    "price": "$0",
+    "location": "Jamaica Estates",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-used-window-cmultiple-pieces/7944179805.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937864152",
+    "title": "Used window AC air conditioner 8000BTU",
+    "price": "$50",
+    "location": "Hollis Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/oakland-gardens-used-window-ac-air/7937864152.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7921619223",
+    "title": "VACUUM LUX MODEL U162A IN EXCELLENT CONDITION",
+    "price": "$125",
+    "location": "Whitestone",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/whitestone-vacuum-lux-model-u162a-in/7921619223.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943984467",
+    "title": "Variety of house plants for new home",
+    "price": "$5",
+    "location": "Lic",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/long-island-city-variety-of-house/7943984467.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942924428",
+    "title": "Viking Open Burner Range Top (cooktop) Model VGRT4216 \u2013 NG or LP",
+    "price": "$1,000",
+    "location": "Ridgewood",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-viking-open-burner-range-top/7942924428.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939237697",
+    "title": "Vintage Braun Citromatic Juicer",
+    "price": "$7",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-vintage-braun-citromatic/7939237697.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7919939167",
+    "title": "Vintage Burton Snowboards and bindings",
+    "price": "$250",
+    "location": "Rockaway Beach",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/arverne-vintage-burton-snowboards-and/7919939167.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939237737",
+    "title": "Vintage Salton Drink Mixtir Blender Drink Mixer with Clear Glass",
+    "price": "$5",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-vintage-salton-drink-mixtir/7939237737.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943577110",
+    "title": "Vissani Portable A/C - 8000 BTU",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-vissani-portable-c-btu/7943577110.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7941951432",
+    "title": "Vissani Portable Air Conditioner",
+    "price": "$200",
+    "location": "Queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/jamaica-vissani-portable-air-conditioner/7941951432.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939916756",
+    "title": "VITAMIX EXPLORIAN E 310 BLENDER - LIKE NEW LITTLE USE",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-vitamix-explorian-310-blender/7939916756.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7909793538",
+    "title": "VITAMIX Foodcyler Eco 5 ($250 OBO)",
+    "price": "$250",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-vitamix-foodcyler-eco-obo/7909793538.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7938225859",
+    "title": "Washer & Dryer Set \u2014 Sell Together or Separately \ud83e\uddfa",
+    "price": "$280",
+    "location": "WOODHAVEN",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-washer-dryer-set-sell/7938225859.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7927860765",
+    "title": "Washing machine",
+    "price": "$250",
+    "location": "Queens Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/queens-village-washing-machine/7927860765.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942285881",
+    "title": "Water dispenser",
+    "price": "$0",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-water-dispenser/7942285881.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943337436",
+    "title": "Webber Genesis Grill E435",
+    "price": "$500",
+    "location": "Oakland Gardens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/oakland-gardens-webber-genesis-grill/7943337436.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7939237643",
+    "title": "West Bend Poppery II 2 Hot Air Popcorn Popper 1200W Made In USA",
+    "price": "$7",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-west-bend-poppery-ii-hot-air/7939237643.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7936546699",
+    "title": "Westinghouse Fan Ceiling Light Kit",
+    "price": "$15",
+    "location": "Forest Hills, NY 11375",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-westinghouse-fan-ceiling/7936546699.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7910506560",
+    "title": "Whirlpool  rv, travel trailer, camper,microwave",
+    "price": "$75",
+    "location": "Astoria",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/astoria-whirlpool-rv-travel-trailer/7910506560.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7937652137",
+    "title": "Whirlpool Electric Dryer",
+    "price": "$350",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ridgewood-whirlpool-electric-dryer/7937652137.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7928366819",
+    "title": "Whirlpool Gold Accudry dehumidifier",
+    "price": "$35",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/glen-rock-whirlpool-gold-accudry/7928366819.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7928744606",
+    "title": "Whirlpool OEM Gas Stove Burner Grate Rubber Foot Pads - 814383 / 81432",
+    "price": "$5",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-whirlpool-oem-gas-stove/7928744606.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943777249",
+    "title": "White Electric Standing Desk with Digital Preset Controller + Matching 3-Tier St",
+    "price": "$70",
+    "location": "Bedstuy",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-white-electric-standing-desk/7943777249.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942964932",
+    "title": "Who needs the boot removed ?",
+    "price": "$90",
+    "location": "Brooklyn",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/brooklyn-who-needs-the-boot-removed/7942964932.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7944185394",
+    "title": "Window air conditioner",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-window-air-conditioner/7944185394.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7942206727",
+    "title": "Window air conditioner",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/ozone-park-window-air-conditioner/7942206727.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7943204741",
+    "title": "Window Fan, Bionaire BWF0502M-WM - White",
+    "price": "$55",
+    "location": "queens",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-window-fan-bionaire/7943204741.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7918534696",
+    "title": "Wine cooler",
+    "price": "$999",
+    "location": "Forest Hills",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/forest-hills-wine-cooler/7918534696.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7935278794",
+    "title": "\u2744\ufe0f \ud83c\udf2c\ufe0f Window Air Conditioner \ud83d\udd34 several available!",
+    "price": "$70",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-window-air-conditioner/7935278794.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7922926974",
+    "title": "\ud83d\udd34 \ud83d\udfe2 FRIEDRICH IN WALL A/C 18000 BTU - MINT!",
+    "price": "$450",
+    "location": "Middle Village",
+    "category": "app",
+    "url": "https://newyork.craigslist.org/que/app/d/middle-village-friedrich-in-wall-c-btu/7922926974.html",
+    "matched_query": "appliances"
+  },
+  {
+    "pid": "7916819121",
+    "title": "$640 Restoration Hardware Military Chalkboard World Map",
+    "price": "$100",
+    "location": "Long Island City",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/long-island-city-640-restoration/7916819121.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7910249950",
+    "title": "169 Various size Art Mattes beveled precut (single/dual color)",
+    "price": "$255",
+    "location": "Forest Hills",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/forest-hills-169-various-size-art/7910249950.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944098071",
+    "title": "Art Deco Style Woman in Red Dress \u2013 Canvas Wall Art (Ready to Hang)",
+    "price": "$40",
+    "location": "Ridgewood",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/ridgewood-art-deco-style-woman-in-red/7944098071.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7944209179",
+    "title": "Believe Dream Imagine Wall Art \u2013 Vertical Canvas Decor",
+    "price": "$20",
+    "location": "Ridgewood",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/ridgewood-believe-dream-imagine-wall/7944209179.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7911452399",
+    "title": "Pineapple Canvas Wall Art \u2013 Tropical / Coastal Decor (20\u201d x 16\u201d)",
+    "price": "$40",
+    "location": "Ridgewood",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/ridgewood-pineapple-canvas-wall-art/7911452399.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939154165",
+    "title": "Two Ikea Multi Picture Frames (NEW)",
+    "price": "$20",
+    "location": "Forest Hills",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/forest-hills-two-ikea-multi-picture/7939154165.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7926334622",
+    "title": "Vintage Chinese Lacquer Wall Panels \u2013 Hand-Carved Soapstone Figures",
+    "price": "$130",
+    "location": "Ridgewood",
+    "category": "art",
+    "url": "https://newyork.craigslist.org/que/art/d/ridgewood-vintage-chinese-lacquer-wall/7926334622.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943609488",
+    "title": "Antique Ice Box Wooden Oak Chest w/Shelves -Gibson Cambria early 1900s",
+    "price": "$500",
+    "location": "Ridgewood, Queens",
+    "category": "atq",
+    "url": "https://newyork.craigslist.org/que/atq/d/brooklyn-antique-ice-box-wooden-oak/7943609488.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7917110850",
+    "title": "Custom Vintage Mid-Century Modern Mahogany Glass Front Hutch",
+    "price": "$4,400",
+    "location": "New York",
+    "category": "atq",
+    "url": "https://newyork.craigslist.org/que/atq/d/new-york-custom-vintage-mid-century/7917110850.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7913936377",
+    "title": "OLD TOOLS& STUFF $10 FOR ALL",
+    "price": "$10",
+    "location": "OZONE PARK",
+    "category": "atq",
+    "url": "https://newyork.craigslist.org/que/atq/d/ozone-park-old-tools-stuff-10-for-all/7913936377.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935784391",
+    "title": "Parents Moving - Must Sell: Hutch, Wardrobe, File Cabinet & Table",
+    "price": "$0",
+    "location": "Queens",
+    "category": "atq",
+    "url": "https://newyork.craigslist.org/que/atq/d/woodside-parents-moving-must-sell-hutch/7935784391.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938545823",
+    "title": "Babyletto Mercer 3-in-1 Convertible Crib",
+    "price": "$130",
+    "location": "Bay Terrace",
+    "category": "bab",
+    "url": "https://newyork.craigslist.org/que/bab/d/bayside-babyletto-mercer-in-convertible/7938545823.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939568279",
+    "title": "Like new crib",
+    "price": "$100",
+    "location": "Forest Hills",
+    "category": "bab",
+    "url": "https://newyork.craigslist.org/que/bab/d/forest-hills-like-new-crib/7939568279.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939355960",
+    "title": "Computer desk",
+    "price": "$225",
+    "location": "Brooklyn ridgewood was",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/brooklyn-computer-desk/7939355960.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939354735",
+    "title": "Desk for computer",
+    "price": "$50",
+    "location": "Brooklyn ridgewood was",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/brooklyn-desk-for-computer/7939354735.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943369573",
+    "title": "Lab Cleanup \u2013 Vacuum Deposition / ALD / Thin Film Research Equipment",
+    "price": "$0",
+    "location": "LIC",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/astoria-lab-cleanup-vacuum-deposition/7943369573.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941274391",
+    "title": "Ricoh Aficio MP C2800 Color Laser Multifunction Printer Copier",
+    "price": "$1,799",
+    "location": "Jamaica",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-mp-c2800-color/7941274391.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7928065751",
+    "title": "Ricoh Aficio MP C2800 Color Laser Multifunction Printer Copier",
+    "price": "$1,799",
+    "location": "Jamaica",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-mp-c2800-color/7928065751.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921508535",
+    "title": "Ricoh Aficio Sp C430dn Color Laser Printer",
+    "price": "$899",
+    "location": "Jamaica",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-sp-c430dn-color/7921508535.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910240007",
+    "title": "Student computer chair",
+    "price": "$25",
+    "location": "Jamaica",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/jamaica-student-computer-chair/7910240007.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7920493316",
+    "title": "Toshiba e-Studio 3540C Copier Printer",
+    "price": "$2,199",
+    "location": "Jamaica",
+    "category": "bfs",
+    "url": "https://newyork.craigslist.org/que/bfs/d/jamaica-toshiba-studio-3540c-copier/7920493316.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943391578",
+    "title": "24 Speed SPECIALIZED CROSSTRAILS Mountain Bicycle 21 inch frame",
+    "price": "$240",
+    "location": "Commack",
+    "category": "bik",
+    "url": "https://newyork.craigslist.org/que/bik/d/commack-24-speed-specialized/7943391578.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943376940",
+    "title": "Specialized Allez Elite 52CM",
+    "price": "$375",
+    "location": "Astoria",
+    "category": "bik",
+    "url": "https://newyork.craigslist.org/que/bik/d/astoria-specialized-allez-elite-52cm/7943376940.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915040720",
+    "title": "Lightning Noir",
+    "price": "$15",
+    "location": "Queens, New York City",
+    "category": "bks",
+    "url": "https://newyork.craigslist.org/que/bks/d/forest-hills-lightning-noir/7915040720.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7933206486",
+    "title": "Turn up your marketing with AI",
+    "price": "$27",
+    "location": "queens",
+    "category": "bks",
+    "url": "https://newyork.craigslist.org/que/bks/d/south-ozone-park-turn-up-your-marketing/7933206486.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7920784078",
+    "title": "Trim tab blades",
+    "price": "$1",
+    "location": "Maspeth",
+    "category": "bpo",
+    "url": "https://newyork.craigslist.org/que/bpo/d/maspeth-trim-tab-blades/7920784078.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7928333169",
+    "title": "Brenthaven Prostyle carrying case",
+    "price": "$10",
+    "location": "Kew Gardens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/jamaica-brenthaven-prostyle-carrying/7928333169.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938485077",
+    "title": "Coach Black Bag Signature Collection Limited Edition Satchel",
+    "price": "$125",
+    "location": "Hollis",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/hollis-coach-black-bag-signature/7938485077.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940447871",
+    "title": "Donna Karen New York BRAND NEW Bag",
+    "price": "$150",
+    "location": "Maspeth",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/maspeth-donna-karen-new-york-brand-new/7940447871.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939626748",
+    "title": "Dooney&Bourke All Weather Vintage Saddle Bag",
+    "price": "$95",
+    "location": "jackson heights",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/jackson-heights-dooneybourke-all/7939626748.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938208715",
+    "title": "Jet Set Charm Md Conv Pouchette Xbody Black",
+    "price": "$120",
+    "location": "Flushing",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/flushing-jet-set-charm-md-conv/7938208715.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938860784",
+    "title": "LEVEL8 Laptop Backpack, Work Backpack Computer Bag",
+    "price": "$50",
+    "location": "queens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/brooklyn-level8-laptop-backpack-work/7938860784.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915000576",
+    "title": "Litto Howler - 1.5\" Collar with Handle LIMITED EDITION Tortugas Seafoa",
+    "price": "$40",
+    "location": "Bayside",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/oakland-gardens-litto-howler-15-collar/7915000576.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939729368",
+    "title": "Lululemon Core Computer Backpack 20L Heather Gray Out of Range",
+    "price": "$15",
+    "location": "Long island city",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/long-island-city-lululemon-core/7939729368.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938012795",
+    "title": "Michael Kors Jet Set Large Sig logo Bag",
+    "price": "$80",
+    "location": "Valley Stream",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/valley-stream-michael-kors-jet-set/7938012795.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7924244131",
+    "title": "Michael Kors jet set tote",
+    "price": "$50",
+    "location": "Oakland Gardens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/oakland-gardens-michael-kors-jet-set/7924244131.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938484620",
+    "title": "Michael Kors Leather Shoulder Bag",
+    "price": "$100",
+    "location": "Hollis",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/hollis-michael-kors-leather-shoulder-bag/7938484620.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7934559345",
+    "title": "Miniseti Black Canvas Bag",
+    "price": "$10",
+    "location": "Jackson Heights",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/jackson-heights-miniseti-black-canvas/7934559345.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938715723",
+    "title": "New DKMY Black Saffiano Leather Satchel Crossbody bag",
+    "price": "$50",
+    "location": "queens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/bayside-new-dkmy-black-saffiano-leather/7938715723.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7912733085",
+    "title": "Prada Twin Pocket Tote Glace Calf BN2619",
+    "price": "$900",
+    "location": "queens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/oakland-gardens-prada-twin-pocket-tote/7912733085.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7910877330",
+    "title": "Red Suede Wedge Heels with Ankle Strap",
+    "price": "$20",
+    "location": "Sunnyside",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/sunnyside-red-suede-wedge-heels-with/7910877330.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7944115419",
+    "title": "Rolling Backpack/Wheeled Laptop Backpac",
+    "price": "$39",
+    "location": "Queens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/long-island-city-rolling-backpack/7944115419.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7926558969",
+    "title": "Seal Line Laptop Waterproof Computer Sleeve Large Padded",
+    "price": "$30",
+    "location": "astoria",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/astoria-seal-line-laptop-waterproof/7926558969.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939962152",
+    "title": "Solid wood and black leather modern computer chair!!! originally $300!",
+    "price": "$125",
+    "location": "queens",
+    "category": "clo",
+    "url": "https://newyork.craigslist.org/que/clo/d/flushing-solid-wood-and-black-leather/7939962152.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938204591",
+    "title": "2 IMAC's for sale",
+    "price": "$240",
+    "location": "queens",
+    "category": "clt",
+    "url": "https://newyork.craigslist.org/que/clt/d/maspeth-imacs-for-sale/7938204591.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940770906",
+    "title": "40\" Vintage Chinese Hand Carved Camphor Wood Chest Blanket Trunk",
+    "price": "$650",
+    "location": "Sunnyside",
+    "category": "clt",
+    "url": "https://newyork.craigslist.org/que/clt/d/sunnyside-40-vintage-chinese-hand/7940770906.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7924666735",
+    "title": "Smokeing pipes (3) 3 pipe tools / cigarette wood box",
+    "price": "$65",
+    "location": "Kew Gardens Queens",
+    "category": "clt",
+    "url": "https://newyork.craigslist.org/que/clt/d/kew-gardens-smokeing-pipes-3-pipe-tools/7924666735.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942090123",
+    "title": "2017 Ford Escape Titanium 4WD SUV",
+    "price": "$8,950",
+    "location": "Floral Park",
+    "category": "ctd",
+    "url": "https://newyork.craigslist.org/que/ctd/d/floral-park-2017-ford-escape-titanium/7942090123.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942095817",
+    "title": "2019 Nissan Sentra - Great Deal!-queens",
+    "price": "$10,995",
+    "location": "Woodside",
+    "category": "ctd",
+    "url": "https://newyork.craigslist.org/que/ctd/d/woodside-2019-nissan-sentra-great-deal/7942095817.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942442627",
+    "title": "7 SEATER MODEL Y COMP 4 AWD 63KMILES",
+    "price": "$34,550",
+    "location": "QUEENS NY",
+    "category": "cto",
+    "url": "https://newyork.craigslist.org/que/cto/d/oakland-gardens-seater-model-comp-awd/7942442627.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943108048",
+    "title": "Mercedes Benz ML350 4Matic",
+    "price": "$6,500",
+    "location": "queens",
+    "category": "cto",
+    "url": "https://newyork.craigslist.org/que/cto/d/flushing-mercedes-benz-ml350-4matic/7943108048.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7914768705",
+    "title": "* NEW * JBL Tune 125TWS Ear Buds headphones Wireless Bluetooth",
+    "price": "$50",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-jbl-tune-125tws-ear/7914768705.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914768955",
+    "title": "* NEW * Ooma Smart Security Starter Pack",
+    "price": "$140",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-ooma-smart-security/7914768955.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914768403",
+    "title": "* NEW * Pixel Buds Pro (Corel) * Earbud Headphones Ear Bud",
+    "price": "$130",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-pixel-buds-pro-corel/7914768403.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918249927",
+    "title": "10.1\" Planet Audio P100CPAC Bluetooth Multimedia Player/ Rear Camera",
+    "price": "$199",
+    "location": "Carplay and Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-101-planet-audio-p100cpac/7918249927.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931408380",
+    "title": "116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-116-peace-screwdriver/7931408380.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940103990",
+    "title": "2 Kensington headphones classic USB-A connection",
+    "price": "$15",
+    "location": "Forest Hills, Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-kensington-headphones-classic/7940103990.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938036768",
+    "title": "2- APPLE I-PADS ONE WORKS, ONE DOESN'T POWER ON!",
+    "price": "$99",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-apple-pads-one-works/7938036768.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920272303",
+    "title": "24\" DELL COMPUTER MONITOR (no base stand!)",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-dell-computer/7920272303.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920271542",
+    "title": "24\" VIZIO LED SMART TV & REMOTE CONTROL",
+    "price": "$65",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-vizio-led-smart-tv/7920271542.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921513387",
+    "title": "24\" VIZIO LED SMART TV & REMOTE CONTROL",
+    "price": "$65",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-vizio-led-smart-tv/7921513387.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918789096",
+    "title": "32\" APEX LCD TV & REMOTE CONTROL",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-apex-lcd-tv-remote/7918789096.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923891718",
+    "title": "32\" PHILLIPS FLAT SCREEN TV & REMOTE CONTROL",
+    "price": "$70",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-phillips-flat-screen/7923891718.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920271720",
+    "title": "32\" PHILLIPS FLAT SCREEN TV & REMOTE CONTROL",
+    "price": "$70",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-phillips-flat-screen/7920271720.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923646977",
+    "title": "32\" SAMSUNG LCD FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-lcd-flat/7923646977.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7919432544",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7919432544.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7922222367",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7922222367.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7912957128",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7912957128.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936784232",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7936784232.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7911614397",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7911614397.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913706345",
+    "title": "32\" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7913706345.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7929731077",
+    "title": "32\" TV",
+    "price": "$45",
+    "location": "bayside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-tv/7929731077.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933291243",
+    "title": "40 inch Samsung TV, HDTV model. Works and looks perfect",
+    "price": "$40",
+    "location": "Kew Gardens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-40-inch-samsung-tv-hdtv-model/7933291243.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943147367",
+    "title": "43 Inch Smart Monitor M7 M70F",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-43-inch-smart-monitor/7943147367.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917102366",
+    "title": "4k camera with lots of accessories -Waterproof Underwater Diving +",
+    "price": "$65",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-4k-camera-with-lots-of/7917102366.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7928058629",
+    "title": "ACCUVOICE AV155 TV SPEAKER WITH HEARING AID TECHNOLOGY",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/forest-hills-accuvoice-av155-tv-speaker/7928058629.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918789488",
+    "title": "ACER 19\" LCD COMPUTER MONITOR WORKS GREAT MODEL# A1916W",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-acer-19-lcd-computer/7918789488.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920271887",
+    "title": "ACER 19\" LCD COMPUTER MONITOR WORKS GREAT MODEL# A1916W",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-acer-19-lcd-computer/7920271887.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927559231",
+    "title": "Adcom GFA-7400 Power Amplifier 5 Channel (100 WPC)",
+    "price": "$325",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-adcom-gfa-7400-power-amplifier/7927559231.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909972500",
+    "title": "ADZEN AUDIO MIXER",
+    "price": "$380",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-adzen-audio-mixer/7909972500.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921542257",
+    "title": "Aiwa Boombox Plays CDS Cassettes & AM/FM Radio",
+    "price": "$75",
+    "location": "Flushing Queens NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-aiwa-boombox-plays-cds/7921542257.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933646444",
+    "title": "AJA IO HD MEDIA CONVERTER ANALOG/DIGITAL",
+    "price": "$200",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/astoria-aja-io-hd-media-converter/7933646444.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7911290622",
+    "title": "ALPINE S-SERIES MONO SUBWOOFER AMPLIFIER | S-A60M",
+    "price": "$99",
+    "location": "600w @2ohms",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-alpine-series-mono/7911290622.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913087248",
+    "title": "Altec Lansing High Definition Wifi Security Camera",
+    "price": "$19",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-altec-lansing-high/7913087248.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909743155",
+    "title": "Altec Lansing High Definition Wifi Security Camera",
+    "price": "$18",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-altec-lansing-high/7909743155.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913087081",
+    "title": "Amazon Fire TV 50\u201d 4K  4-Series Alexa",
+    "price": "$269",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7913087081.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913097526",
+    "title": "Amazon Fire TV 50\u201d 4K  4-Series Alexa",
+    "price": "$269",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7913097526.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909741549",
+    "title": "Amazon Fire TV 50\u201d 4K  4-Series Alexa",
+    "price": "$255",
+    "location": "Middle Village",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7909741549.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7912403751",
+    "title": "AMX ACV-2100BL Acendo Vibe Conferencing Echo Cancellation BT Sound Bar",
+    "price": "$99",
+    "location": "Bluetooth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-amx-acv-2100bl-acendo-vibe/7912403751.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936432813",
+    "title": "anker soundcore rave neo",
+    "price": "$80",
+    "location": "Jackson Heights",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jackson-heights-anker-soundcore-rave-neo/7936432813.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942754823",
+    "title": "Apple 60-Watt MagSafe Power Adapter Wall Charger",
+    "price": "$15",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-60-watt-magsafe-power/7942754823.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942755158",
+    "title": "Apple iMac 21.5\u201d Intel Quad-Core i5 2.8GHz 8GB RAM 1TB + 24GB",
+    "price": "$175",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-imac-215-intel-quad/7942755158.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7922595032",
+    "title": "Apple iPod 32gb w/extras",
+    "price": "$35",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-apple-ipod-32gb-extras/7922595032.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942755623",
+    "title": "Apple Mac Mini A1188 110W 18.5V 6.0A and A1105 85W 18.5V 4.6A Adapters",
+    "price": "$7",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-mini-w-185v-60a-and/7942755623.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942749755",
+    "title": "Apple Mac Pro 3.5GHz 6-Core Intel Xeon E5, 16GB RAM 512GB SSD",
+    "price": "$233",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-pro-35ghz-core/7942749755.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942753470",
+    "title": "Apple Mac Pro 3.7GHz Intel Xeon E5, 16GB RAM 251GB SSD",
+    "price": "$213",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-pro-37ghz-intel/7942753470.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942755963",
+    "title": "Apple MacBook 65 Watt Portable Power Adapter A1021",
+    "price": "$19",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-65-watt/7942755963.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942756002",
+    "title": "Apple MacBook Pro 13.3\u201d Retina Intel Core i5 2.7GHz 8GB RAM 128GB SSD.",
+    "price": "$195",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-pro-133-retina/7942756002.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942748074",
+    "title": "Apple MacBook Pro13.3\u201d Retina NEW BATTERY",
+    "price": "$249",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-pro133-retina/7942748074.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942761249",
+    "title": "Apple Magic Keyboard Bluetooth",
+    "price": "$35",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-magic-keyboard-bluetooth/7942761249.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943560617",
+    "title": "Apple slim USB Wired Keyboard",
+    "price": "$29",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-slim-usb-wired-keyboard/7943560617.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942754524",
+    "title": "Apple Trackpad Silver Multi-Touch Dual Sensor Wireless / Bluetooth",
+    "price": "$24",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-trackpad-silver-multi/7942754524.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942750583",
+    "title": "Apple Wireless Bluetooth Keyboard, Silver",
+    "price": "$23",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-apple-wireless-bluetooth/7942750583.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914559340",
+    "title": "Art 4330937335 C1 Cardiod FET USB Condenser Dynamic Range Microphone",
+    "price": "$79",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-art-c1-cardiod-fet-usb/7914559340.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944202944",
+    "title": "ASUS 4K Gaming / Work Monitor - 28\" - Adjustable Height / Rotate",
+    "price": "$160",
+    "location": "Financial district",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-asus-4k-gaming-work-monitor/7944202944.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914834459",
+    "title": "Atlas Sound FAP4OT Ceiling Speaker System (pair)",
+    "price": "$99",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-atlas-sound-fap4ot-ceiling/7914834459.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914794120",
+    "title": "Atlas Sound IPDC-DSE+ Sided Wall or Ceiling Mount 16 x 64 LED Display",
+    "price": "$299",
+    "location": "or Best Offer",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-atlas-sound-ipdc-dse-sided-wall/7914794120.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933091402",
+    "title": "Audio & Video Cables",
+    "price": "$15",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/corona-audio-video-cables/7933091402.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923019066",
+    "title": "AudioQuest Type 6 Bi-Wire Speaker Cables (LGC Copper;10ft & 13ft Pair)",
+    "price": "$175",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-audioquest-type-bi-wire/7923019066.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921650667",
+    "title": "B&W Speaker Spikes (Set of 4; Opened Box)",
+    "price": "$10",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-bw-speaker-spikes-set-of/7921650667.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940949165",
+    "title": "Baby blue ceramic lamps with shades pair",
+    "price": "$30",
+    "location": "Arverne",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/arverne-baby-blue-ceramic-lamps-with/7940949165.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7911815751",
+    "title": "Bang and Olufsen Beoplay S3 Bluetooth/Wired Speaker",
+    "price": "$150",
+    "location": "Broad Channel",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/far-rockaway-bang-and-olufsen-beoplay/7911815751.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917104355",
+    "title": "Beats Flex Wireless Earphones",
+    "price": "$30",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-beats-flex-wireless/7917104355.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7916744813",
+    "title": "Beats mixed wired headset with 2.0 with  MP3",
+    "price": "$55",
+    "location": "Queens ny",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixed-wired-headset/7916744813.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936498631",
+    "title": "Beats mixer headset with Sansa am/fm mp/3 player",
+    "price": "$65",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixer-headset-with/7936498631.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942971267",
+    "title": "Beats mixer wired headset",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixer-wired-headset/7942971267.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7939302971",
+    "title": "Beats wires stereo headphones",
+    "price": "$25",
+    "location": "Queens ny",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-wires-stereo/7939302971.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914832951",
+    "title": "Belkin PureAV PF60 Power Conditioner (Great Condition)",
+    "price": "$125",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-belkin-pureav-pf60-power/7914832951.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944029087",
+    "title": "Black 50 Inch Samsung 4K LED UHD 2020 Smart TV Television UN50TU7000F",
+    "price": "$350",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/woodside-black-50-inch-samsung-4k-led/7944029087.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921654202",
+    "title": "Black Metal Speaker Spikes \u2013 Set of 8 \u2013 New (No Box)",
+    "price": "$10",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-black-metal-speaker-spikes-set/7921654202.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934029295",
+    "title": "Blue Screen, Green Screen, Grey Screen White/Black Backdrop and Tripod",
+    "price": "$79",
+    "location": "Astoria",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/astoria-blue-screen-green-screen-grey/7934029295.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7935424551",
+    "title": "Bosch Optikon Binoculars Coated Lens Complete with Compass Lens Caps",
+    "price": "$30",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-bosch-optikon-binoculars/7935424551.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942753996",
+    "title": "BOSE 161 SPEAKERS",
+    "price": "$55",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-bose-161-speakers/7942753996.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751733",
+    "title": "Bose 161 Speakers & Bose VCS-10 Center Channel Speaker Surround Sound",
+    "price": "$111",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-bose-161-speakers-bose-vcs-10/7942751733.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941869829",
+    "title": "BOSE Acoustimass 16 Home Entertainment Center.",
+    "price": "$250",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-bose-acoustimass-16-home/7941869829.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941981166",
+    "title": "Bose Acoustimass 3 Series III Subwoofer & Satellite Speakers",
+    "price": "$70",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-bose-acoustimass-series-iii/7941981166.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941980194",
+    "title": "Bose Acoustimass 7 Speaker System Subwoofer & 3 Satellites Wall Mounts",
+    "price": "$100",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-bose-acoustimass-speaker/7941980194.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925708470",
+    "title": "BOSE Acoustimass*5 Series II Speaker System",
+    "price": "$25",
+    "location": "Glendale",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-bose-acoustimass5-series-ii/7925708470.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936795349",
+    "title": "Bose Companion 2 Series II Multimedia Powered Computer Speakers Nice",
+    "price": "$45",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-bose-companion-series-ii/7936795349.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942754649",
+    "title": "BOSE VCS-10 CENTER CHANNEL SPEAKER",
+    "price": "$55",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-bose-vcs-10-center-channel/7942754649.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924666676",
+    "title": "Bose wired headset w/case",
+    "price": "$65",
+    "location": "Queens ny",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-bose-wired-headset-case/7924666676.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7910133765",
+    "title": "Bose wired headset.      W/case \u2026..",
+    "price": "$20",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-bose-wired-headset-case/7910133765.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926984249",
+    "title": "Boston Acoustics A60 Bookshelf Speakers New Foam Surrounds Black",
+    "price": "$90",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-boston-acoustics-a60/7926984249.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941638572",
+    "title": "Brand New Bissell 1974 SmartClean Robot Vacuum",
+    "price": "$38",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-brand-new-bissell-1974/7941638572.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921814823",
+    "title": "Brand New Blend Jet In Box",
+    "price": "$35",
+    "location": "Flushing Queens NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-brand-new-blend-jet-in-box/7921814823.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944134506",
+    "title": "Brand new Dell u3225q 32in 4k 120htz monitor",
+    "price": "$500",
+    "location": "Woodhaven",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/woodhaven-brand-new-dell-u3225q-32in-4k/7944134506.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917173518",
+    "title": "Brand new HID and led Headlights  \ud83d\ude97",
+    "price": "$0",
+    "location": "18 months warranty - Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-brand-new-hid-and-led/7917173518.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943404779",
+    "title": "brand new HP monitor V24i FHD never open",
+    "price": "$100",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-brand-new-hp-monitor-v24i-fhd/7943404779.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913098738",
+    "title": "Brand new JBL Tune 660NC On-ear noise canceling wireless headphones",
+    "price": "$69",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/maspeth-brand-new-jbl-tune-660nc-on-ear/7913098738.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944204978",
+    "title": "Brand New Yamaha YAS-201 Sound Bar + Wireless Subwoofer",
+    "price": "$150",
+    "location": "Brooklyn",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/brooklyn-brand-new-yamaha-yas-201-sound/7944204978.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943974822",
+    "title": "Brother MFC-7840W All-In-One Laser Printer - for repair. Toner include",
+    "price": "$40",
+    "location": "Forest Hills",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/forest-hills-brother-mfc-7840w-all-in/7943974822.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941486021",
+    "title": "Camera bag - WANDRD PRVKE 21L v3",
+    "price": "$130",
+    "location": "corona",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/corona-camera-bag-wandrd-prvke-21l-v3/7941486021.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944148552",
+    "title": "Canon PC940 Copier/Printer in Good Condition!",
+    "price": "$120",
+    "location": "Douglaston",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/little-neck-canon-pc940-copier-printer/7944148552.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7912211780",
+    "title": "CANON PIXMA TR4720 WIRELESS ALL-IN-ONE INKJET PRINTER | 5074C002 | NEW",
+    "price": "$75",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-canon-pixma-tr4720/7912211780.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7916490377",
+    "title": "Cerwin-Vega B52 \u2013 Stealth Bomber Series 2-Channel Class D Amplifier",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-cerwin-vega-b52-stealth/7916490377.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917103890",
+    "title": "Charger Dock Compatible with Fitbit",
+    "price": "$15",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-charger-dock/7917103890.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7911305528",
+    "title": "Classic marantz stereo receiver 2230 ( no-cabinet)",
+    "price": "$235",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-classic-marantz-stereo/7911305528.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909772098",
+    "title": "COBY HI-FI STEREO EARPHONES CV-E20 (NEW IN PACKAGE)",
+    "price": "$10",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/coby-hi-fi-stereo-earphones-cv-e20-new/7909772098.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925715880",
+    "title": "COBY Progressive DVD player",
+    "price": "$40",
+    "location": "Glendale",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-coby-progressive-dvd-player/7925715880.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7930284925",
+    "title": "COMPUTER CONTROL CENTER",
+    "price": "$20",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-control-center/7930284925.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923219119",
+    "title": "COMPUTER CONTROL CENTER",
+    "price": "$20",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-control-center/7923219119.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938484798",
+    "title": "Computer Keyboard",
+    "price": "$10",
+    "location": "Rego Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-computer-keyboard/7938484798.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938485325",
+    "title": "Computer Keyboard Apple",
+    "price": "$10",
+    "location": "Rego Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-computer-keyboard-apple/7938485325.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913902641",
+    "title": "Computer Monitors",
+    "price": "$30",
+    "location": "Ozone Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ozone-park-computer-monitors/7913902641.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7924503553",
+    "title": "COMPUTER MONITORS: 15\" 17\" & 19\" & DELL, HP",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7924503553.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923218778",
+    "title": "COMPUTER MONITORS: 15\" 17\" & 19\" & DELL, HP",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7923218778.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7922219484",
+    "title": "COMPUTER MONITORS: 15\" 17\" & 19\" & DELL, HP",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7922219484.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944121660",
+    "title": "Crown D75 Power Amp",
+    "price": "$289",
+    "location": "Forest Hills",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/forest-hills-crown-d75-power-amp/7944121660.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931322020",
+    "title": "Dayton Audio APA150 150W Power Amplifier/Subwoofer Amp/Monoblock",
+    "price": "$125",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-dayton-audio-apa-power/7931322020.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909804400",
+    "title": "Definitive Technology ProCenter 60 Center Speaker",
+    "price": "$45",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-definitive-technology/7909804400.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944120924",
+    "title": "Definitive Technology SM55 Bookshelf speakers",
+    "price": "$350",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/forest-hills-definitive-technology-sm55/7944120924.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942923477",
+    "title": "Denon AVR-3806 7.1 Channel AV Receiver (Phono Support; Made in Japan)",
+    "price": "$160",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-denon-avr-channel-av-receiver/7942923477.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914524659",
+    "title": "DIGITAL PROJECTION TITAN HD-500 720P CONFERENCE ROOM PROJECTOR",
+    "price": "$499",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-digital-projection-titan/7914524659.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7905892953",
+    "title": "Doll",
+    "price": "$6",
+    "location": "ridgewood",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/doll/7905892953.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941904390",
+    "title": "Don't miss this.. 2 in 1 touchscreen HP. Laptop",
+    "price": "$300",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-dont-miss-this-in/7941904390.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914532160",
+    "title": "DUKANE I-PRO 456-8806 Replacement 300Watts & 2000 Hours Projector Lamp",
+    "price": "$39",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-dukane-pro-replacement/7914532160.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942230716",
+    "title": "Dyson Zone Active Noise-Cancelling headphones WP01 - ULTRA BLUE - New",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-dyson-zone-active-noise/7942230716.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942753775",
+    "title": "EA Sports UFC for Sony PlayStation 4, PS4.",
+    "price": "$9",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-ea-sports-ufc-for-sony/7942753775.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921071460",
+    "title": "EERO 6 Router",
+    "price": "$35",
+    "location": "New York",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-eero-router/7921071460.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934166769",
+    "title": "Elgato Collapsible Green Screen Chroma Key Panel - Like New",
+    "price": "$140",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-elgato-collapsible/7934166769.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934166796",
+    "title": "Elgato Wave XLR USB-C Audio Interface Like New",
+    "price": "$125",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-elgato-wave-xlr-usb/7934166796.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937970936",
+    "title": "Episode 2-Channel Power Amplifier (Class D Amp; 95 WPC)",
+    "price": "$175",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-episode-channel-power/7937970936.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924319721",
+    "title": "Excellent 2 in 1 HP touchscreen laptop",
+    "price": "$300",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-excellent-in-hp/7924319721.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7908187453",
+    "title": "EXP 48 PRO Medical Grade Battery",
+    "price": "$250",
+    "location": "Ozone Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ozone-park-exp-48-pro-medical-grade/7908187453.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940104273",
+    "title": "Facial Recognition record + Temperature Scan - perfect for business",
+    "price": "$150",
+    "location": "Astoria",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/astoria-facial-recognition-record/7940104273.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917446931",
+    "title": "Fender American Stratocaster pickups post 2000 Staggered",
+    "price": "$110",
+    "location": "BELLEROSE MANOR",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-fender-american/7917446931.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921737837",
+    "title": "Fender custom Shop Texas Specials Pickup set",
+    "price": "$210",
+    "location": "BELLEROSE MANOR",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-fender-custom-shop-texas/7921737837.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940424348",
+    "title": "FIRESTICK Movies Shows and over 1500 Games (SPECIAL SETUP)",
+    "price": "$60",
+    "location": "NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-firestick-movies-shows-and/7940424348.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913089454",
+    "title": "FITBIT CHARGE 3, EXCELLENT CONDITION",
+    "price": "$69",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-fitbit-charge-excellent/7913089454.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909739564",
+    "title": "FITBIT CHARGE 3, EXCELLENT CONDITION",
+    "price": "$69",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-fitbit-charge-excellent/7909739564.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941490425",
+    "title": "Fitbit Versa 4 Advanced Health & Fitness Tracker Smartwatch",
+    "price": "$97",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-fitbit-versa-advanced-health/7941490425.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918595570",
+    "title": "Friedman Twin Sister and 2x12 Bottom",
+    "price": "$3,000",
+    "location": "Queens Village",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-friedman-twin-sister-and/7918595570.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914796241",
+    "title": "FSR T3-MJ+1B-BLACK Table Top Microphone Insert box (1-Button/1-LED)",
+    "price": "$99",
+    "location": "or Best Offer",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-fsr-t3-mj1b-black-table/7914796241.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941632505",
+    "title": "Garmin Edge 705 cycling computer",
+    "price": "$100",
+    "location": "Howard Beach",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/howard-beach-garmin-edge-705-cycling/7941632505.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942342023",
+    "title": "Gen sound vintage preamp",
+    "price": "$65",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7942342023.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920873478",
+    "title": "Gen sound vintage preamp",
+    "price": "$40",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7920873478.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940953342",
+    "title": "Gen sound vintage preamp",
+    "price": "$65",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7940953342.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914588006",
+    "title": "Gen sound vintage preamp",
+    "price": "$65",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7914588006.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7932652583",
+    "title": "Google AC-1304 1 Port 1200Mbps Wireless Router",
+    "price": "$35",
+    "location": "Sunnyside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/sunnyside-google-ac-port-1200mbps/7932652583.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917100985",
+    "title": "Guitar Transmitter Receiver Wireless",
+    "price": "$30",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-guitar-transmitter/7917100985.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7906519074",
+    "title": "H&M Wired Headphones Girl Kids Pink",
+    "price": "$9",
+    "location": "Howard Beach",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/howard-beach-hm-wired-headphones-girl/7906519074.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913098047",
+    "title": "Heygelo Drone S90 for adults",
+    "price": "$19",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-heygelo-drone-s90-for/7913098047.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943657817",
+    "title": "HFT 12 Volt Heater / Defroster With Light",
+    "price": "$20",
+    "location": "Whitestone NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-hft-12-volt-heater-defroster/7943657817.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931316472",
+    "title": "Hifonics ZD-2550.1D Zeus Delta 2500 Watt Mono Block Amplifier",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-hifonics-zd-25501d-zeus/7931316472.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937610500",
+    "title": "Hisense 50\u201d U6 Quantum ULED 4K Fire TV - $100",
+    "price": "$100",
+    "location": "Ridgewood",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-hisense-50-u6-quantum-uled-4k/7937610500.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937608519",
+    "title": "Honeywell home alarm components & IP Cam $150 obo",
+    "price": "$50",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/corona-honeywell-home-alarm-components/7937608519.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917103705",
+    "title": "HP  LAPTOP BAG",
+    "price": "$25",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-hp-laptop-bag/7917103705.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7939634392",
+    "title": "Hubbell CFB2G25RCRE 2\u2011Gang Floor Box Assembly \u2013 New",
+    "price": "$60",
+    "location": "middle village",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-hubbell-cfb2g25rcre/7939634392.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914531466",
+    "title": "IC REALTIME VANDAL DOME NETWORK CAMERA | IPFX-D40V-IRW2 | NEW OPEN BOX",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-ic-realtime-vandal-dome/7914531466.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918790403",
+    "title": "IKEA LAMP COOL LOOKING WHITE FLORSCENT TYPE",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-ikea-lamp-cool-looking/7918790403.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934004463",
+    "title": "Illuminated Address Light Fixture",
+    "price": "$35",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-illuminated-address-light/7934004463.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7923182142",
+    "title": "Inspire Ladies Cotton Underwear 2  In Package X 5 Size  M",
+    "price": "$10",
+    "location": "Flushing Queens NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-inspire-ladies-cotton/7923182142.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923179654",
+    "title": "InspireVinyl Exsmination Gloves Size M Box 100 CT",
+    "price": "$5",
+    "location": "Flushing Queens NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/new-york-inspirevinyl-exsmination/7923179654.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920871825",
+    "title": "IPhone 7 32gb like new unlocked",
+    "price": "$110",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-iphone-32gb-like-new/7920871825.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915868201",
+    "title": "IPhone 7 32gb like new unlocked",
+    "price": "$110",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-iphone-32gb-like-new/7915868201.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937627013",
+    "title": "Jabra Evolve2 65",
+    "price": "$60",
+    "location": "Forest hills",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-jabra-evolve2-65/7937627013.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941072343",
+    "title": "Jbl Bluetooth headset with charge cable and plug",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7941072343.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943369193",
+    "title": "Jbl Bluetooth headset with charge cable and plug",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7943369193.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918836234",
+    "title": "Jbl Bluetooth headset with charge cable and plug",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7918836234.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914075234",
+    "title": "JBL COMPACT DESKTOP REFERENCE MONITOR SPEAKERS  JBL104BT",
+    "price": "$99",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-jbl-compact-desktop/7914075234.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927963336",
+    "title": "JBL CONTROL 45C/T 5.25\" COAXIAL CEILING LOUDSPEAKER PAIR WHITE NEW",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-jbl-control-45c-525/7927963336.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913087790",
+    "title": "JBL Tune 660NC On-ear noise canceling wireless headphones",
+    "price": "$69",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/maspeth-jbl-tune-660nc-on-ear-noise/7913087790.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7909738327",
+    "title": "JBL Tune 660NC On-ear noise canceling wireless headphones",
+    "price": "$77",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/maspeth-jbl-tune-660nc-on-ear-noise/7909738327.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914216273",
+    "title": "JVC 6.8\" BLUETOOTH DIGITAL MULTIMEDIA RECEIVER KW-M180BT",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-68-bluetooth-digital/7914216273.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933092824",
+    "title": "JVC 6.8\" DIGITAL BLUETOOTH MULTIMEDIA RECEIVER KW-M590BT",
+    "price": "$199",
+    "location": "Apple Carplay/Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-68-digital-bluetooth/7933092824.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7939778670",
+    "title": "JVC 6.8\" MULTIMEDIA DVD RECEIVER WITH BLUETOOTH KW-V850BT",
+    "price": "$139",
+    "location": "Carplay and Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-jvc-68-multimedia-dvd-receiver/7939778670.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925072457",
+    "title": "JVC Arsenal KW-NT800HDT  Audio/Video GPS Navigation System CD/DVD. B/T",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-arsenal-kw-nt800hdt/7925072457.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927553897",
+    "title": "JVC XV-N650 DVD Player (Tested and Working)",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-jvc-xv-n650-dvd-player-tested/7927553897.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943657595",
+    "title": "K 903 XD Karaoke Stereo Intergrated Mixer",
+    "price": "$100",
+    "location": "Whitestone  NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-903-xd-karaoke-stereo/7943657595.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943657706",
+    "title": "KEF  Speakers",
+    "price": "$100",
+    "location": "Whitestone  NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-kef-speakers/7943657706.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926796507",
+    "title": "Kenwood CD-404 5 Disc CD Changer No Remote",
+    "price": "$30",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-kenwood-cd-disc-cd-changer/7926796507.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924673394",
+    "title": "KENWOOD CLASS D BRIDGEABLE 600W 4CH /MULTICHANNEL AMPLIFIER KAC-314",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-class-bridgeable/7924673394.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926873098",
+    "title": "Kenwood DMX706S Digitial Multimedia Bluetooth Double Din Receiver",
+    "price": "$199",
+    "location": "AppleCarplay and Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-dmx706s-digitial/7926873098.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941589451",
+    "title": "KENWOOD DOUBLE DIN DVD BLUETOOTH CAR STEREO DDX5707S",
+    "price": "$199",
+    "location": "Carplay and Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-kenwood-double-din-dvd-bluetooth/7941589451.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7929565415",
+    "title": "Kenwood KAC-511 Class D Mono Digital Bass Boost Power Amplifier 1000 W",
+    "price": "$129",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-kac-511-class-mono/7929565415.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918545487",
+    "title": "Kenwood KT-56 AM/FM Stereo Tuner (Made in Japan; Read)",
+    "price": "$10",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-kenwood-kt-56-am-fm-stereo/7918545487.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914792489",
+    "title": "KJB SC7150 Smoke Detector Camera",
+    "price": "$75",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-kjb-sc7150-smoke-detector-camera/7914792489.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927598319",
+    "title": "Klipsch KV-4 Center Speaker - Audiophile Grade",
+    "price": "$275",
+    "location": "Elmhurst",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-klipsch-kv-center-speaker/7927598319.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924259918",
+    "title": "Klipsch SC.5 - High-Performance Center Channel Speaker",
+    "price": "$65",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-klipsch-sc5-high-performance/7924259918.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751655",
+    "title": "Kn\u00f6ll ll Systems 4 Zone Stereo Speakers Multiroom Interface NOS",
+    "price": "$25",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-knll-ll-systems-zone-stereo/7942751655.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917102816",
+    "title": "large calculator - solar powered",
+    "price": "$10",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-large-calculator-solar/7917102816.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927438866",
+    "title": "Lenovo ThinkVision P24h-20 flat screen Hi-Def Monitor (New in box)",
+    "price": "$150",
+    "location": "Ozone Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ozone-park-lenovo-thinkvision-p24h-20/7927438866.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7919433424",
+    "title": "LEVOIT SMART TRUE HEAP AIR PURIFIER MODEL# LV-PUP131S",
+    "price": "$50",
+    "location": "bayside/queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-levoit-smart-true-heap/7919433424.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7935187158",
+    "title": "LG RN5 XBOOM AUDIO SYSTEM WITH BLUETOOTH",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-lg-rn5-xboom-audio-system-with/7935187158.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927963149",
+    "title": "LG RP4 XBOOM 360 PORTABLE WIRELESS BLUETOOTH SPEAKER BURGUNDY",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-lg-rp4-xboom-360-portable/7927963149.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914867194",
+    "title": "LG RP4 XBOOM 360 PORTABLE WIRELESS BLUETOOTH SPEAKER BURGUNDY",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-lg-rp4-xboom-360-portable/7914867194.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913096867",
+    "title": "LG Tablet for sale (LG-LK430)",
+    "price": "$69",
+    "location": "maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-lg-tablet-for-sale-lg/7913096867.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914535539",
+    "title": "LG XBOOM AUDIO SYSTEM WITH BLUETOOTH | RNC5 | NEW",
+    "price": "$199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-lg-xboom-audio-system-with/7914535539.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751067",
+    "title": "Logitech NASCAR Racing Steering Wheel & Pedals for Playstation 2, PS2",
+    "price": "$28",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-logitech-nascar-racing/7942751067.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915516750",
+    "title": "LOT OF (10) BOOM BOXES AS-IS!",
+    "price": "$99",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-lot-of-10-boom-boxes-as/7915516750.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913705444",
+    "title": "LOT OF (10) BOOM BOXES AS-IS!",
+    "price": "$99",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-lot-of-10-boom-boxes-as/7913705444.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914539408",
+    "title": "LTS CMD726W 480TVL Color Dome Camera Heavy Duty Vandal Weather Proof",
+    "price": "$39",
+    "location": "each",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-lts-cmd726w-480tvl-color/7914539408.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942569957",
+    "title": "MANY FLAT SCREEN TV'S FOR SALE",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-many-flat-screen-tvs/7942569957.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917929238",
+    "title": "MARANTZ STEREOPHONIC (FACE PLATE) FOR MODEL 2270",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-marantz-stereophonic/7917929238.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7932497177",
+    "title": "Matrix Audio Series 6 S6.8 MultiRoom Audio Distribution Amp/Controller",
+    "price": "$80",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-matrix-audio-series-s68/7932497177.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921892213",
+    "title": "Memorex DBS 90 cassettes 10-Pack NOS still-sealed! 90s",
+    "price": "$40",
+    "location": "Bayside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-memorex-dbs-90-cassettes-10/7921892213.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944159121",
+    "title": "Meta Quest 3 512GB (Brand New)",
+    "price": "$495",
+    "location": "Oakland Gardens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-meta-quest-512gb-brand/7944159121.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914532727",
+    "title": "METRA 12\" DUAL SEALED SUBWOOFER ENCLOSURE | TCBX-212",
+    "price": "$65",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-metra-12-dual-sealed/7914532727.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921661461",
+    "title": "Monster Interlink 250 Stereo RCA Audio Cable / Subwoofer Cable (13 ft)",
+    "price": "$15",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-monster-interlink-250-stereo/7921661461.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914831887",
+    "title": "Monster Power HTS 3500 Power Conditioner",
+    "price": "$85",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-monster-power-hts-3500-power/7914831887.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914219108",
+    "title": "Monster ScreenClean Screen Cleaner - Small 1.52FL OZ 45ML",
+    "price": "$5",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-monster-screenclean-screen/7914219108.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944206900",
+    "title": "MSI Claw 8AI+",
+    "price": "$950",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-msi-claw-8ai/7944206900.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915693402",
+    "title": "Music Hall Maverick CD25.2 Player",
+    "price": "$350",
+    "location": "Queens Village",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-music-hall-maverick/7915693402.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940829507",
+    "title": "Nakamichi Receiver 2 (Phono Support; Excellent Sound)",
+    "price": "$185",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-nakamichi-receiver-phono/7940829507.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944058607",
+    "title": "Netgear Wifi range extender",
+    "price": "$50",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-netgear-wifi-range/7944058607.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927133579",
+    "title": "New Amazon Alexa Echo 2nd Generation(70), and Google Home Mini(30)",
+    "price": "$80",
+    "location": "rego park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/south-richmond-hill-new-amazon-alexa/7927133579.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942751932",
+    "title": "NEW Case MacBook Air 15 inch 2024 2023 M3 M2 Model A3114 A2941",
+    "price": "$12",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-new-case-macbook-air-15-inch/7942751932.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921629699",
+    "title": "NEW Galaxy Watch6 44mm Graphite BT",
+    "price": "$160",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-galaxy-watch6-44mm/7921629699.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927253702",
+    "title": "NEW Garmin Forerunner 245 Music Running GPS Watch",
+    "price": "$250",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-garmin-forerunner-245/7927253702.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7906443746",
+    "title": "NEW Garmin Forerunner 265 Running GPS Watch",
+    "price": "$330",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-garmin-forerunner-265/7906443746.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926794739",
+    "title": "New Genuine For Hisense Fire TV Voice Remote Control W DirecTv Peacock Netflix",
+    "price": "$12",
+    "location": "Sunnyside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/sunnyside-new-genuine-for-hisense-fire/7926794739.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941930408",
+    "title": "New in the original box Apple iPad 11th Gen (A16) - 11\" WiFi Blue",
+    "price": "$300",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-new-in-the-original-box-apple/7941930408.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914769283",
+    "title": "NEW Samsung Galaxy Buds Pro Wireless Earbud Headphones Phantom Black",
+    "price": "$120",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-samsung-galaxy-buds/7914769283.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914768491",
+    "title": "NEW Samsung Galaxy Buds2 True Wireless Earbud Headphones Phantom Black",
+    "price": "$90",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-samsung-galaxy-buds2/7914768491.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943403794",
+    "title": "NEW WD  Easystore 4TB External USB 3.0 Portable Hard Drive - Black",
+    "price": "$110",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-new-wd-easystore-4tb-external/7943403794.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924449223",
+    "title": "NHT VS-1.4 Center Channel Speaker",
+    "price": "$85",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-nht-vs-14-center-channel/7924449223.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942753902",
+    "title": "NILES MULTIPURPOSE MP5 IN-WALL  CEILING SPEAKERS",
+    "price": "$64",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-niles-multipurpose-mp5-in/7942753902.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7921094175",
+    "title": "Niles Svl-2 Speaker Selection Volume Control System",
+    "price": "$30",
+    "location": "Sunnyside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/sunnyside-niles-svl-speaker-selection/7921094175.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751157",
+    "title": "Nintendo GameCube GameStop Controller Wired Black",
+    "price": "$15",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-nintendo-gamecube-gamestop/7942751157.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944003058",
+    "title": "Nintendo Switch 2 Racer's Bundle + Accessories",
+    "price": "$199",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ozone-park-nintendo-switch-racers/7944003058.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751041",
+    "title": "Nintendo Wii/Wii U Super Mario Wired Fight Pad Controller",
+    "price": "$18",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-nintendo-wii-wii-super-mario/7942751041.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7929584999",
+    "title": "Noctua NH-U12A, Premium CPU Cooler with High-Performance Quiet NF-A12x25 PWM Fan",
+    "price": "$69",
+    "location": "Kew Gardens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-noctua-nh-u12a-premium-cpu/7929584999.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914216002",
+    "title": "Omnimount Dcm DUAL Ceiling Mount 37\" - 63\" Flat Panels Tvs - Up to 400",
+    "price": "$99",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-omnimount-dcm-dual-ceiling-mount/7914216002.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942755744",
+    "title": "ONKYO CENTER CHANNEL SPEAKER SKC-100",
+    "price": "$29",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-onkyo-center-channel-speaker/7942755744.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751502",
+    "title": "ONKYO CENTER CHANNEL SPEAKER SKC-100 Black Wood 100 WATT, 8 Ohm,",
+    "price": "$29",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-onkyo-center-channel-speaker/7942751502.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931321257",
+    "title": "Onkyo TX-SR304 5.1 Channel AV Receiver",
+    "price": "$60",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-onkyo-tx-sr-channel-av-receiver/7931321257.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924512874",
+    "title": "OTTERBOX DEFENDER CASE FOR IPAD PRO 12.9\"",
+    "price": "$70",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/medford-otterbox-defender-case-for-ipad/7924512874.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934452299",
+    "title": "PA SYSTEM PORTABLE MODEL# SG-15000",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-pa-system-portable/7934452299.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942750363",
+    "title": "PAC-MAN Countertop ARCADE",
+    "price": "$85",
+    "location": "Massapequa",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/massapequa-park-pac-man-countertop/7942750363.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913705505",
+    "title": "PANASONIC 32\" FLAT SCREEN TV & REMOTE CONTROL",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-32-flat/7913705505.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7938349497",
+    "title": "Panasonic DVD-RV32 DVD/CD Player",
+    "price": "$10",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-panasonic-dvd-rv32-dvd-cd/7938349497.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7930386452",
+    "title": "Panasonic sound system",
+    "price": "$70",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-panasonic-sound-system/7930386452.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925374147",
+    "title": "PANASONIC VCR 4-HEADS (NEEDS REPAIR)",
+    "price": "$20",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-vcr-heads/7925374147.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7934218724",
+    "title": "PANASONIC VINTAGE PORTABLE RADIO MODEL RF-728",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-vintage/7934218724.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941579213",
+    "title": "PC Case - Hyte Y40 ATX Mid Tower Case - White - $100 > $90",
+    "price": "$90",
+    "location": "Ridgewood",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-pc-case-hyte-y40-atx-mid/7941579213.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939740796",
+    "title": "Philips DVP5982 1080p Upscaling CD/DVD Player (USB Direct Playback)",
+    "price": "$25",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-philips-dvp-upscaling-cd-dvd/7939740796.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923004391",
+    "title": "Philips DVP642 DVD/CD Player \u2013 Tested & Working",
+    "price": "$20",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-philips-dvp642-dvd-cd-player/7923004391.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7935307995",
+    "title": "PIONEER DIGITAL AUDIO/VIDEO STEREO 100 WATTS RECIVER  VSX-516",
+    "price": "$99",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-pioneer-digital-audio/7935307995.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7932491854",
+    "title": "Pioneer Elite PRO-R05U Media Receiver - for PRO-1120HD / PRO-920HD",
+    "price": "$50",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-pioneer-elite-pro-r05u-media/7932491854.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924896289",
+    "title": "Pioneer GM-D8601 Mono subwoofer amplifier \u2014 800 watts RMS at 1 ohm",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-pioneer-gm-d8601-mono/7924896289.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942390885",
+    "title": "Pioneer Kuro PDP-6010FD 60\" 1080p HD Plasma Television",
+    "price": "$99",
+    "location": "Bayside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-pioneer-kuro-pdp-6010fd-hd/7942390885.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937388022",
+    "title": "Pioneer PD-M502 6 Disc CD Changer No Remote Untested Read",
+    "price": "$45",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-pioneer-pd-m502-disc-cd/7937388022.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914793207",
+    "title": "Pioneer PDP-503CMX 50\" Commercial Plasma Display FOR REPAIR",
+    "price": "$99",
+    "location": "READ DESCRIPTION, NEEDS REPAIR",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-pioneer-pdp-503cmx-50/7914793207.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914866236",
+    "title": "PLATINUM 3MP WIFI VIDEO DOORBELL | DB3W | WHITE | NEW OPEN BOX",
+    "price": "$49",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-platinum-3mp-wifi-video/7914866236.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926797535",
+    "title": "Polk Audio M3 Speakers Series II M3II Bookshelf",
+    "price": "$40",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-polk-audio-m3-speakers/7926797535.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942489391",
+    "title": "Polk Audio Monitor 30 bookshelf speakers",
+    "price": "$95",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-polk-audio-monitor-30/7942489391.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7941986350",
+    "title": "Polk Audio RM705 5.1 Powered Subwoofer with Satellie Speaker",
+    "price": "$150",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-polk-audio-rm-powered/7941986350.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7916161607",
+    "title": "Pre-owned Iphone XS Max 64 GB Unlocked",
+    "price": "$250",
+    "location": "Rego Park, Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-pre-owned-iphone-xs-max-64-gb/7916161607.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7916161133",
+    "title": "Pre-owned SHURE VP83F LensHopper Shotgun Microphone with Audio",
+    "price": "$130",
+    "location": "Rego Park, Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-pre-owned-shure-vp83f/7916161133.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936038151",
+    "title": "PSB Stratus C6 Audiophile Center Speaker - Rare Piano Black Finish",
+    "price": "$275",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-psb-stratus-c6-audiophile/7936038151.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7935819963",
+    "title": "Quad 11L Audiophile Bookshelf Speakers - Piano Black",
+    "price": "$250",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-quad-11l-audiophile-bookshelf/7935819963.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7911630333",
+    "title": "Quartet Glass Dry Erase White Board Desktop Computer Pad for Notetakin",
+    "price": "$19",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-quartet-glass-dry/7911630333.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913099889",
+    "title": "RAYOVAC 9v ultra pro alkaline pack of 30",
+    "price": "$29",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-rayovac-9v-ultra-pro/7913099889.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942759904",
+    "title": "RCA RT2600 650W 5.1CH SILVER HOME THEATER AUDIO VIDEO RECEIVER SYSTEM",
+    "price": "$55",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-rca-rt-51ch-silver-home/7942759904.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7911893555",
+    "title": "REALWEAR HANDS FREE INTRINSICALLY SAFE WEARABLE TABLET  HMT-1Z1 T1100S",
+    "price": "$1,199",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-realwear-hands-free/7911893555.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7939613904",
+    "title": "Rejuvenation Fenton GFCI Switch Plates \u2013 Solid Brass \u2013 Set of 4 \u2013 New",
+    "price": "$130",
+    "location": "middle village",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-rejuvenation-fenton-gfci/7939613904.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7932207222",
+    "title": "Rotel RTC-950AX Preamplifier (Clean and Detailed Sound)",
+    "price": "$175",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-rotel-rtc-950ax-preamplifier/7932207222.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7912957443",
+    "title": "SAMSUNG STEREO SYSTEM WITH SPEAKERS",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-samsung-stereo-system/7912957443.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933803635",
+    "title": "SAMSUNG VCR-DVD-COMBO (DVD NOT WORKING!)",
+    "price": "$60",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-samsung-vcr-dvd-combo/7933803635.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7930811855",
+    "title": "Sanus Sonos Era 300 wall mounts",
+    "price": "$20",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-sanus-sonos-era-300/7930811855.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914216068",
+    "title": "SARAMONIC VMIC MINI COMPACT CONDENSER VIDEO MICROPHONE  VMIC MINI NEW",
+    "price": "$29",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-saramonic-vmic-mini/7914216068.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942760474",
+    "title": "SCHOOLHOUSE ELECTRIC Light Chrome Wall Sconce 7in White Muslin Glass",
+    "price": "$47",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-light/7942760474.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942761171",
+    "title": "SCHOOLHOUSE ELECTRIC Light Chrome Wall Sconce White Muslin Glass",
+    "price": "$36",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-light/7942761171.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942760739",
+    "title": "SCHOOLHOUSE ELECTRIC Sconce Bronze White Opal Glass Light 7 Inch Width",
+    "price": "$115",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-sconce/7942760739.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944009040",
+    "title": "Signal Generator",
+    "price": "$100",
+    "location": "Flushing",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-signal-generator/7944009040.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915538099",
+    "title": "Smartwatch.. Samsung Galaxy watch 4",
+    "price": "$75",
+    "location": "Fresh Meadows",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/fresh-meadows-smartwatch-samsung-galaxy/7915538099.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7910883555",
+    "title": "Sonance PS-P83T-BL 8\" Pendant Speaker High-Performance Commercial",
+    "price": "$150",
+    "location": "each",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-sonance-ps-p83t-bl-pendant/7910883555.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7928907794",
+    "title": "Sonance PS-P83WT-BL Professional Series 8 Pendant Woofer Speaker",
+    "price": "$149",
+    "location": "NO GRILLE",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-sonance-ps-p83wt-bl/7928907794.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7927595095",
+    "title": "Sonance Sonamp 260 Amplifier (One Channel Not Working)",
+    "price": "$20",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sonance-sonamp-260-amplifier/7927595095.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940828479",
+    "title": "Sonos Playbase - Premium TV Sound Base (Excellent Condition)",
+    "price": "$250",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sonos-playbase-premium-tv/7940828479.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931785790",
+    "title": "SONY 10\" Woofers 1-544-191-11",
+    "price": "$50",
+    "location": "Sunnyside",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/sunnyside-sony-10-woofers/7931785790.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7919028415",
+    "title": "SONY 3-WAY SPEAKERS",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-way-speakers/7919028415.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7930384439",
+    "title": "Sony 55 inch Tv with Rocu",
+    "price": "$80",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-sony-55-inch-tv-with-rocu/7930384439.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7929797161",
+    "title": "SONY 6.95\" DIGITAL BLUETOOTH MULTIMEDIA RECEIVER XAV-AX4000",
+    "price": "$349",
+    "location": "Carplay and Android Auto",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-sony-695-digital-bluetooth/7929797161.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944099092",
+    "title": "Sony A7ii",
+    "price": "$875",
+    "location": "Rego Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-sony-a7ii/7944099092.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923223221",
+    "title": "SONY AUDIO/VIDEO 5.1 STEREO RECEIVER 100 WATTS PER CH MODEL# STR-K740P",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-audio-video-51/7923223221.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926796251",
+    "title": "Sony CDP-CE375 5-DISC CD Changer w/Remote May Be New",
+    "price": "$60",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-sony-cdp-ce375-disc-cd/7926796251.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7924471605",
+    "title": "Sony CDP-CE375 5-Disc CD Changer \u2013 Tested & Working",
+    "price": "$95",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sony-cdp-ce375-disc-cd-changer/7924471605.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923006254",
+    "title": "Sony DVP-NS50P DVD/CD Player \u2013 Tested & Working",
+    "price": "$20",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sony-dvp-ns50p-dvd-cd-player/7923006254.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937899613",
+    "title": "Sony FE 35mm",
+    "price": "$230",
+    "location": "corona",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/corona-sony-fe-35mm/7937899613.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942750061",
+    "title": "SONY HOME THEATER",
+    "price": "$65",
+    "location": "Massapequa",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/massapequa-park-sony-home-theater/7942750061.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914833051",
+    "title": "Sony LTS - CMD718W 36 IR LED Color Dome Camera",
+    "price": "$39",
+    "location": "each",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-sony-lts-cmd718w-36-ir-led/7914833051.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7931530747",
+    "title": "Sony PlayStation 3 Video Game System Fat Console only",
+    "price": "$110",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/maspeth-sony-playstation-video-game/7931530747.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918790725",
+    "title": "SONY PORTABLE AM-FM- C/D PLAYER",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-portable-am-fm-d/7918790725.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7919877226",
+    "title": "Sony Portable Bluetooth Speaker \u2013 Extra Bass, Waterproof, Party Ready",
+    "price": "$59",
+    "location": "Jackson Heights",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jackson-heights-sony-portable-bluetooth/7919877226.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943825138",
+    "title": "Sony portable dvd w/Bose headset won\u2019t seperate sold together",
+    "price": "$75",
+    "location": "Kew Gardens Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7943825138.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940572576",
+    "title": "Sony portable dvd w/Bose headset won\u2019t seperate sold together",
+    "price": "$0",
+    "location": "Kew Gardens Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7940572576.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925100494",
+    "title": "Sony portable dvd w/Bose headset won\u2019t seperate sold together",
+    "price": "$0",
+    "location": "Kew Gardens Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7925100494.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944098680",
+    "title": "Sony SCD-777ES",
+    "price": "$1,200",
+    "location": "Rego Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-sony-scd-777es/7944098680.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944118662",
+    "title": "Sony STJ75 FM Tuner",
+    "price": "$209",
+    "location": "Forest Hills",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/forest-hills-sony-stj75-fm-tuner/7944118662.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942924856",
+    "title": "Sony TA-AV531 Integrated Amplifier (Phono Support; 100 WPC)",
+    "price": "$115",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sony-ta-av531-integrated/7942924856.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918293592",
+    "title": "Sony TA-E77ESD Preamp (Flagship ES Preamplifier; Made in Japan)",
+    "price": "$550",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-sony-ta-e77esd-preamp-flagship/7918293592.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915589927",
+    "title": "Sony, Panasonic and Samsung TVs cheap must sell ASAP",
+    "price": "$25",
+    "location": "Ozone Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ozone-park-sony-panasonic-and-samsung/7915589927.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917201165",
+    "title": "Sound Bar",
+    "price": "$70",
+    "location": "Saint Albans",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-sound-bar/7917201165.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914798594",
+    "title": "Spectra Series LED PAR 100W RGBA - White (120v-220v) SPOT/STAGE LIGHT/",
+    "price": "$599",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/hollis-spectra-series-led-par-100w-rgba/7914798594.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942759866",
+    "title": "Star Trek Scene It The DVD Game Deluxe Edition New with real Star Trek",
+    "price": "$12",
+    "location": "RIDGEWOOD 11385",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-star-trek-scene-it-the-dvd/7942759866.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7918566226",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7918566226.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7923439373",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7923439373.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7911948138",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7911948138.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934852281",
+    "title": "Tandberg TR-2025 Stereo Receiver (Made in Norway; Everything Works)",
+    "price": "$295",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-tandberg-tr-2025-stereo/7934852281.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914835210",
+    "title": "TechLogix Networx TL-TP70-HDC HDMI & Cable Extender set",
+    "price": "$99",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/saint-albans-techlogix-networx-tl-tp70/7914835210.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917108719",
+    "title": "Teeran Android Auto Wireless Adapter for OEM Factory Wired Android Aut",
+    "price": "$40",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-teeran-android-auto/7917108719.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917101673",
+    "title": "Texas Instruments BA II Plus Financial Calculator, Black Medium",
+    "price": "$30",
+    "location": "Long Island City",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/long-island-city-texas-instruments-ba/7917101673.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7938781595",
+    "title": "Tools electric or battery and more.",
+    "price": "$0",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/maspeth-tools-electric-or-battery-and/7938781595.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942518187",
+    "title": "TOSHIBA 24\" 24L4200U Full HD",
+    "price": "$44",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-toshiba-24-24l4200u-full-hd/7942518187.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942754594",
+    "title": "TOSHIBA 24\" 24L4200U HDTV",
+    "price": "$45",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-toshiba-24-24l4200u-hdtv/7942754594.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7939740079",
+    "title": "Toshiba D-R400 DVD Recorder (VCR/Camcorder to DVD; w/ Remote)",
+    "price": "$90",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-toshiba-r400-dvd-recorder-vcr/7939740079.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7937501571",
+    "title": "TOSHIBA HQ VCR WORKS ONLY ON 2- HOUR SPEED",
+    "price": "$40",
+    "location": "BAYSIDE/QUEENS",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/oakland-gardens-toshiba-hq-vcr-works/7937501571.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944065898",
+    "title": "Towel Warmer - NEW IN BOX",
+    "price": "$90",
+    "location": "Ridgewood",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/brooklyn-towel-warmer-new-in-box/7944065898.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7925133697",
+    "title": "TP-Link AC1750 Wireless Dual Band Gigabit Router",
+    "price": "$50",
+    "location": "SunnySide",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/sunnyside-tp-link-ac1750-wireless-dual/7925133697.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913452460",
+    "title": "TV bracket loctek  14\"-40\"articulating flat panel TV bracket",
+    "price": "$20",
+    "location": "Astoria",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/astoria-tv-bracket-loctek-14/7913452460.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930385719",
+    "title": "Tv stand",
+    "price": "$80",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-tv-stand/7930385719.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914219482",
+    "title": "Vanguard Dynamics  6 Zone Speaker Selector",
+    "price": "$75",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-vanguard-dynamics-zone-speaker/7914219482.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7914526126",
+    "title": "Vanguard Dynamics FLC-600 6 1/2\" 2-Way Flangeless In Ceiling Speaker",
+    "price": "$59",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/jamaica-vanguard-dynamics-flc-way/7914526126.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7915652891",
+    "title": "Velodyne vLeve On-Ear Headphones - New Open Box + Free Skins",
+    "price": "$10",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-velodyne-vleve-on-ear/7915652891.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7920446029",
+    "title": "ViewSonic VP930b 19\" LCD Swivel Computer Monitor",
+    "price": "$20",
+    "location": "Astoria",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/astoria-viewsonic-vp930b-19-lcd-swivel/7920446029.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930213146",
+    "title": "Vintage Adcom GTP-500 II Preamp-Tuner with Remote Works Great",
+    "price": "$200",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-vintage-adcom-gtp-500-ii/7930213146.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942751471",
+    "title": "Vintage Argus Supplementary Wide Angle & Telephoto Lens with Case",
+    "price": "$14",
+    "location": "Ridgewood 11385 Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/ridgewood-vintage-argus-supplementary/7942751471.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7933318950",
+    "title": "Vintage KEF Coda 70  Bookshelf Speakers",
+    "price": "$90",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/flushing-vintage-kef-coda-70-bookshelf/7933318950.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7922618238",
+    "title": "Vintage Koss M65 Plus Dina-Mite Bookshelf Speakers",
+    "price": "$40",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-vintage-koss-m65-plus-dina/7922618238.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936744912",
+    "title": "Vintage NHT Super Zero Bookshelf Speakers A450 Very Nice!",
+    "price": "$90",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-vintage-nht-super-zero/7936744912.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7926807916",
+    "title": "Vintage Pioneer T-3300 Cassette Deck Needs Repair",
+    "price": "$25",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-vintage-pioneer-3300/7926807916.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7936745412",
+    "title": "Vintage Technics SA-EX500 NOS Surround Sound Stereo Receiver",
+    "price": "$125",
+    "location": "queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/floral-park-vintage-technics-sa-ex500/7936745412.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7944139403",
+    "title": "Vintage Wharfedale Speakers",
+    "price": "$150",
+    "location": "Elmhurst",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-vintage-wharfedale-speakers/7944139403.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942493402",
+    "title": "Vizio 22 inch 1080p TV with power cable and programmable remote",
+    "price": "$25",
+    "location": "Rego Park",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/rego-park-vizio-22-inch-1080p-tv-with/7942493402.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7913099141",
+    "title": "Westek 3 pack adjustable white battery operated LED Light",
+    "price": "$19",
+    "location": "Maspeth",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/middle-village-westek-pack-adjustable/7913099141.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7942488401",
+    "title": "Yamaha AVENTAGE RX-A780 7.2 Channel Receiver (4K Video;Burr-Brown DAC)",
+    "price": "$225",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-aventage-rx-channel/7942488401.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7928365340",
+    "title": "Yamaha CDC-597 CD Changer (for parts or repair)",
+    "price": "$15",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-cdc-597-cd-changer-for/7928365340.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7943657512",
+    "title": "Yamaha Center Speaker",
+    "price": "$20",
+    "location": "Whitestone  NY",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/bayside-yamaha-center-speaker/7943657512.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7932206165",
+    "title": "Yamaha NS-C210 Center Channel Speaker",
+    "price": "$55",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-ns-c210-center-channel/7932206165.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7928698281",
+    "title": "YamahaNatural Sound CD Player (Made in Japan; Audiophile Grade)",
+    "price": "$95",
+    "location": "Queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/elmhurst-yamahanatural-sound-cd-player/7928698281.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7917172985",
+    "title": "\u2588 JDM Made in Japan Xenon light HID Kit",
+    "price": "$70",
+    "location": "18 mths warranty queens",
+    "category": "ele",
+    "url": "https://newyork.craigslist.org/que/ele/d/queens-village-jdm-made-in-japan-xenon/7917172985.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7938442512",
+    "title": "Custom Driveway Gates (USA Made) \u2013 Easy DIY Install + FREE Delivery",
+    "price": "$2,969",
+    "location": "queens",
+    "category": "fod",
+    "url": "https://newyork.craigslist.org/que/fod/d/floral-park-custom-driveway-gates-usa/7938442512.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943898450",
+    "title": "10 Vintage Retractable and 1 Fixed Non-Retractable Aluminum Awnings",
+    "price": "$3,000",
+    "location": "queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/astoria-10-vintage-retractable-and/7943898450.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7910247990",
+    "title": "169 Various size Art Mattes beveled precut (single/dual color)",
+    "price": "$255",
+    "location": "Forest Hills",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/forest-hills-169-various-size-art/7910247990.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937418524",
+    "title": "24\" VIZIO LED SMART TV & REMOTE CONTROL",
+    "price": "$65",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-24-vizio-led-smart-tv/7937418524.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918789377",
+    "title": "32\" APEX LCD TV & REMOTE CONTROL",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-32-apex-lcd-tv-remote/7918789377.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7924506303",
+    "title": "32\" SAMSUNG LCD FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L",
+    "price": "$85",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-32-samsung-lcd-flat/7924506303.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942123393",
+    "title": "Apollo 2-Pack 180 Degree Frameless Shower Door Hinges Chrome for 8-12mm Glass",
+    "price": "$35",
+    "location": "Flushing",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/flushing-apollo-pack-180-degree/7942123393.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7924269716",
+    "title": "Canon MicroPrinter 90",
+    "price": "$15",
+    "location": "Flatbush",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/brooklyn-canon-microprinter-90/7924269716.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942122379",
+    "title": "CRL Vienna V1E045CH 135 Degree Glass-to-Glass Hinge Polished Chrome New",
+    "price": "$75",
+    "location": "Flushing",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/flushing-crl-vienna-v1e045ch-135-degree/7942122379.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938495033",
+    "title": "Dartboard 18 inch",
+    "price": "$15",
+    "location": "Bayside",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-dartboard-18-inch/7938495033.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7920609408",
+    "title": "Defiant Collection Satin Nickel Closet Door Handle",
+    "price": "$13",
+    "location": "Forest Hills",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/forest-hills-defiant-collection-satin/7920609408.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930640346",
+    "title": "everything must go  offer best price  By appointment; phone #",
+    "price": "$0",
+    "location": "queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/jackson-heights-everything-must-go/7930640346.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7928586117",
+    "title": "Exterior Light Fixtures",
+    "price": "$10",
+    "location": "Whitestone",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/whitestone-exterior-light-fixtures/7928586117.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914121583",
+    "title": "garage sale things",
+    "price": "$2",
+    "location": "forest hills",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/forest-hills-garage-sale-things/7914121583.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7914122353",
+    "title": "gifts",
+    "price": "$2",
+    "location": "forest hills",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-gifts/7914122353.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943926489",
+    "title": "Grainfather and Homebrewing equipment",
+    "price": "$0",
+    "location": "Sunnyside Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/sunnyside-grainfather-and-homebrewing/7943926489.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7914517096",
+    "title": "IKEA Stave Mirror Rectangular Black Brown",
+    "price": "$50",
+    "location": "Ridgewood",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/ridgewood-ikea-stave-mirror-rectangular/7914517096.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7929261788",
+    "title": "ITM Tools 750TE210 1\" X 18\" SDS-plus X-cutter Rotary Hammer Bit",
+    "price": "$30",
+    "location": "queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/forest-hills-itm-tools-750te210-x-18/7929261788.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7917661091",
+    "title": "Jabra Engage 75 Wireless Headset (OBO)",
+    "price": "$145",
+    "location": "Forest Hills Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-jabra-engage-75-wireless/7917661091.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930726546",
+    "title": "Medeco lock cylinder, keys, mounting hardware. Brand new",
+    "price": "$20",
+    "location": "Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-medeco-lock-cylinder-keys/7930726546.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937463359",
+    "title": "NEW Kate Spade Staci Lily Blooms Bag",
+    "price": "$0",
+    "location": "Elmhurst",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/elmhurst-new-kate-spade-staci-lily/7937463359.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7933460229",
+    "title": "Pre-owned Chromacast Acoustic Guitar Hard Case",
+    "price": "$85",
+    "location": "Rego Park, Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-chromacast-acoustic/7933460229.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7907984077",
+    "title": "Pre-owned Epiphone Dreadnought FT-350 Guitar with Case + Accessories",
+    "price": "$225",
+    "location": "Rego Park, Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-epiphone/7907984077.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7923318177",
+    "title": "Pre-owned Onkyo TX-8020 Receiver and (2) TWO Micca MB42X Speakers",
+    "price": "$150",
+    "location": "Rego Park, Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-onkyo-tx-8020/7923318177.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7925755136",
+    "title": "Pre-owned Sound Percussion Labs Lil 3 Piece Junior Drum Set + Hardware",
+    "price": "$100",
+    "location": "Rego Park, Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-sound-percussion/7925755136.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942510542",
+    "title": "Pre-owned TP-Link G1500 Whole Home Mesh WiFi 6 System",
+    "price": "$80",
+    "location": "Rego Park, Queens",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-tp-link-g1500-whole/7942510542.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7921339774",
+    "title": "ProMaster Camera Bag",
+    "price": "$15",
+    "location": "Whitestone",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/whitestone-promaster-camera-bag/7921339774.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7919881662",
+    "title": "SHARP 22\" LCD FLAT SCREEN TV",
+    "price": "$45",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-sharp-22-lcd-flat/7919881662.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923647086",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7923647086.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7924507748",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7924507748.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7919432236",
+    "title": "T0SHIBA 24\" LED TV And REMOTE  CONTROL!",
+    "price": "$75",
+    "location": "BAYSIDE/QUEENS",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7919432236.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917666720",
+    "title": "Three 2\u201d White Vinyl Blinds",
+    "price": "$25",
+    "location": "Astoria",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/astoria-three-white-vinyl-blinds/7917666720.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943185049",
+    "title": "Vintage Floral Glass Touch Table Lamp",
+    "price": "$79",
+    "location": "Rego Park",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/rego-park-vintage-floral-glass-touch/7943185049.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7934166729",
+    "title": "WANDRD PRVKE Backpack Rhone Burgundy 15L BRAND NEW",
+    "price": "$180",
+    "location": "Long Island City",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/long-island-city-wandrd-prvke-backpack/7934166729.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7928800554",
+    "title": "Zapbox 4 | Next-gen iPhone VR Headset - TWO NEW SETS",
+    "price": "$40",
+    "location": "Long Island City",
+    "category": "for",
+    "url": "https://newyork.craigslist.org/que/for/d/long-island-city-zapbox-next-gen-iphone/7928800554.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943603588",
+    "title": "\u2605 7th Avenue / Restoration Hardware Cloud Couch Modular Sectional Sofa",
+    "price": "$6,900",
+    "location": "queens",
+    "category": "fud",
+    "url": "https://newyork.craigslist.org/que/fud/d/new-york-7th-avenue-restoration/7943603588.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7926953520",
+    "title": "2 Computer Chairs",
+    "price": "$20",
+    "location": "Greenpoint",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-computer-chairs/7926953520.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943008490",
+    "title": "30\" W x 12\" D x 30\" H Plywood Shaker Wall Kitchen Cabinet in Alpine Wh",
+    "price": "$125",
+    "location": "Long Island City",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/long-island-city-30-x-12-x-30-plywood/7943008490.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930649711",
+    "title": "Art N Craft Mobile;Priced $199.99; without drop leaf only 50, $99.99",
+    "price": "$75",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/jackson-heights-art-craft-mobilepriced/7930649711.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941231671",
+    "title": "Bedside table + Bed Computer desk",
+    "price": "$20",
+    "location": "Oakland Gardens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/oakland-gardens-bedside-table-bed/7941231671.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7909407862",
+    "title": "COMPUTER / WRITING TABLE, SOLID WOOD, NEW INPLASTIC",
+    "price": "$89",
+    "location": "woodside",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/astoria-computer-writing-table-solid/7909407862.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7916900133",
+    "title": "Computer chair",
+    "price": "$9",
+    "location": "Flushing",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/jamaica-computer-chair/7916900133.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944015833",
+    "title": "Computer Desk",
+    "price": "$20",
+    "location": "Brooklyn",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-computer-desk/7944015833.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930515405",
+    "title": "COMPUTER TABLE, SOLID WOOD IRON FRAME, NEW",
+    "price": "$99",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/astoria-computer-table-solid-wood-iron/7930515405.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7936777099",
+    "title": "Contemporary office desks computer workstations furniture",
+    "price": "$0",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/flushing-contemporary-office-desks/7936777099.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930084168",
+    "title": "Custom Architected Solid Maplewood Desk",
+    "price": "$750",
+    "location": "Secaucus, New Jersey",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/new-york-custom-architected-solid/7930084168.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936543181",
+    "title": "Decorative Rod",
+    "price": "$8",
+    "location": "Forest Hills, NY 11375",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/forest-hills-decorative-rod/7936543181.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940154866",
+    "title": "Delta-brand gray crib",
+    "price": "$40",
+    "location": "astoria",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/astoria-delta-brand-gray-crib/7940154866.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938939866",
+    "title": "Double Front Entry door MUST SELL",
+    "price": "$550",
+    "location": "Howard Beach, NY",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/howard-beach-double-front-entry-door/7938939866.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7906996146",
+    "title": "Foldable Desk",
+    "price": "$25",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/little-neck-foldable-desk/7906996146.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7935276950",
+    "title": "Folding Computer Desk",
+    "price": "$40",
+    "location": "Ridgewood",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/ridgewood-folding-computer-desk/7935276950.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939696389",
+    "title": "FOR SALE: Dark Espresso Wood L-Shaped Corner Computer Desk",
+    "price": "$150",
+    "location": "Brooklyn, Queens, Bronx",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/jackson-heights-for-sale-dark-espresso/7939696389.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7929130300",
+    "title": "Furniture Sale",
+    "price": "$100",
+    "location": "Greenpoint",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-furniture-sale/7929130300.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7929422344",
+    "title": "Furniture Sale",
+    "price": "$100",
+    "location": "Williamsburg",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-furniture-sale/7929422344.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938201343",
+    "title": "Glass Computer Desk with Grey Trim",
+    "price": "$50",
+    "location": "Queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/jamaica-glass-computer-desk-with-grey/7938201343.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941069735",
+    "title": "Harold Traditional Solid Rosewood Pedestal Dining Table Set For 12",
+    "price": "$5,600",
+    "location": "Arverne",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/arverne-harold-traditional-solid/7941069735.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7939078668",
+    "title": "Machinto Restoration Hardware Dining Table and Chairs",
+    "price": "$750",
+    "location": "Hempstead, NY",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/hempstead-machinto-restoration-hardware/7939078668.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938698445",
+    "title": "Mirror (reduced price!)",
+    "price": "$30",
+    "location": "Ridgewood",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-mirror-reduced-price/7938698445.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940919509",
+    "title": "Mirror dresser and a gentleman chest",
+    "price": "$1,000",
+    "location": "Brooklyn",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-mirror-dresser-and-gentleman/7940919509.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941882329",
+    "title": "Modern White Computer Desk with Storage \u2013 Great for Home Office / Gami",
+    "price": "$49",
+    "location": "long island city",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/long-island-city-modern-white-computer/7941882329.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938977419",
+    "title": "Nesting Coffee Tables - Glass and gold table base",
+    "price": "$75",
+    "location": "Long Island City",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/long-island-city-nesting-coffee-tables/7938977419.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914069113",
+    "title": "New dressing table, Queens bed, sofa, coffee table, computer chair",
+    "price": "$1",
+    "location": "Elmhurst",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/elmhurst-new-dressing-table-queens-bed/7914069113.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942351315",
+    "title": "Office Furniture Lot",
+    "price": "$0",
+    "location": "Ozone Park",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/ozone-park-office-furniture-lot/7942351315.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936780733",
+    "title": "Office storage cabinets and filing solutions furnriture",
+    "price": "$0",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/jamaica-office-storage-cabinets-and/7936780733.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7932913685",
+    "title": "OXO Kitchen Tools, Cheese Cutter, Pastry Cutter, Apple Corer",
+    "price": "$20",
+    "location": "New York",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/new-york-oxo-kitchen-tools-cheese/7932913685.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940897196",
+    "title": "Prescott dresser and mirror and Cambridge gentleman chest",
+    "price": "$1,000",
+    "location": "Ridgewood queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/brooklyn-prescott-dresser-and-mirror/7940897196.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937259167",
+    "title": "Privacy screen, room divider, outdoor patio furniture",
+    "price": "$40",
+    "location": "Long Island City",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/long-island-city-privacy-screen-room/7937259167.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940866605",
+    "title": "Professional Computer Desk for Sale",
+    "price": "$25",
+    "location": "Howard Beach",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/howard-beach-professional-computer-desk/7940866605.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7935117154",
+    "title": "Restoration Hardware Dining Chairs (Set of 8)",
+    "price": "$150",
+    "location": "Fresh Meadows",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/fresh-meadows-restoration-hardware/7935117154.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942779934",
+    "title": "Restoration Hardware Dresser",
+    "price": "$2,350",
+    "location": "Whitestone",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/whitestone-restoration-hardware-dresser/7942779934.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7933720760",
+    "title": "Restoration Hardware(RH) furnitures",
+    "price": "$100",
+    "location": "Bayside",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/bayside-restoration-hardwarerh/7933720760.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7935137219",
+    "title": "Rh Emery Track Arm Fabric Dining Armchairs (Set of 4)",
+    "price": "$310",
+    "location": "Fresh Meadows",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/fresh-meadows-rh-emery-track-arm-fabric/7935137219.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937406663",
+    "title": "RH Modern Industrial 5-Shelf Bookcase \u2014 Solid Wood & Steel \u2014 Nearly 8 Fee",
+    "price": "$650",
+    "location": "Ridgewood",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/ridgewood-rh-modern-industrial-shelf/7937406663.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941166655",
+    "title": "San Francisco Solid Wood China Cabinet Dining Room Hutch with Iron Grill Door",
+    "price": "$4,760",
+    "location": "Arverne",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/arverne-san-francisco-solid-wood-china/7941166655.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7944028693",
+    "title": "Solid Wood Dresser / Buffet \u2013 Cream & Cherry Finish/$400 OBO",
+    "price": "$400",
+    "location": "Elmhurst",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/elmhurst-solid-wood-dresser-buffet/7944028693.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943121411",
+    "title": "Stainless Steel Drawers",
+    "price": "$60",
+    "location": "queens",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/sunnyside-stainless-steel-drawers/7943121411.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942926466",
+    "title": "Studio Closing Sale - Furniture & Kitchen Appliances",
+    "price": "$50",
+    "location": "Long Island City",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/long-island-city-studio-closing-sale/7942926466.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943663865",
+    "title": "West Elm Reclaimed Wood 3-Drawer Console",
+    "price": "$350",
+    "location": "Little Neck",
+    "category": "fuo",
+    "url": "https://newyork.craigslist.org/que/fuo/d/little-neck-west-elm-reclaimed-wood/7943663865.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942048697",
+    "title": "Huge yard sale",
+    "price": "$0",
+    "location": "queens",
+    "category": "gms",
+    "url": "https://newyork.craigslist.org/que/gms/d/ridgewood-huge-yard-sale/7942048697.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937561494",
+    "title": "Moving Sale  all furniture and everything else",
+    "price": "$0",
+    "location": "queens ny",
+    "category": "gms",
+    "url": "https://newyork.craigslist.org/que/gms/d/jackson-heights-moving-sale-all/7937561494.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943579119",
+    "title": "Tools for sale",
+    "price": "$0",
+    "location": "queens",
+    "category": "gms",
+    "url": "https://newyork.craigslist.org/que/gms/d/brooklyn-tools-for-sale/7943579119.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942304034",
+    "title": "Workbench, tv stand, cb2 table",
+    "price": "$0",
+    "location": "Long island city",
+    "category": "gms",
+    "url": "https://newyork.craigslist.org/que/gms/d/long-island-city-workbench-tv-stand-cb2/7942304034.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938650636",
+    "title": "\ud83d\udc20 29 Gallon Aquarium Stand \u2013 Steel & MDF \u2013 Built-In Power Panel \u2013 242",
+    "price": "$103",
+    "location": "queens",
+    "category": "grd",
+    "url": "https://newyork.craigslist.org/que/grd/d/sunnyside-29-gallon-aquarium-stand/7938650636.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938221771",
+    "title": "Steel Buildings - Hay Storage - Equipment Storage - Grain Storage",
+    "price": "$1",
+    "location": "Talk To An Expert Now!",
+    "category": "grq",
+    "url": "https://newyork.craigslist.org/que/grq/d/floral-park-steel-buildings-hay-storage/7938221771.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7926002619",
+    "title": "Bolt hardware",
+    "price": "$12",
+    "location": "Ridgewood",
+    "category": "hab",
+    "url": "https://newyork.craigslist.org/que/hab/d/sunnyside-bolt-hardware/7926002619.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936487882",
+    "title": "RED LIGHT PANEL - LIKE NEW - HOOGA HG 1000",
+    "price": "$450",
+    "location": "QUEENS",
+    "category": "hab",
+    "url": "https://newyork.craigslist.org/que/hab/d/long-island-city-red-light-panel-like/7936487882.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943117127",
+    "title": "Walking Pad",
+    "price": "$50",
+    "location": "queens",
+    "category": "hab",
+    "url": "https://newyork.craigslist.org/que/hab/d/ridgewood-walking-pad/7943117127.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910249100",
+    "title": "169 Various size Art Mattes beveled precut (single/dual color)",
+    "price": "$255",
+    "location": "Forest Hills",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/forest-hills-169-various-size-art/7910249100.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940780550",
+    "title": "Black Crystal Semi-Flush Chandelier \u2013 Like New, Never Installed",
+    "price": "$45",
+    "location": "queens",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/woodhaven-black-crystal-semi-flush/7940780550.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943827942",
+    "title": "Bose Lifestyle 28 Series III DVD Media Center AV18 w/ Speakers & Sub P",
+    "price": "$250",
+    "location": "Jamaica",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/jamaica-bose-lifestyle-28-series-iii/7943827942.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937837040",
+    "title": "Bose Lifestyle 28 Series III DVD Media Center AV18 w/ Speakers & Sub P",
+    "price": "$250",
+    "location": "Jamaica",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/jamaica-bose-lifestyle-28-series-iii/7937837040.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7934229012",
+    "title": "computer stool chair",
+    "price": "$5",
+    "location": "Woodhaven",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/woodhaven-computer-stool-chair/7934229012.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913618274",
+    "title": "Decopolitan White Adjustable Curtain Rods 1' diameter - (2) Sets",
+    "price": "$40",
+    "location": "ASTORIA",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/astoria-decopolitan-white-adjustable/7913618274.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7929799250",
+    "title": "Everbilt Plast Hardware Cloth Roll Black, 1/2\" Square Mesh, 3' X 15'",
+    "price": "$30",
+    "location": "queens",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/corona-everbilt-plast-hardware-cloth/7929799250.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936697385",
+    "title": "Lampshade",
+    "price": "$15",
+    "location": "Woodside",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/woodside-lampshade/7936697385.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936697650",
+    "title": "Lampshade black",
+    "price": "$15",
+    "location": "Woodside",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/woodside-lampshade-black/7936697650.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936697147",
+    "title": "Lampshade pleated vintage cone shape",
+    "price": "$15",
+    "location": "Woodside",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/woodside-lampshade-pleated-vintage-cone/7936697147.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938659660",
+    "title": "Regina Andrew wall sconce 15-1014 PN",
+    "price": "$90",
+    "location": "queens",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/east-meadow-regina-andrew-wall-sconce-pn/7938659660.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7917637524",
+    "title": "Sanus VML10-B1 Ultra Low Profile TV wall mount 26\"-47\"",
+    "price": "$40",
+    "location": "BROOKLYN",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/brooklyn-sanus-vml10-b1-ultra-low/7917637524.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943119521",
+    "title": "Solid Oak Flat Panel Cabinet Doors / Frame",
+    "price": "$15",
+    "location": "Ozone Park",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/ozone-park-solid-oak-flat-panel-cabinet/7943119521.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7924777638",
+    "title": "Style Selections Tension Shower Curtain Rod (24\u201d\u201340\u201d)",
+    "price": "$10",
+    "location": "Bayside",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/oakland-gardens-style-selections/7924777638.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930650043",
+    "title": "Tools of the Trade, Cookware set; brand new packed",
+    "price": "$149",
+    "location": "Jackson Heights",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/jackson-heights-tools-of-the-trade/7930650043.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939598824",
+    "title": "Vintage American Tourister Escort Suitcase",
+    "price": "$20",
+    "location": "jackson heights",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/jackson-heights-vintage-american/7939598824.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7922883610",
+    "title": "Vintage Asian Wicker Basket, Purse with Asian Style Accent Closure and",
+    "price": "$37",
+    "location": "Queens",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/college-point-vintage-asian-wicker/7922883610.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7928739402",
+    "title": "West Elm Seamless Medicine Cabinet 16.5x27.5 Antique Brass - NEW IN BO",
+    "price": "$190",
+    "location": "Forest Hills",
+    "category": "hsh",
+    "url": "https://newyork.craigslist.org/que/hsh/d/forest-hills-west-elm-seamless-medicine/7928739402.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938270308",
+    "title": "Black iron sliding barndoor hardware 72\u201d",
+    "price": "$50",
+    "location": "Astoria",
+    "category": "hvo",
+    "url": "https://newyork.craigslist.org/que/hvo/d/astoria-black-iron-sliding-barndoor/7938270308.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943369704",
+    "title": "Heavy Stainless Scientific Equipment \u2013 Vacuum Chambers, Pumps, Cooling",
+    "price": "$1",
+    "location": "Astoria",
+    "category": "hvo",
+    "url": "https://newyork.craigslist.org/que/hvo/d/astoria-heavy-stainless-scientific/7943369704.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942562353",
+    "title": "Polar Hardware 301 Hinge",
+    "price": "$77",
+    "location": "queens",
+    "category": "hvo",
+    "url": "https://newyork.craigslist.org/que/hvo/d/bayside-polar-hardware-301-hinge/7942562353.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940915775",
+    "title": "#EXIT DOOR HARDWARE",
+    "price": "$50",
+    "location": "Long Island CITY",
+    "category": "mat",
+    "url": "https://newyork.craigslist.org/que/mat/d/long-island-city-exit-door-hardware/7940915775.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7912228489",
+    "title": "Garden Craft 36 in. H X 25 ft. L Galvanized Steel Hardware Cloth 1/2 i",
+    "price": "$60",
+    "location": "queens",
+    "category": "mat",
+    "url": "https://newyork.craigslist.org/que/mat/d/brooklyn-garden-craft-36-in-x-25-ft/7912228489.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943409331",
+    "title": "UNDERMOUNT SS DOUBLE SINK BLANCO WAVE NEW RETAIL $648",
+    "price": "$400",
+    "location": "queens",
+    "category": "mat",
+    "url": "https://newyork.craigslist.org/que/mat/d/whitestone-undermount-ss-double-sink/7943409331.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942328346",
+    "title": "PS5 HDMI Port  Repair",
+    "price": "$65",
+    "location": "Oakland Gardens",
+    "category": "mob",
+    "url": "https://newyork.craigslist.org/que/mob/d/oakland-gardens-ps5-hdmi-port-repair/7942328346.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943687205",
+    "title": "High-Performance Sound Absorption Rockwool Bass Traps & Acoustic Panel",
+    "price": "$0",
+    "location": "Mention this ad for a discount!",
+    "category": "msd",
+    "url": "https://newyork.craigslist.org/que/msd/d/floral-park-high-performance-sound/7943687205.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7942233880",
+    "title": "Professional Acoustic Panels & Bass Traps for Studios",
+    "price": "$0",
+    "location": "Mention this ad for a discount!",
+    "category": "msd",
+    "url": "https://newyork.craigslist.org/que/msd/d/floral-park-professional-acoustic/7942233880.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940686663",
+    "title": "Professional Acoustic Panels & Bass Traps for Studios",
+    "price": "$0",
+    "location": "Mention this ad for a discount!",
+    "category": "msd",
+    "url": "https://newyork.craigslist.org/que/msd/d/floral-park-professional-acoustic/7940686663.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937949970",
+    "title": "Superior Sound Absorption with Acoustic Panels & Bass Traps",
+    "price": "$0",
+    "location": "Mention this ad for a discount!",
+    "category": "msd",
+    "url": "https://newyork.craigslist.org/que/msd/d/floral-park-superior-sound-absorption/7937949970.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7920167249",
+    "title": "Arbiter drum set - very unique and hard to find - Clear Teal Gloss",
+    "price": "$1,550",
+    "location": "Whitestone",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/whitestone-arbiter-drum-set-very-unique/7920167249.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943921772",
+    "title": "ART PRO VLA II",
+    "price": "$225",
+    "location": "Brooklyn",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/brooklyn-art-pro-vla-ii/7943921772.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7910757992",
+    "title": "Drum hardware snare,cymbal,hi hat",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/astoria-drum-hardware-snarecymbalhi-hat/7910757992.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940161908",
+    "title": "DW Design Series w/ Collector's Bell Brass Snare & Massive Extras!",
+    "price": "$1,300",
+    "location": "Forest Hills",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/forest-hills-dw-design-series/7940161908.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7915088150",
+    "title": "Fender Prosonic 2x10 (electronically restored)Combo Mint",
+    "price": "$950",
+    "location": "BELLEROSE MANOR",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/queens-village-fender-prosonic-2x10/7915088150.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914864938",
+    "title": "Fender Prosonic Amp MINT Clean Bill of Health",
+    "price": "$950",
+    "location": "BELLEROSE MANOR",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/queens-village-fender-prosonic-amp-mint/7914864938.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936222593",
+    "title": "Groove Synthesis 3rd Wave 24m Desktop 24-voice 4-parts",
+    "price": "$3,000",
+    "location": "Queens",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/queens-village-groove-synthesis-3rd/7936222593.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914864960",
+    "title": "Heritage H-150 CUSTOM CORE (H-150)",
+    "price": "$3,200",
+    "location": "Jamaica",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/queens-village-heritage-150-custom-core/7914864960.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7917674115",
+    "title": "HERITGE H-150 CUSTOM CORE",
+    "price": "$3,200",
+    "location": "BELLEROSE MANOR",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/queens-village-heritge-150-custom-core/7917674115.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937042780",
+    "title": "Hohner G3T headless Steinberger-style guitar",
+    "price": "$519",
+    "location": "Bayside",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/bayside-hohner-g3t-headless-steinberger/7937042780.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7928023253",
+    "title": "Ibanez Hollow Body Bass Guitar Case Hard Shell AGB Artcore",
+    "price": "$175",
+    "location": "Bayside",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/bayside-ibanez-hollow-body-bass-guitar/7928023253.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7944160788",
+    "title": "Ludwig double pedal",
+    "price": "$440",
+    "location": "Astoria",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/astoria-ludwig-double-pedal/7944160788.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941580903",
+    "title": "Peavey RadialPro 1000 - Yellow - Near Mint",
+    "price": "$1,950",
+    "location": "Whitestone",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/whitestone-peavey-radialpro-yellow-near/7941580903.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7925818105",
+    "title": "Pensa Suhr Jazz Bass 1993 built by Masu Hino",
+    "price": "$5,500",
+    "location": "Great Neck, Long Island",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/great-neck-pensa-suhr-jazz-bass-1993/7925818105.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7929336632",
+    "title": "QSC CX204V\n4-Channel Power Amplifier, 200W Per Channel at 70V",
+    "price": "$335",
+    "location": "Flushing",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/flushing-qsc-cx204v-channel-power/7929336632.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7928407817",
+    "title": "The RODS David Rock Feinstein Harley Benton DC-Junior Melody Maker",
+    "price": "$420",
+    "location": "Queens",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/whitestone-the-rods-david-rock/7928407817.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7910664655",
+    "title": "WAVES LV1 SYSTEM \"Turn Key System\"  3 Server included ( PLUG / PLAY )",
+    "price": "$6,000",
+    "location": "BROOKLYN",
+    "category": "msg",
+    "url": "https://newyork.craigslist.org/que/msg/d/brooklyn-waves-lv1-system-turn-key/7910664655.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7920365653",
+    "title": "Camera, Grip, Electric, Lighting Equipment (continuously updated)",
+    "price": "$0",
+    "location": "queens",
+    "category": "pho",
+    "url": "https://newyork.craigslist.org/que/pho/d/astoria-camera-grip-electric-lighting/7920365653.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7926760906",
+    "title": "Columbus nGPS GPS for Nikon Digital SLRs Cameras",
+    "price": "$45",
+    "location": "astoria",
+    "category": "pho",
+    "url": "https://newyork.craigslist.org/que/pho/d/astoria-columbus-ngps-gps-for-nikon/7926760906.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7926554797",
+    "title": "Kingston Workflow SD Reader Micro Sd, Compact Flash readers",
+    "price": "$40",
+    "location": "astoria",
+    "category": "pho",
+    "url": "https://newyork.craigslist.org/que/pho/d/astoria-kingston-workflow-sd-reader/7926554797.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944121017",
+    "title": "Lot Of Video Gear (Hero Pro Gear and Others) and Assorted Electronics",
+    "price": "$0",
+    "location": "Flushing",
+    "category": "pho",
+    "url": "https://newyork.craigslist.org/que/pho/d/flushing-lot-of-video-gear-hero-pro/7944121017.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7940514101",
+    "title": "1999-2025 FORD SUPERDUTY PARTS- PARTS REQUEST",
+    "price": "$0",
+    "location": "queens",
+    "category": "ptd",
+    "url": "https://newyork.craigslist.org/que/ptd/d/lorain-ford-superduty-parts-parts/7940514101.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940389784",
+    "title": "2018 - 2023 Buick enclave oem running Boards",
+    "price": "$500",
+    "location": "Astoria",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/astoria-buick-enclave-oem-running-boards/7940389784.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936320602",
+    "title": "Dodge Grand Caravan Starter and Computer",
+    "price": "$90",
+    "location": "Ridgewood Queens",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/ridgewood-dodge-grand-caravan-starter/7936320602.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7926096295",
+    "title": "Mercedes Brake Rotor AMG GT - C192 R232 X254 - Front Right",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-mercedes-brake-rotor-amg-gt-c192/7926096295.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7925710832",
+    "title": "Mercedes C192 AMG GT - Upper Grille Shell - #A1928880400",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-mercedes-c192-amg-gt-upper/7925710832.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7926095325",
+    "title": "Mercedes GLE/GLS AMG - Compound Brake Rotor - Front Left #A1674213600",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-mercedes-gle-gls-amg-compound/7926095325.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7925709179",
+    "title": "Mercedes W167 GLE63 AMG - Front Grille - Panamericana #A1678887000",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-mercedes-w167-gle63-amg-front/7925709179.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7925714112",
+    "title": "Mercedes W167 X167 GLE/GLS - OE Front Windshield Glass - #A1676703001",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-mercedes-w167-x167-gle-gls-oe/7925714112.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7925019747",
+    "title": "Porsche Macan - Brushed Silver License Plate Frame - Genuine OE",
+    "price": "$1",
+    "location": "Corona",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/corona-porsche-macan-brushed-silver/7925019747.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941735851",
+    "title": "Rooftop Rack Cargo Carrier Basket  with Waterproof Cargo Bag",
+    "price": "$100",
+    "location": "South Richmond Hill",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/south-richmond-hill-rooftop-rack-cargo/7941735851.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914436216",
+    "title": "Subrau Forester 2.0 swap",
+    "price": "$6,500",
+    "location": "South Ozone Park",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/south-ozone-park-subrau-forester-20-swap/7914436216.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7932736920",
+    "title": "Toyota Tacoma OEM Trailer Wiring Receptacle Cover",
+    "price": "$10",
+    "location": "Bayside",
+    "category": "pts",
+    "url": "https://newyork.craigslist.org/que/pts/d/oakland-gardens-toyota-tacoma-oem/7932736920.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937868625",
+    "title": "#NEW VINTAGE APPLE EXTENDED KEYBOARD",
+    "price": "$100",
+    "location": "LIC",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7937868625.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941550472",
+    "title": "#NEW VINTAGE APPLE EXTENDED KEYBOARD",
+    "price": "$100",
+    "location": "LIC",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7941550472.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7914769147",
+    "title": "* NEW * Solid Gear Basix Series 600 Watt Power Supply",
+    "price": "$30",
+    "location": "Fresh Meadows",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-new-solid-gear-basix/7914769147.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941878614",
+    "title": "**Keyboards and Mouses**",
+    "price": "$15",
+    "location": "Whitestone",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/whitestone-keyboards-and-mouses/7941878614.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934451278",
+    "title": "116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-116-peace-screwdriver/7934451278.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944170593",
+    "title": "16gb (8x2) ddr4 3000 ram kit",
+    "price": "$80",
+    "location": "Ridgewood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-16gb-8x2-ddr-ram-kit/7944170593.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7919633322",
+    "title": "2 Logitech mice",
+    "price": "$35",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-logitech-mice/7919633322.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917431884",
+    "title": "2009 mac pro single CPU tray",
+    "price": "$30",
+    "location": "Elmhurst",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-2009-mac-pro-single-cpu-tray/7917431884.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913949091",
+    "title": "2010 macbook box with manual and install DVd",
+    "price": "$20",
+    "location": "Elmhurst",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-2010-macbook-box-with-manual/7913949091.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930234707",
+    "title": "24 inch display, HP brand 1920 by 1200 resolution, DP, DVI",
+    "price": "$25",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-24-inch-display-hp-brand-1920/7930234707.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940733965",
+    "title": "2x ARCTIC P9 Max 92mm PWM High Static Pressure Fans \u2013 New",
+    "price": "$20",
+    "location": "Sunnyside, NY",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-2x-arctic-p9-max-92mm-pwm/7940733965.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915032942",
+    "title": "3 OEM Apple video adapters",
+    "price": "$30",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-oem-apple-video-adapters/7915032942.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930997165",
+    "title": "32GB RAM A-TECH",
+    "price": "$40",
+    "location": "Ridgewood Glendale",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-32gb-ram-tech/7930997165.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921899094",
+    "title": "34\"+29\" DELL curved ips 2 screen setup with monitor stand + LED Lights",
+    "price": "$925",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-3429-dell-curved-ips/7921899094.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917101328",
+    "title": "34\"+29\" DELL curved ips 2 screen setup with monitor stand + LED Lights",
+    "price": "$925",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-3429-dell-curved-ips/7917101328.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943960247",
+    "title": "4-in-1 combo mobo+cpu+cooler+ram",
+    "price": "$700",
+    "location": "bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-in-combo/7943960247.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7917336925",
+    "title": "43\" LG 4k Monitor (LG43UD79-B)",
+    "price": "$200",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-43-lg-4k-monitor-lg43ud79/7917336925.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939035542",
+    "title": "5 Port Ethernet Switch",
+    "price": "$20",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-port-ethernet-switch/7939035542.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7911345838",
+    "title": "902XL 2pk. Higher Yield Cartridges",
+    "price": "$20",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-902xl-2pk-higher-yield/7911345838.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7925393385",
+    "title": "ACER 12\" LAPTOP COMPUTER AS-IS!! MODEL V5",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-acer-12-laptop-computer/7925393385.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7909880228",
+    "title": "Acer 21.5\" HD LCD Monitor Black",
+    "price": "$72",
+    "location": "astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-acer-215-hd-lcd-monitor-black/7909880228.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7935182124",
+    "title": "Acer display 23 inch G235H in perfect condition",
+    "price": "$25",
+    "location": "Rego Park",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-acer-display-23-inch-g235h-in/7935182124.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918126861",
+    "title": "Adobe Creative Suite 3 Web Premium Upgrade version",
+    "price": "$50",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-adobe-creative-suite-web/7918126861.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917100792",
+    "title": "APC Smart-UPS 1000VA, Tower, LCD 120V with SmartConnect Port",
+    "price": "$360",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-apc-smart-ups-1000va/7917100792.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942079582",
+    "title": "Apple 32\" Pro Display XDR 16:9 Retina 6K HDR IPS Display (Nano-Texture Glass) wi",
+    "price": "$2,500",
+    "location": "Newyork",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/brooklyn-apple-32-pro-display-xdr-169/7942079582.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942737004",
+    "title": "Apple ADC to DVI adapter. Model: A1006",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-apple-adc-to-dvi-adapter/7942737004.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7909246184",
+    "title": "Apple iMac 24-Inch M1\" 2021 Models (A2439) OEM EMPTY BOX ONLY.",
+    "price": "$55",
+    "location": "Queens, Middle Village",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/middle-village-apple-imac-24-inch/7909246184.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7916393801",
+    "title": "Apple iMac 24-Inch M1\" 2021 Models (A2439) OEM EMPTY BOX ONLY.",
+    "price": "$55",
+    "location": "Queens, Middle Village",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/middle-village-apple-imac-24-inch/7916393801.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7919430274",
+    "title": "Apple iWork '06 CD unopened",
+    "price": "$5",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-apple-iwork-06-cd-unopened/7919430274.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7914344850",
+    "title": "Apple Keyboard, wireless bluetooth,  French AZERTY layout",
+    "price": "$50",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-apple-keyboard-wireless/7914344850.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7935142976",
+    "title": "Apple Magic Mouse 2 - White (Renewed)",
+    "price": "$60",
+    "location": "Bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/bayside-apple-magic-mouse-white-renewed/7935142976.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7922982146",
+    "title": "Apple magic mouse v2",
+    "price": "$30",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/east-elmhurst-apple-magic-mouse-v2/7922982146.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7925568375",
+    "title": "Apple MD826ZM/A Lightning Digital AV Adapter",
+    "price": "$10",
+    "location": "Queens, Middle Village",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/middle-village-apple-md826zm-lightning/7925568375.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7916400819",
+    "title": "Apple MD826ZM/A Lightning Digital AV Adapter",
+    "price": "$10",
+    "location": "Middle Village",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/middle-village-apple-md826zm-lightning/7916400819.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7919016624",
+    "title": "Apple Mini DisplayPort to VGA Adapter",
+    "price": "$25",
+    "location": "Whitestone",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/whitestone-apple-mini-displayport-to/7919016624.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938949678",
+    "title": "ASRock Fatal1ty Gaming Z170aming K6 Motherboard",
+    "price": "$150",
+    "location": "QUEENS",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-asrock-fatal1ty-gaming/7938949678.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7933042062",
+    "title": "ASUS  B360M-A mobo with IO plate",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-asus-b360m-mobo-with-io-plate/7933042062.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7911513039",
+    "title": "ASUS 24\" computer monitor",
+    "price": "$40",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-asus-24-computer-monitor/7911513039.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931409515",
+    "title": "ASUS Gaming 240hrz Monitor",
+    "price": "$200",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-asus-gaming-240hrz-monitor/7931409515.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7932883996",
+    "title": "ASUS Gaming 240hrz Monitor",
+    "price": "$200",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-asus-gaming-240hrz-monitor/7932883996.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927326145",
+    "title": "Belden 2413 Cat6 Plenum Solid Copper 1000ft Ethernet Cable",
+    "price": "$250",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-belden-2413-cat6-plenum/7927326145.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910009694",
+    "title": "BenQ RC-1331 Circular Remote Control for Projector Genuine Original",
+    "price": "$18",
+    "location": "Sunnyside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-benq-rc-1331-circular-remote/7910009694.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7912966269",
+    "title": "Besign Aluminum Laptop Stand",
+    "price": "$20",
+    "location": "Forest Hills, Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-besign-aluminum-laptop/7912966269.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940109051",
+    "title": "Black Laptop (business) bag",
+    "price": "$20",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-black-laptop-business-bag/7940109051.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943800740",
+    "title": "Bluetooth keyboard and mouse",
+    "price": "$50",
+    "location": "New York",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/new-york-bluetooth-keyboard-and-mouse/7943800740.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917127626",
+    "title": "Brand new bamboo portable podium 20 x 14",
+    "price": "$30",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-brand-new-bamboo-portable/7917127626.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913903274",
+    "title": "Canon FX3 cartridge",
+    "price": "$15",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/far-rockaway-canon-fx3-cartridge/7913903274.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939661144",
+    "title": "Canon gpr 58 5 sets c/y/m/b 20 pcs total",
+    "price": "$0",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-canon-gpr-58-sets-y-b-20/7939661144.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927227709",
+    "title": "CDRW unit",
+    "price": "$0",
+    "location": "Glendale",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/middle-village-cdrw-unit/7927227709.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940141614",
+    "title": "Classic Syntrex Word Processor",
+    "price": "$200",
+    "location": "Ridgewood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-classic-syntrex-word-processor/7940141614.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910436393",
+    "title": "coax and ethernet cable",
+    "price": "$5",
+    "location": "woodside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/maspeth-coax-and-ethernet-cable/7910436393.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7929591898",
+    "title": "Computer Power Supplies - 2 NEW in Box  $20 each or $30 for both",
+    "price": "$20",
+    "location": "Bayside, Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/bayside-computer-power-supplies-new-in/7929591898.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927226152",
+    "title": "Computer programs  etc",
+    "price": "$0",
+    "location": "Glendale",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-computer-programs-etc/7927226152.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934356021",
+    "title": "COOLER MASTER silent pro 850w For Gaming",
+    "price": "$55",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-cooler-master-silent-pro-850w/7934356021.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941490517",
+    "title": "Corsair CX650M power supply",
+    "price": "$70",
+    "location": "Springfield Gardens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/springfield-gardens-corsair-cx650m/7941490517.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940723155",
+    "title": "Crucial 16GB DDR5-4800 RAM \u2014 Used",
+    "price": "$130",
+    "location": "Sunnyside, NY",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-crucial-16gb-ddr-ram-used/7940723155.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7929078747",
+    "title": "Crucial 2.5inch Solid State Drive 500GB",
+    "price": "$75",
+    "location": "East Elmhurst",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/east-elmhurst-crucial-25inch-solid/7929078747.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938357533",
+    "title": "DEFCON\u2122 Compact Serialized Combo Cable Lock",
+    "price": "$5",
+    "location": "Jackson Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jackson-heights-defcon-compact/7938357533.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931783700",
+    "title": "Dell 45W Replacement AC Adapter for Dell",
+    "price": "$20",
+    "location": "Sunnyside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-dell-45w-replacement-ac/7931783700.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941678681",
+    "title": "Dell Dual-Monitor Stand",
+    "price": "$45",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-dell-dual-monitor-stand/7941678681.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908057881",
+    "title": "Dell monitor E1913C in perfect condition, Power cable, VGA cable",
+    "price": "$25",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-dell-monitor-e1913c-in-perfect/7908057881.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942913568",
+    "title": "Dell optiplex aio 7420 35W W32C all in one - Cracked screen NO HD & Me",
+    "price": "$100",
+    "location": "Bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/bayside-dell-optiplex-aio-w32c-all-in/7942913568.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941347035",
+    "title": "DELL THUNDERBOLDT 4 DOCK -LIKE NEW",
+    "price": "$70",
+    "location": "FOREST HILLS",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/new-york-dell-thunderboldt-dock-like-new/7941347035.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931338747",
+    "title": "Dell WD19 Docking station,",
+    "price": "$60",
+    "location": "Rego Park",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-dell-wd19-docking-station/7931338747.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943118623",
+    "title": "ECS KBN-I/5200 AMD A6-5200 Quad Core processor Mini ITX Motherboard",
+    "price": "$50",
+    "location": "Rego Park",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-ecs-kbn-5200-amd-quad-core/7943118623.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917103218",
+    "title": "Elgato - Stream Deck MK.2 Full-size Wired USB Keypad",
+    "price": "$100",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-elgato-stream-deck-mk2/7917103218.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923159007",
+    "title": "EVGA Classified Super Record 2 SR-2 Dual Xeon X5650 DDR3 G-Skill 48GB",
+    "price": "$900",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-evga-classified-super-record-sr/7923159007.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942642410",
+    "title": "Gas Spring Desk Mount for Single Monitor 13\" to 34\"",
+    "price": "$70",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-gas-spring-desk-mount/7942642410.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923010720",
+    "title": "gateway 17 inch monitor with VGA and power cable",
+    "price": "$20",
+    "location": "Rego Park",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-gateway-17-inch-monitor-with/7923010720.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7905819837",
+    "title": "GENUINE LEXMARK 1361215 PHOTOCONDUCTOR",
+    "price": "$0",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-genuine-lexmark-photoconductor/7905819837.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938562930",
+    "title": "Gigabyte B760M C V3 DDR5 Motherboard - LGA1700 + Intel 12/13/14 Gen",
+    "price": "$90",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-gigabyte-b760m-v3-ddr5/7938562930.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940682046",
+    "title": "Gigabyte GeForce RTX 4060 OC GPU",
+    "price": "$220",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-gigabyte-geforce-rtx-4060-oc/7940682046.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934146924",
+    "title": "GPU cables. 6 pin female to 8 pin male. New.",
+    "price": "$15",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-gpu-cables-pin-female-to-pin/7934146924.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940053855",
+    "title": "Hawaiian \ud83c\udf3a tikki Mug \ud83e\udd1e",
+    "price": "$45",
+    "location": "Kew Gardens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/kew-gardens-hawaiian-tikki-mug/7940053855.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915237016",
+    "title": "Headset with Microphone",
+    "price": "$10",
+    "location": "Whitestone",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/whitestone-headset-with-microphone/7915237016.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7933056507",
+    "title": "HP 24mh Monitor, perfect condition",
+    "price": "$50",
+    "location": "Kew Gardens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-hp-24mh-monitor-perfect/7933056507.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943735821",
+    "title": "HP 952XL/952 Black High Yield and Cyan/Magenta/Yellow Standard Yleld Ink Cartrid",
+    "price": "$245",
+    "location": "Bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/bayside-hp-952xl-952-black-high-yield/7943735821.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7932711686",
+    "title": "HP Compaq LA2205wg 22\" DVI VGA DisplayPort LCD Monitor USB HUB +Stand & Cables",
+    "price": "$10",
+    "location": "Ozone Park",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ozone-park-hp-compaq-la2205wg-22-dvi/7932711686.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938352676",
+    "title": "HP Poly Savi 7300 Office Wireless Headset for sale.",
+    "price": "$40",
+    "location": "Jackson Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jackson-heights-hp-poly-savi-7300/7938352676.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908785015",
+    "title": "HP TONER 304A - CYAN/MAGENTA/YELLOW - $60 EACH",
+    "price": "$60",
+    "location": "OZONE PARK",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ozone-park-hp-toner-304a-cyan-magenta/7908785015.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938355093",
+    "title": "HP USB-C Dock G5 (L64086-001) for sale.",
+    "price": "$50",
+    "location": "Jackson Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jackson-heights-hp-usb-dock-g5-for-sale/7938355093.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910470341",
+    "title": "hp xw9400",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jamaica-hp-xw9400/7910470341.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7933703952",
+    "title": "Humanscale CPU600 Under Desk Mount PC Computer Case Bracket Holder",
+    "price": "$50",
+    "location": "Gravesend, Brooklyn",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/brooklyn-humanscale-cpu600-under-desk/7933703952.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940724547",
+    "title": "HYTE Revolt 3 ITX Case + 700W PSU + Wavlink WiFi 6 Adapter",
+    "price": "$160",
+    "location": "Sunnyside, NY",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-hyte-revolt-itx-case-700w-psu/7940724547.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942719110",
+    "title": "ID-COOLING CORSAIR COOLER, GREAT CONDITION(NO FANS)",
+    "price": "$40",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/saint-albans-id-cooling-corsair-cooler/7942719110.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918141993",
+    "title": "Ide/pata hard drive 160GB. NOT a SATA drive!",
+    "price": "$25",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-ide-pata-hard-drive-160gb-not/7918141993.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917431904",
+    "title": "iMac late 2013 parts. Logicboard 2.9GHz, power supply, more NO DISPLAY",
+    "price": "$1",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-imac-late-2013-parts/7917431904.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910313350",
+    "title": "Kensington Targus Combination Laptop Lock security cable lock",
+    "price": "$30",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-kensington-targus-combination/7910313350.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7920060172",
+    "title": "Keyboard, Dell Power Adapter",
+    "price": "$9",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-keyboard-dell-power-adapter/7920060172.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908730028",
+    "title": "Kingston DDR4 RAM 32GB (2x16GB) DIMM SODIMM",
+    "price": "$110",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-kingston-ddr4-ram-32gb-2x16gb/7908730028.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908729318",
+    "title": "Kingston DDR4 RAM 32GB (2x16GB) DIMM SODIMM NEW SEALED",
+    "price": "$160",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-kingston-ddr4-ram-32gb-2x16gb/7908729318.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7936223255",
+    "title": "Lenovo 42T4438 Original AC 100-240V Adapter 20V 4.5A 7.9mm OD Plug",
+    "price": "$10",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-lenovo-42t4438-original-ac/7936223255.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938315864",
+    "title": "Lian Li O11 Dynamic ATX Computer Case Tempered Glass",
+    "price": "$30",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-lian-li-o11-dynamic/7938315864.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917101836",
+    "title": "Logitech C930E 1080p HD Video Webcam",
+    "price": "$40",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-logitech-c930e-1080p/7917101836.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913114411",
+    "title": "Logitech G105 Call of Duty MW3 USB Gaming Keyboard - Pre-owned",
+    "price": "$25",
+    "location": "Glendale, Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-logitech-g105-call-of-duty/7913114411.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7909879855",
+    "title": "Logitech USB Wired Mouse",
+    "price": "$14",
+    "location": "astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-logitech-usb-wired-mouse/7909879855.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940483250",
+    "title": "Logitech webcam , 720p",
+    "price": "$10",
+    "location": "Kew Gardens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/kew-gardens-logitech-webcam-720p/7940483250.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917947926",
+    "title": "Mac G5 video card with dual DVI ports",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-mac-g5-video-card-with-dual/7917947926.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934147188",
+    "title": "Mac OS X Tiger 10.4 Install DVD",
+    "price": "$20",
+    "location": "Queens center mall",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jackson-heights-mac-os-tiger-104/7934147188.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934146153",
+    "title": "Mac Pro 2010 single CPU tray",
+    "price": "$40",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-mac-pro-2010-single-cpu-tray/7934146153.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923133127",
+    "title": "Macally 3.5\" SATA Hard Drive Enclosure NEW PC MAC",
+    "price": "$60",
+    "location": "Woodside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/woodside-macally-35-sata-hard-drive/7923133127.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910493402",
+    "title": "Mechanical gaming keyboard",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/rego-park-mechanical-gaming-keyboard/7910493402.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940451249",
+    "title": "Memorex DVD-R 50 pack brand new unopned",
+    "price": "$5",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-memorex-dvd-50-pack-brand/7940451249.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941953675",
+    "title": "Memory Card SanDisk Extreme III 2.0GB",
+    "price": "$15",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-memory-card-sandisk-extreme/7941953675.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938447950",
+    "title": "Microsoft LifeCam HD3000",
+    "price": "$15",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-microsoft-lifecam-hd3000/7938447950.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931000077",
+    "title": "Miscellaneous RAM",
+    "price": "$25",
+    "location": "Ridgewood Glendale",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-miscellaneous-ram/7931000077.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915032867",
+    "title": "Monitor VESA mount 18\" to top, 10.5\" x 13.5\" base",
+    "price": "$30",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-monitor-vesa-mount-18-to/7915032867.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918534581",
+    "title": "Montclair waist",
+    "price": "$600",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-montclair-waist/7918534581.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941990477",
+    "title": "Mycloud NAS, 2 TB",
+    "price": "$80",
+    "location": "Sunnyside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-mycloud-nas-tb/7941990477.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921094797",
+    "title": "Netgear DS104 4-Port Dual Speed Hub + Power Supply",
+    "price": "$20",
+    "location": "Sunnyside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-netgear-ds104-port-dual-speed/7921094797.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942321266",
+    "title": "New Magic keyboard apple",
+    "price": "$70",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-new-magic-keyboard-apple/7942321266.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937868399",
+    "title": "NEW VINTAGE APPLE EXTENDED KEYBOARD",
+    "price": "$100",
+    "location": "LIC",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7937868399.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938562463",
+    "title": "Nvidia GeForce RTX 3070 FE",
+    "price": "$225",
+    "location": "Fresh Meadows",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-nvidia-geforce-rtx-3070-fe/7938562463.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934199551",
+    "title": "Nvidia GT 120 graphics card Mac Pro",
+    "price": "$20",
+    "location": "Queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/fresh-meadows-nvidia-gt-120-graphics/7934199551.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943248484",
+    "title": "NVidia RTX 5090 FE Founders Edition NEW CLEAN",
+    "price": "$3,200",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-nvidia-rtx-5090-fe-founders/7943248484.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7932738901",
+    "title": "OMOTON Vertical Laptop Stand Holder \u2013 Aluminum Desktop Dock",
+    "price": "$10",
+    "location": "Bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-omoton-vertical-laptop/7932738901.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939723387",
+    "title": "PC Case - Hyte Y40 ATX Mid Tower Case - White",
+    "price": "$100",
+    "location": "Ridgewood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-pc-case-hyte-y40-atx-mid/7939723387.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934199714",
+    "title": "PCIe card to connect Apple SSDs to Mac Pro 2009 - 2012",
+    "price": "$20",
+    "location": "Briarwood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jamaica-pcie-card-to-connect-apple-ssds/7934199714.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934146391",
+    "title": "PCIe card with 4  USB3 ports",
+    "price": "$20",
+    "location": "Elmhurst",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-pcie-card-with-usb3-ports/7934146391.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943856192",
+    "title": "Quad Monitor Stand for Desktop",
+    "price": "$100",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/east-elmhurst-quad-monitor-stand-for/7943856192.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942450875",
+    "title": "ROCKSPACE 1200MBPS WIFI RANGE EXTENDER",
+    "price": "$40",
+    "location": "QUEENS NY",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/east-elmhurst-rockspace-1200mbps-wifi/7942450875.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913651963",
+    "title": "Router Wireless (Netgear)",
+    "price": "$19",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-router-wireless-netgear/7913651963.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943139796",
+    "title": "RX 5600 XT 6gb Vram",
+    "price": "$150",
+    "location": "Jamaica",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jamaica-rx-5600-xt-6gb-vram/7943139796.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944149029",
+    "title": "rx 580 rx580 8gb gpu",
+    "price": "$70",
+    "location": "Ridgewood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-rx-580-rx580-8gb-gpu/7944149029.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939903601",
+    "title": "RX 7800XT",
+    "price": "$550",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/east-elmhurst-rx-7800xt/7939903601.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944153404",
+    "title": "rx6600 rx 6600 gpu",
+    "price": "$150",
+    "location": "Ridgewood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/ridgewood-rx6600-rx-6600-gpu/7944153404.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7934145753",
+    "title": "Sabrent 2.5 SSd and sata converter to 3.5 Desktop. NEW",
+    "price": "$12",
+    "location": "Elmhurst",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/elmhurst-sabrent-25-ssd-and-sata/7934145753.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944181018",
+    "title": "Samsung 990 2 tb ssd",
+    "price": "$160",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-samsung-tb-ssd/7944181018.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938957634",
+    "title": "Seagate Barracuda 7,200 RPM 80Gb Hard Drive",
+    "price": "$20",
+    "location": "Cambria Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/cambria-heights-seagate-barracuda-7200/7938957634.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938960074",
+    "title": "Seagate Barracuda ATA ST320414A - IDE Hard Drive - 20Gb",
+    "price": "$15",
+    "location": "Cambria Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/cambria-heights-seagate-barracuda-ata/7938960074.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908474529",
+    "title": "Sharp LL-172G-B 17\" LCD Monitor",
+    "price": "$60",
+    "location": "Sunnyside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/sunnyside-sharp-ll-172g-17-lcd-monitor/7908474529.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7926782675",
+    "title": "SSD and Hard Drives for sale",
+    "price": "$100",
+    "location": "astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-ssd-and-hard-drives-for-sale/7926782675.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7932741295",
+    "title": "Svarog Aluminum Laptop Stand / Desktop Notebook Riser \u2013 Silver",
+    "price": "$10",
+    "location": "Bayside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/oakland-gardens-svarog-aluminum-laptop/7932741295.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7928743286",
+    "title": "Targus DEFCON Security Anchor Base Plate (PA400P) - Unused",
+    "price": "$5",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-targus-defcon-security/7928743286.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943862567",
+    "title": "Tobi Eye Tracker 5",
+    "price": "$250",
+    "location": "Roosevelt Island",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/new-york-tobi-eye-tracker/7943862567.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918141957",
+    "title": "Toshiba Qosmio fan, brand new.",
+    "price": "$15",
+    "location": "Briarwood",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/jamaica-toshiba-qosmio-fan-brand-new/7918141957.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7906641784",
+    "title": "TP-LINK TC-7610 DOCSIS 3.0 Cable Modem",
+    "price": "$15",
+    "location": "Woodside",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/woodside-tp-link-tc-7610-docsis-30/7906641784.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913653397",
+    "title": "USB Cables Set",
+    "price": "$15",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-usb-cables-set/7913653397.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931532625",
+    "title": "USB Hub Ethernet Adapter",
+    "price": "$5",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/far-rockaway-usb-hub-ethernet-adapter/7931532625.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918534896",
+    "title": "Waterproof Protective Case iBdry",
+    "price": "$19",
+    "location": "Forest Hills",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/forest-hills-waterproof-protective-case/7918534896.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7943985808",
+    "title": "WD 8TB Elements External HDD",
+    "price": "$300",
+    "location": "Flushing",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-wd-8tb-elements-external-hdd/7943985808.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938961104",
+    "title": "Western Digital WD Caviar IDE Hard Drive - 250Gb",
+    "price": "$40",
+    "location": "Cambria Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/cambria-heights-western-digital-wd/7938961104.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938960687",
+    "title": "Western Digital WD200 Caviar IDE Hard Drive - 20Gb",
+    "price": "$15",
+    "location": "Cambria Heights",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/cambria-heights-western-digital-wd200/7938960687.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917103372",
+    "title": "Wireless Keyboard and Track pad",
+    "price": "$25",
+    "location": "Long Island City",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/long-island-city-wireless-keyboard-and/7917103372.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910313415",
+    "title": "Xcellon 7 Port Powered USB 3.0 Aluminum Hub (Black)",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/astoria-xcellon-port-powered-usb-30/7910313415.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7936707934",
+    "title": "ZTNY B41N1341 Replacement Battery",
+    "price": "$35",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-ztny-b41n1341-replacement/7936707934.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937306409",
+    "title": "ZTNY B41N1341 Replacement Battery",
+    "price": "$30",
+    "location": "queens",
+    "category": "sop",
+    "url": "https://newyork.craigslist.org/que/sop/d/flushing-ztny-b41n1341-replacement/7937306409.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7908678211",
+    "title": "Burton Snowboard Bundle",
+    "price": "$800",
+    "location": "Flushing",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/flushing-burton-snowboard-bundle/7908678211.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7943209049",
+    "title": "Gerber multi tools \ud83e\uddf0 compact small with many tools",
+    "price": "$20",
+    "location": "Queens",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/kew-gardens-gerber-multi-tools-compact/7943209049.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7928806425",
+    "title": "Hi-Lift UTV Model UTV-364",
+    "price": "$100",
+    "location": "Bayside",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/oakland-gardens-hi-lift-utv-model-utv/7928806425.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7933414815",
+    "title": "Peloton Bike (2020) - Ground Floor Pickup - 2Pairs Shoes, Weights, Mat",
+    "price": "$500",
+    "location": "Ridgewood",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/brooklyn-peloton-bike-ground-floor/7933414815.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7940027745",
+    "title": "Pre-owned Motu 828 Firewire Audio Interface",
+    "price": "$85",
+    "location": "Rego Park, Queens",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/rego-park-pre-owned-motu-828-firewire/7940027745.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937940131",
+    "title": "Sunny Health & Fitness SF-B2715 Zephyr Air Bike - Full Body Fan Bike",
+    "price": "$125",
+    "location": "Kensington, Brooklyn, NY",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/brooklyn-sunny-health-fitness-sf-b2715/7937940131.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7906458527",
+    "title": "Victoria's Secret Pink Collegiate Large Backpack Green Camo New",
+    "price": "$50",
+    "location": "Howard Beach",
+    "category": "spo",
+    "url": "https://newyork.craigslist.org/que/spo/d/howard-beach-victorias-secret-pink/7906458527.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7923170182",
+    "title": "15 Dell Optiplex 380 and 755 desktop computer systems",
+    "price": "$80",
+    "location": "Jamaica",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jamaica-15-dell-optiplex-380-and-755/7923170182.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930037549",
+    "title": "27\" LENOVO ALL IN ONE COMPUTER (TOUCH SCREEN)",
+    "price": "$0",
+    "location": "Long Island / Queens Area",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/garden-city-27-lenovo-all-in-one/7930037549.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7928839818",
+    "title": "ACER 12\" LAPTOP COMPUTER AS-IS!! MODEL V5",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7928839818.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930754760",
+    "title": "ACER 12\" LAPTOP COMPUTER AS-IS!! MODEL V5",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7930754760.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7925393160",
+    "title": "ACER 12\" LAPTOP COMPUTER AS-IS!! MODEL V5",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7925393160.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7913946024",
+    "title": "Amiga 500, 1084 monitor, 1084S, A590 plus,25 orig/200 dsk, 3 PS, more",
+    "price": "$995",
+    "location": "Woodside",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/woodside-amiga-monitor-1084s-a590/7913946024.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941321200",
+    "title": "Apple imac all in one computer great condrion",
+    "price": "$600",
+    "location": "Jamaica",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jamaica-apple-imac-all-in-one-computer/7941321200.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942619614",
+    "title": "Cisco UCS C240 M3 Server 12 Core Vmware ESX Similar Dell R720 R720xd",
+    "price": "$80",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-cisco-ucs-c240-m3-server-12/7942619614.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7941327918",
+    "title": "Computer",
+    "price": "$20",
+    "location": "queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/east-elmhurst-computer/7941327918.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938802394",
+    "title": "Computer",
+    "price": "$40",
+    "location": "queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/east-elmhurst-computer/7938802394.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923218958",
+    "title": "COMPUTER CONTROL CENTER",
+    "price": "$20",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-control-center/7923218958.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918563370",
+    "title": "COMPUTER MONITORS: 15\" 17\" & 19\" & DELL, HP",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-monitors-dell/7918563370.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7923222173",
+    "title": "COMPUTER MONITORS: 15\" 17\" & 19\" & DELL, HP",
+    "price": "$0",
+    "location": "BAYSIDE/QUEENS",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-monitors-dell/7923222173.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7944148982",
+    "title": "Computer stand | Laptop screen heightener",
+    "price": "$10",
+    "location": "Richmond Hill",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/richmond-hill-computer-stand-laptop/7944148982.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939436213",
+    "title": "custom computer build for business or gaming",
+    "price": "$50",
+    "location": "queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/ridgewood-custom-computer-build-for/7939436213.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7919877316",
+    "title": "Custom Gaming PC \u2013 Ready to Crush Any Game! \ud83d\udcbb\u2728",
+    "price": "$699",
+    "location": "Kew Gardens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/kew-gardens-custom-gaming-pc-ready-to/7919877316.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942447933",
+    "title": "Dell 7920 Video Editing PC Computer 48 Core 96 Threads Adobe CAD Maya",
+    "price": "$980",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-7920-video-editing-pc/7942447933.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941004747",
+    "title": "DELL Computer 8 Core 32GB RAM SSD NVIDIA Quadro",
+    "price": "$380",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-computer-core-32gb-ram/7941004747.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937827335",
+    "title": "Dell Gaming PC Computer 10 Core i9 32GB RAM GTX Titan X 12GB 512NVMe",
+    "price": "$540",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-gaming-pc-computer-10/7937827335.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930304368",
+    "title": "Dell Gaming PC i7 NVIDIA GTX 1650 16GB RAM 512GB NVMe Computer",
+    "price": "$340",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-gaming-pc-i7-nvidia-gtx/7930304368.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940430591",
+    "title": "Dell Inspiron One 2320 AIO PC Windows 10 Computer",
+    "price": "$135",
+    "location": "Forest Hills",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/forest-hills-dell-inspiron-one-2320-aio/7940430591.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918444824",
+    "title": "Dell Latitude E6410 14\" Laptop,Intel i5,500GB HDD,Windows 11,MS Office",
+    "price": "$120",
+    "location": "Jackson Heights, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-dell-latitude/7918444824.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942619017",
+    "title": "DELL Office PC Computer Intel Xeon 5820 16GB NVIDIA P620 Windows 11",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-office-pc-computer/7942619017.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942619297",
+    "title": "DELL PC Computer Editing 5820 6 Core 16GB Adobe CAD",
+    "price": "$300",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-pc-computer-editing/7942619297.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941004471",
+    "title": "Dell PC Computer i7-7700k 32GB Memory SSD",
+    "price": "$180",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-pc-computer-i7-7700k/7941004471.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915382669",
+    "title": "Dell Precision Tower 7810 24 Cores PC Computer Home Lab VMware ProxMox",
+    "price": "$200",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-precision-tower-cores/7915382669.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910026728",
+    "title": "Dell Precision Workstation 5820 Xeon W2125 NVIDIA Quadro PC Computer",
+    "price": "$200",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-precision-workstation/7910026728.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942618762",
+    "title": "Dell T3620 Gaming PC Computer i7 16GB RAM SSD",
+    "price": "$180",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-dell-t3620-gaming-pc/7942618762.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7930345500",
+    "title": "Fractal Design Define R5 Mid-Tower Case and 850w PSU",
+    "price": "$150",
+    "location": "Rego Park",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/rego-park-fractal-design-define-r5-mid/7930345500.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7918445010",
+    "title": "Gaming computer, Intel i5-4690K, GTX 560 Ti,500GB SSD,Win 11+MS Office",
+    "price": "$120",
+    "location": "Jackson Heights, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-gaming-computer-intel/7918445010.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941006648",
+    "title": "Gaming Laptop Sager NVIDIA RTX 3060 i7 1270H 32GB RAM 1TB Computer",
+    "price": "$580",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-gaming-laptop-sager-nvidia/7941006648.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941306714",
+    "title": "GENUINE LOGITECH *PRO* USB RECEIVER MOUSE Dongle Adapter FAST SHIP",
+    "price": "$20",
+    "location": "New York",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/new-york-genuine-logitech-pro-usb/7941306714.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7915446572",
+    "title": "HP 280 G1 Desktop Computer, Intel i5, Windows 11,MS Office",
+    "price": "$99",
+    "location": "Jackson Heights, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-hp-280-g1-desktop/7915446572.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7939958001",
+    "title": "HP Computer Monitor - $20",
+    "price": "$20",
+    "location": "Woodside, Queens, NY 11377",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/woodside-hp-computer-monitor-20/7939958001.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927328610",
+    "title": "HP desktop all-in-one with 1TB of storage",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/astoria-hp-desktop-all-in-one-with-1tb/7927328610.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937827425",
+    "title": "HP Gaming Z4 G4 Computer 6 Core 3.7GHz SSD NVIDIA GTX 970 1TB",
+    "price": "$300",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-hp-gaming-z4-g4-computer/7937827425.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942584293",
+    "title": "HP Touchsmart 310 PC - Touchscreen All-in-ONE computer",
+    "price": "$140",
+    "location": "queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/maspeth-hp-touchsmart-310-pc/7942584293.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941004270",
+    "title": "HP Z2 G4 Computer i5 16GB 1TB NVMe AMD FirePro Win 11 Pro",
+    "price": "$290",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-hp-z2-g4-computer-i5-16gb/7941004270.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937827151",
+    "title": "HP Z240 Tower Workstation Desktop Computer",
+    "price": "$30",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-hp-z240-tower-workstation/7937827151.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942619105",
+    "title": "HP Z4 G4 PC Computer Xeon CPU w-2125 4.00Ghz NVIDIA K420 500GB SSD",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-hp-z4-g4-pc-computer-xeon/7942619105.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7927339532",
+    "title": "HP Z640 18 Core Computer Tower Workstation 16GB 1TB AMD Radeon Pro WX",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-hp-core-computer-tower/7927339532.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941004220",
+    "title": "Lenovo Computer Professional Workstation Intel Xeon",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-computer-professional/7941004220.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942619237",
+    "title": "Lenovo Computer Proffesional Workstation Intel Xeon w2125 16GB RAM 512",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-computer-proffesional/7942619237.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941004910",
+    "title": "Lenovo P320 Desktop PC Computer I7-7700K 16GB",
+    "price": "$180",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-p320-desktop-pc/7941004910.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7917072841",
+    "title": "Lenovo ThinkCentre Desktop Computer\u2013 Compact Powerhouse! \ud83d\udcbb",
+    "price": "$69",
+    "location": "Jackson Heights",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-lenovo-thinkcentre/7917072841.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921052224",
+    "title": "Lenovo ThinkCentre M900 Tiny Computer, Intel i5-6500T,8GB RAM, WiFi",
+    "price": "$90",
+    "location": "Jackson Heights, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-lenovo-thinkcentre-m900/7921052224.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937880403",
+    "title": "Lenovo ThinkStation P330 i5-9600KF 32GB 4TB Workstation PC Computer",
+    "price": "$280",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-thinkstation-p330-i5/7937880403.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7916080928",
+    "title": "LIKE NEW Apple iMac 21.5\", 500 GB HD, i5, 2.5 GHz, 4 GB (Mid 2011)",
+    "price": "$250",
+    "location": "Richmond Hill, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jamaica-like-new-apple-imac-gb-hd-i5-25/7916080928.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7938753776",
+    "title": "Like New HP All-in-One 24-cb1257c Touchscreen Computer",
+    "price": "$490",
+    "location": "Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/forest-hills-like-new-hp-all-in-one-24/7938753776.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7921052431",
+    "title": "MSI GT62VR Dominator PRO Extreme Gaming Laptop:i7-6700/GeForce GTX1070",
+    "price": "$450",
+    "location": "Jackson Heights, Queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/jackson-heights-msi-gt62vr-dominator/7921052431.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7930037764",
+    "title": "New HP COMPUTER 24 INCH (Touch Screen )All In One Model -K0024",
+    "price": "$0",
+    "location": "Long Island / Queens Area",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/west-hempstead-new-hp-computer-24-inch/7930037764.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7910313274",
+    "title": "OWC / Akitio Thunder3 Dock Pro - Thunderbolt 3 Docking Station",
+    "price": "$250",
+    "location": "astoria",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/astoria-owc-akitio-thunder3-dock-pro/7910313274.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7931803596",
+    "title": "Surface computer ipod",
+    "price": "$288",
+    "location": "New York",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/new-york-surface-computer-ipod/7931803596.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937826738",
+    "title": "ThinkStation P320 Tower Workstation Desktop Computer",
+    "price": "$40",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-thinkstation-p320-tower/7937826738.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7925782889",
+    "title": "TOSHIBA Satellite C55t-C5300. Can't connect to Internet!",
+    "price": "$50",
+    "location": "Astoria",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/astoria-toshiba-satellite-c55t-c5300/7925782889.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938335477",
+    "title": "VariDesk Pro - Standing, adjustable Desk Converter",
+    "price": "$175",
+    "location": "queens",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/woodside-varidesk-pro-standing/7938335477.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937827291",
+    "title": "Video CAD Adobe Maya Computer 10 Core i9 32GB RAM 500GB SSD NVMe",
+    "price": "$440",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-video-cad-adobe-maya/7937827291.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942620011",
+    "title": "Video Editing PC Computer Gaming 10 Core Adobe CAD Maya 3D",
+    "price": "$340",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-video-editing-pc-computer/7942620011.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942618587",
+    "title": "Video Editing PC Computer Gaming 14 Core 32GB Adobe CAD Maya 3D",
+    "price": "$640",
+    "location": "Great Neck",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/great-neck-video-editing-pc-computer/7942618587.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7906918978",
+    "title": "View Sonic VA2342-LED Computer Monitor 23\"",
+    "price": "$20",
+    "location": "Ridgewood",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/ridgewood-view-sonic-va2342-led/7906918978.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940319466",
+    "title": "WANTED MACBOOK /PC LOCKED NOT WORKING WITH SOFTWARE/HARDWARE ISSUE",
+    "price": "$1",
+    "location": "ASTORIA",
+    "category": "sys",
+    "url": "https://newyork.craigslist.org/que/sys/d/astoria-wanted-macbook-pc-locked-not/7940319466.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937808432",
+    "title": "Learning Resources Botley 2.0 Coding Robot \u2013 Great STEM Toy for Kids!",
+    "price": "$50",
+    "location": "Jackson Heights",
+    "category": "tag",
+    "url": "https://newyork.craigslist.org/que/tag/d/jackson-heights-learning-resources/7937808432.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937808975",
+    "title": "Meccano STEM Engineering Sets (#20105 and #18202) with Pull-Back Motor",
+    "price": "$30",
+    "location": "Jackson Heights",
+    "category": "tag",
+    "url": "https://newyork.craigslist.org/que/tag/d/jackson-heights-meccano-stem/7937808975.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7937809262",
+    "title": "Ultimate Screen-Free STEM Bundle: Botley 2.0 & Meccano Engineering Set",
+    "price": "$80",
+    "location": "Jackson Heights",
+    "category": "tag",
+    "url": "https://newyork.craigslist.org/que/tag/d/jackson-heights-ultimate-screen-free/7937809262.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7914997730",
+    "title": "(2) TWO NEW Milwaukee 5AH Batteries + Charger",
+    "price": "$175",
+    "location": "Rego Park, Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-two-new-milwaukee-5ah/7914997730.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943075499",
+    "title": "***** RIDGID 300 - REPAIR SERVICE  141/258/918/200",
+    "price": "$150",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/cambria-heights-ridgid-repair-service/7943075499.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943459181",
+    "title": "***** RIDGID 450 TRIPOD CHAIN VISE 5\u201d CAPACITY *****",
+    "price": "$250",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/hollis-ridgid-450-tripod-chain-vise/7943459181.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7931942352",
+    "title": "***** RIDGID RP251 PROPRESS KIT *****",
+    "price": "$2,000",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/hollis-ridgid-rp251-propress-kit/7931942352.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943075824",
+    "title": "******* NEAR NEW RIDGID 141 DIE HEAD / GEARED THREADER *******",
+    "price": "$1,600",
+    "location": "QUEENS",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/hollis-near-new-ridgid-141-die-head/7943075824.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558956",
+    "title": "1/2 inch Drive Handle",
+    "price": "$10",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-2-inch-drive-handle/7943558956.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943559023",
+    "title": "1/2\" Drive Ratchets",
+    "price": "$12",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-2-drive-ratchets/7943559023.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913854007",
+    "title": "10 AWG WIRE",
+    "price": "$150",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-10-awg-wire/7913854007.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7923217615",
+    "title": "116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-116-peace-screwdriver/7923217615.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924503784",
+    "title": "116 PEACE SCREWDRIVER, BIT AND HEX KEY SET, BRAND NEW",
+    "price": "$50",
+    "location": "BAYSIDE/QUEENS",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-116-peace-screwdriver/7924503784.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246851",
+    "title": "18 in. Magnetic Tool Holder Brand New Sealed in the Original Packaging",
+    "price": "$10",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-18-in-magnetic-tool/7909246851.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935494967",
+    "title": "19\" Tool Box 5 piece door hinge adjustment tool GB wire Stripper more",
+    "price": "$10",
+    "location": "Glendale, Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-19-tool-box-piece-door-hinge/7935494967.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929375633",
+    "title": "2 hand saws",
+    "price": "$15",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-hand-saws/7929375633.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921220311",
+    "title": "3-Way Shower Arm Diverter with Handshower Mount Delta Faucet U4920-PK",
+    "price": "$20",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-way-shower-arm-diverter/7921220311.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943559115",
+    "title": "3/8\" Drive Ratchet",
+    "price": "$12",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-8-drive-ratchet/7943559115.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939337880",
+    "title": "4 1/2 in metal cutting dics",
+    "price": "$1",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-in-metal-cutting-dics/7939337880.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558894",
+    "title": "4 Dies",
+    "price": "$17",
+    "location": "Ozone Park, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dies/7943558894.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557601",
+    "title": "4 Wrenches - Stanley / Armstrong / Pronto / S&K",
+    "price": "$45",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-wrenches-stanley-armstrong/7943557601.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930103628",
+    "title": "4' Uboat All Metal Heavy Duty",
+    "price": "$175",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-uboat-all-metal-heavy-duty/7930103628.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930117533",
+    "title": "4' wide Wire Rack, Bakers Rack Walk-in Freezer, Food Service",
+    "price": "$150",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-wide-wire-rack-bakers-rack-walk/7930117533.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557289",
+    "title": "5 Piece Air Compressor Tool Kit",
+    "price": "$40",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-piece-air-compressor-tool-kit/7943557289.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7907718781",
+    "title": "5 SEKTION Wall cabinet horizontal, white/Nickebo",
+    "price": "$385",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/long-island-city-sektion-wall-cabinet/7907718781.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930102992",
+    "title": "5' Pallet Rack Beige for Basement, Shipping Containers, Warehouse",
+    "price": "$300",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-pallet-rack-beige-for-basement/7930102992.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916398432",
+    "title": "6 Pallet Trucks Delivered As A Group Anywhere in Queens-Pick Your Size",
+    "price": "$1,998",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-pallet-trucks-delivered-as/7916398432.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912145865",
+    "title": "64'' Fiberglass Long Handle Carbon Steel Square Point Shovel",
+    "price": "$30",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-64-fiberglass-long/7912145865.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916397642",
+    "title": "64'' Fiberglass Long Handle Carbon Steel Square Point Shovel",
+    "price": "$30",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-64-fiberglass-long/7916397642.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557363",
+    "title": "8 IN 1 Magnetic Screwdriver Set",
+    "price": "$10",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-in-magnetic-screwdriver-set/7943557363.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913845042",
+    "title": "A/C & Refrigeration Manifold Imperial",
+    "price": "$170",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-c-refrigeration-manifold/7913845042.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927225504",
+    "title": "A/C Charging unit /Guages",
+    "price": "$0",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-c-charging-unit-guages/7927225504.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558641",
+    "title": "Adjustable Round Split Dies - High Speed Steel",
+    "price": "$19",
+    "location": "Ozone Park, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-adjustable-round-split-dies/7943558641.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932455603",
+    "title": "Adjustable Wrench Stanley 12In/300MM 87-472 Chrome",
+    "price": "$15",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-adjustable-wrench-stanley/7932455603.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918561938",
+    "title": "American Lock",
+    "price": "$20",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-american-lock/7918561938.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912981635",
+    "title": "American Locks Series 2000 (4) for",
+    "price": "$120",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-american-locks-series-for/7912981635.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7933772681",
+    "title": "Ametek Battery Mate 80 Model 750M1 Forklift Battery Charger",
+    "price": "$199",
+    "location": "College Point",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/college-point-ametek-battery-mate-80/7933772681.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913435445",
+    "title": "Amprobe Clamp Meter",
+    "price": "$89",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-amprobe-clamp-meter/7913435445.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940785652",
+    "title": "Argon empty tank with regulator",
+    "price": "$130",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-argon-empty-tank-with-regulator/7940785652.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558511",
+    "title": "Armstrong Tool Stud Removers",
+    "price": "$20",
+    "location": "Ozone Park, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-armstrong-tool-stud-removers/7943558511.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937608392",
+    "title": "Arrow electric nail gun - Great condition",
+    "price": "$25",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/corona-arrow-electric-nail-gun-great/7937608392.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942632558",
+    "title": "ASPL saw blade 300x30x3,2 z=72 GS",
+    "price": "$75",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-aspl-saw-blade-300x30x32/7942632558.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939556757",
+    "title": "Assortment of extension cords",
+    "price": "$60",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-assortment-of-extension-cords/7939556757.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558394",
+    "title": "Automotive Tools",
+    "price": "$70",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-automotive-tools/7943558394.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558450",
+    "title": "Automotive Tools / Wrenches",
+    "price": "$65",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-automotive-tools-wrenches/7943558450.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942657948",
+    "title": "BG CT2 Coolant Transfusion System - Professional Coolant Exchange",
+    "price": "$600",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-bg-ct2-coolant-transfusion/7942657948.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7910696771",
+    "title": "Biohacking & wellness peptidess test janoshik",
+    "price": "$40",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-biohacking-wellness-peptidess/7910696771.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942855635",
+    "title": "Black & Decker Saw Blade Hedge Trimmer Corded",
+    "price": "$15",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-black-decker-saw-blade/7942855635.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913845396",
+    "title": "Blades Sabre Saw-JIG SAW (18) for",
+    "price": "$15",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-blades-sabre-saw-jig-saw-18-for/7913845396.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912982139",
+    "title": "Blades Saw All - Lenox 12\" long (5) for",
+    "price": "$20",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-blades-saw-all-lenox-12-long/7912982139.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913932472",
+    "title": "BLUE POINT 3/8 INPACT GUN",
+    "price": "$20",
+    "location": "OZONE PARK",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-blue-point-8-inpact-gun/7913932472.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924682589",
+    "title": "Bolt cutters",
+    "price": "$25",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-bolt-cutters/7924682589.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7944221058",
+    "title": "Bosch 11316evs",
+    "price": "$340",
+    "location": "Ridgewood  glendale queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-bosch-11316evs/7944221058.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916382217",
+    "title": "Bosch 125ft 3point leveling laser",
+    "price": "$100",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-bosch-125ft-3point-leveling/7916382217.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938557300",
+    "title": "Bosch Jigsaw",
+    "price": "$65",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-bosch-jigsaw/7938557300.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7922293621",
+    "title": "Braun series 3",
+    "price": "$25",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-braun-series/7922293621.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938558654",
+    "title": "Cable and web hoists/pullers",
+    "price": "$75",
+    "location": "Fresh meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/floral-park-cable-and-web-hoists-pullers/7938558654.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913205028",
+    "title": "Cart Flat Bed",
+    "price": "$325",
+    "location": "Farmingdale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/farmingdale-cart-flat-bed/7913205028.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912428689",
+    "title": "Charger, Two 18V M18 Batteries & Tool Bag for Milwaukee Drill Drivers",
+    "price": "$59",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-charger-two-18v-m18/7912428689.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943588237",
+    "title": "Chisels",
+    "price": "$10",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-chisels/7943588237.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918861407",
+    "title": "Cleaning out my workbench, all kinds of miscellaneous tools",
+    "price": "$50",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-cleaning-out-my-workbench-all/7918861407.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916398871",
+    "title": "Contour Gauge Set 10\"& 5'' Profile Duplicator Ruler W/Lock (BRAND NEW)",
+    "price": "$20",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-contour-gauge-set-10/7916398871.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246600",
+    "title": "Contour Gauge Set 10\"&5'' Profile Duplicator Ruler W/Lock (BRAND NEW)",
+    "price": "$20",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-contour-gauge-set-105/7909246600.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7917047742",
+    "title": "Corbin Russwin CL3351 NZD 626 Lockset",
+    "price": "$150",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-cl3351-nzd-626/7917047742.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935670595",
+    "title": "Corbin Russwin CL3351 NZD 626 Lockset",
+    "price": "$150",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-cl3351-nzd-626/7935670595.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915100125",
+    "title": "Corbin Russwin ML2003-LWA-630 Lockset",
+    "price": "$150",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-ml2003-lwa-630/7915100125.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912982566",
+    "title": "Core Removal Tool \"C and D\"",
+    "price": "$50",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-core-removal-tool-and/7912982566.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916211431",
+    "title": "CRAFTSMAN 20V tool set",
+    "price": "$450",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-craftsman-20v-tool-set/7916211431.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921363770",
+    "title": "Craftsman 47046 12 pc. SAE Combination Wrench Set w/ organizer, USA",
+    "price": "$40",
+    "location": "Jackson Heights, Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/jackson-heights-craftsman-pc-sae/7921363770.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925651084",
+    "title": "CRAFTSMAN 6500 TOOL BOX",
+    "price": "$55",
+    "location": "GLENDALE",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-craftsman-6500-tool-box/7925651084.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929124693",
+    "title": "Craftsman 9.0 HP 28\" Snow Blower",
+    "price": "$400",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-craftsman-90-hp-28-snow-blower/7929124693.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932005204",
+    "title": "Craftsman metal toolbox / drawers",
+    "price": "$30",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-craftsman-metal-toolbox-drawers/7932005204.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558283",
+    "title": "Craftsman Oil Filter Wrench",
+    "price": "$10",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-craftsman-oil-filter-wrench/7943558283.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916209589",
+    "title": "Craftsman Pro Series Router",
+    "price": "$150",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-craftsman-pro-series-router/7916209589.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930104555",
+    "title": "Crown Narrow Fork Pallet Jack",
+    "price": "$500",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-crown-narrow-fork-pallet-jack/7930104555.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929124225",
+    "title": "Cub Cadet 524 Snow Blower",
+    "price": "$400",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-cub-cadet-524-snow-blower/7929124225.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942817319",
+    "title": "Curtain rod",
+    "price": "$20",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/maspeth-curtain-rod/7942817319.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934640722",
+    "title": "Dewalt 1 3/4 pnuematic coil roofing nailgun",
+    "price": "$175",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-pnuematic-coil/7934640722.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942852646",
+    "title": "Dewalt 1.7ah twin pack powerstack batteries",
+    "price": "$130",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-17ah-twin-pack/7942852646.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222698",
+    "title": "DEWALT 10\" Heavy Duty Wet Tile Saw",
+    "price": "$400",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-dewalt-10-heavy-duty-wet-tile/7943222698.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915879966",
+    "title": "DEWALT 20-Volt MAX XR Cordless Brushless Compact Router",
+    "price": "$175",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-dewalt-20-volt-max-xr/7915879966.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943185358",
+    "title": "DeWalt 20v Cordless Pro Tools",
+    "price": "$500",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-dewalt-20v-cordless-pro-tools/7943185358.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940487318",
+    "title": "Dewalt 3 pc Combo Router kit, 3100 PSI pressure washer, BBQ Grill.",
+    "price": "$450",
+    "location": "Ozone park , Queens, NYC",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-pc-combo-router-kit/7940487318.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943154595",
+    "title": "DEWALT 9 Gallon Wet/Dry VAC, Heavy-Duty Shop Vacuum with Attachments",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-dewalt-gallon-wet-dry-vac-heavy/7943154595.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7923819015",
+    "title": "Dewalt battery pack kit",
+    "price": "$200",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-battery-pack-kit/7923819015.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942340260",
+    "title": "Dewalt battery pack kit",
+    "price": "$200",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-battery-pack-kit/7942340260.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937278351",
+    "title": "DeWALT DCD998B Max XR 1/2\" 20V Brushless Hammer Drill",
+    "price": "$199",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-dcd998b-max-xr/7937278351.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927720490",
+    "title": "Dewalt impact bit sets",
+    "price": "$15",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-impact-bit-sets/7927720490.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222438",
+    "title": "DeWalt Metal Chop Saw 14\"",
+    "price": "$80",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-dewalt-metal-chop-saw-14/7943222438.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558807",
+    "title": "Dies - Set of 5",
+    "price": "$20",
+    "location": "Ozone Park, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-dies-set-of/7943558807.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943800625",
+    "title": "DIY toolkit",
+    "price": "$20",
+    "location": "New York",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/new-york-diy-toolkit/7943800625.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943894641",
+    "title": "Door lock hole opener",
+    "price": "$50",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-door-lock-hole-opener/7943894641.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921094398",
+    "title": "DORMA Door Closer Model 7601 PA Sn1 Al",
+    "price": "$40",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-dorma-door-closer-model-7601/7921094398.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246743",
+    "title": "Drill Bit Organizer Rotatable in Blue",
+    "price": "$15",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-drill-bit-organizer/7909246743.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932454763",
+    "title": "Drill Bits - 705C-19/64",
+    "price": "$10",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-drill-bits-705c-19-64/7932454763.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916399279",
+    "title": "Drill Bits and Milling Cutter Tools Organizer (Orange)",
+    "price": "$15",
+    "location": "Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-and-milling/7916399279.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246697",
+    "title": "Drill Bits Milling Cutter Tools Organizer (Orange)",
+    "price": "$15",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-milling/7909246697.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916399347",
+    "title": "Drill Bits Organizer Rotatable (Blue)",
+    "price": "$15",
+    "location": "Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-organizer/7916399347.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927227737",
+    "title": "Drill kit",
+    "price": "$0",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-drill-kit/7927227737.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943588154",
+    "title": "Dust Collector system 4'' Y",
+    "price": "$5",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-dust-collector-system-y/7943588154.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7931773305",
+    "title": "Edwards RV3  Two Stage Rotary Vane Vacuum Pump",
+    "price": "$200",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-edwards-rv3-two-stage-rotary/7931773305.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924929438",
+    "title": "Edward\u2019s GS shop wall clock",
+    "price": "$80",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-edwards-gs-shop-wall-clock/7924929438.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943947990",
+    "title": "Ego snowbliwer",
+    "price": "$450",
+    "location": "Maspeth ny",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/maspeth-ego-snowbliwer/7943947990.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932726359",
+    "title": "Electric snowblower (Toro 1500 Power Curve)",
+    "price": "$50",
+    "location": "Kew Gardens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/kew-gardens-electric-snowblower-toro/7932726359.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912983008",
+    "title": "Electric Steel Fish Tape 50ft. (Ideal)",
+    "price": "$30",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-electric-steel-fish-tape-50ft/7912983008.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940785708",
+    "title": "Engraving Machine, Vigor EN-775",
+    "price": "$400",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-engraving-machine-vigor-en-775/7940785708.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943613265",
+    "title": "Esab Rebel 215 welder",
+    "price": "$2,599",
+    "location": "New York",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/new-york-esab-rebel-215-welder/7943613265.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937107332",
+    "title": "Evolution R355TCT 14\" Multi-Material Cutting Blade",
+    "price": "$55",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-evolution-r355tct-14/7937107332.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937979758",
+    "title": "Festool LR32 Guide Rail System Package (Excellent Condition)",
+    "price": "$320",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-festool-lr32-guide-rail/7937979758.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937980202",
+    "title": "Festool TS 55 FEQ-F-Plus Plunge-Cut Track Saw",
+    "price": "$525",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-festool-ts-55-feq-plus/7937980202.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7928769753",
+    "title": "Fiskars 18\" Machete with Sheath",
+    "price": "$10",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-fiskars-18-machete-with/7928769753.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925970644",
+    "title": "Freud 4 inch joiner machine",
+    "price": "$100",
+    "location": "south ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/south-ozone-park-freud-inch-joiner/7925970644.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943323590",
+    "title": "gain box & jobox",
+    "price": "$1,900",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-gain-box-jobox/7943323590.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913435844",
+    "title": "Gas Pressure Regulator",
+    "price": "$125",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-gas-pressure-regulator/7913435844.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915088285",
+    "title": "Gator Grip Universal Socket Wrench",
+    "price": "$4",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-gator-grip-universal-socket/7915088285.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912983425",
+    "title": "Gauges TIF for A/C & Refrigeration (3) for",
+    "price": "$79",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-gauges-tif-for-c-refrigeration/7912983425.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937104635",
+    "title": "General Tools No. 825 Drill Grinding Attachment (Brand New)",
+    "price": "$20",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-general-tools-no-825/7937104635.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943841027",
+    "title": "Gibson Les Paul Kirk Hammett Greeny 2025",
+    "price": "$2,500",
+    "location": "BELLEROSE MANOR",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-gibson-les-paul-kirk/7943841027.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915606951",
+    "title": "Graco TrueCoat 360 DSP Airless Paint Sprayer",
+    "price": "$325",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-graco-truecoat-360-dsp/7915606951.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918366313",
+    "title": "Graftsman circulating saw",
+    "price": "$89",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-graftsman-circulating-saw/7918366313.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918366060",
+    "title": "Graftsman circulating saw",
+    "price": "$89",
+    "location": "FLUSHING",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-graftsman-circulating-saw/7918366060.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943504107",
+    "title": "Greenlee knockout sets",
+    "price": "$100",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-greenlee-knockout-sets/7943504107.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913436294",
+    "title": "Halogen Leak Detector TIF",
+    "price": "$110",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-halogen-leak-detector-tif/7913436294.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943588321",
+    "title": "Hand Tools",
+    "price": "$5",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-hand-tools/7943588321.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937849448",
+    "title": "hand truck",
+    "price": "$165",
+    "location": "east elmhurst",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/east-elmhurst-hand-truck/7937849448.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936700470",
+    "title": "Hand truck",
+    "price": "$165",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/east-elmhurst-hand-truck/7936700470.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943844377",
+    "title": "Hand Truck",
+    "price": "$15",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-hand-truck/7943844377.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943420277",
+    "title": "Hand Truck\u00a0Aluminum",
+    "price": "$85",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-hand-truck-aluminum/7943420277.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937005815",
+    "title": "handtruck",
+    "price": "$165",
+    "location": "Jackson Heights",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/east-elmhurst-handtruck/7937005815.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916139319",
+    "title": "Heat Welding Kit",
+    "price": "$300",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-heat-welding-kit/7916139319.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7914022673",
+    "title": "Helium Regulator for Latex & Foil Balloons",
+    "price": "$149",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-helium-regulator-for-latex/7914022673.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7914022039",
+    "title": "Helium Regulator for Latex Balloons",
+    "price": "$59",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-helium-regulator-for-latex/7914022039.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941508455",
+    "title": "HILTI #3514171 SDS-MAX TE 70-ATC-AVR Corded Rotary Hammer Drill 120-Vo",
+    "price": "$1,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-hilti-sds-max-te-70-atc/7941508455.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222523",
+    "title": "Hilti DX2 Powder Actuated Fastening Tool",
+    "price": "$200",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-hilti-dx2-powder-actuated/7943222523.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936966927",
+    "title": "HK Porter 2790 heavy-duty slotted angle iron shears",
+    "price": "$40",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-hk-porter-2790-heavy-duty/7936966927.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943327068",
+    "title": "Hoists 2000 LBS & 1000LBS",
+    "price": "$2,500",
+    "location": "Astoria, NY Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-hoists-2000-lbs-1000lbs/7943327068.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934937810",
+    "title": "Homelite 16 in electric chainsaw",
+    "price": "$90",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-homelite-16-in-electric/7934937810.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939590092",
+    "title": "Homelite Mighty Lite 26bp Backpack Blower",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/east-elmhurst-homelite-mighty-lite-26bp/7939590092.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915269355",
+    "title": "Hunter DSP400 Alignment Machine (Parts Only)",
+    "price": "$800",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-hunter-dsp400-alignment/7915269355.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558200",
+    "title": "Husky and Armstrong 1/2\" Drive Sockets",
+    "price": "$23",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-husky-and-armstrong-2-drive/7943558200.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7907004293",
+    "title": "Husky BS1004W 4 gal. 135 psi compressor w/ hose",
+    "price": "$150",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-husky-bs1004w-gal-135-psi/7907004293.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937101451",
+    "title": "IRWIN Record 1/2\" Heavy Duty Pipe Clamp (Brand New)",
+    "price": "$15",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-irwin-record-2-heavy/7937101451.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918478857",
+    "title": "IRWIN VISE-GRIP 2078612/2078610 12/10\" ProPliers Adjustable Wrench Set",
+    "price": "$35",
+    "location": "Jackson Heights, Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/jackson-heights-irwin-vise-grip/7918478857.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916272954",
+    "title": "JigSaw blades",
+    "price": "$2",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-jigsaw-blades/7916272954.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942744631",
+    "title": "JMR Electric Hydraulic Tubing Bender & Tooling",
+    "price": "$2,500",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-jmr-electric-hydraulic-tubing/7942744631.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925210200",
+    "title": "John Bean Prism Alignment Machine Toolbox Style",
+    "price": "$5,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-john-bean-prism-alignment/7925210200.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937106614",
+    "title": "Kreg Bench Dogs 3/4\" Hole Diameter (Brand New)",
+    "price": "$10",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-kreg-bench-dogs-4-hole/7937106614.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937102741",
+    "title": "Kreg KHC6 Automaxx 6\" Wood Project Clamp",
+    "price": "$65",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-kreg-khc6-automaxx-wood/7937102741.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246645",
+    "title": "Leather Work Apron With 6 Pockets Tool Heavy Duty",
+    "price": "$15",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-leather-work-apron-with/7909246645.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916399207",
+    "title": "Leather Work Apron With 6 Pockets Tool Heavy Duty",
+    "price": "$15",
+    "location": "Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-leather-work-apron-with/7916399207.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558104",
+    "title": "Lineman Pliers and wire stripper",
+    "price": "$14",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-lineman-pliers-and-wire/7943558104.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935581952",
+    "title": "Long Sleeve Navy Blue Size XLarge Shirt With Front Pocket \u2013 4 Pc",
+    "price": "$8",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-long-sleeve-navy-blue-size/7935581952.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943143066",
+    "title": "Lots of Tools",
+    "price": "$0",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-lots-of-tools/7943143066.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7931966072",
+    "title": "Louisville 8 ft ladder / fiberglass",
+    "price": "$75",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-louisville-ft-ladder-fiberglass/7931966072.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915088393",
+    "title": "Lufkin 16ft Mezurlok Power Tape & Folding Ruler",
+    "price": "$6",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-lufkin-16ft-mezurlok-power/7915088393.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916401825",
+    "title": "Magnetic Tool Holder 18'' (Brand New)",
+    "price": "$10",
+    "location": "Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-magnetic-tool-holder-18/7916401825.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937216593",
+    "title": "MagSwitch Magnetic Featherboard for Table Saw/Router Table/Band Saw",
+    "price": "$45",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-magswitch-magnetic/7937216593.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936755349",
+    "title": "Makita 18 volt charger",
+    "price": "$75",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7936755349.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939337950",
+    "title": "Makita 18 volt charger",
+    "price": "$75",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7939337950.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939918367",
+    "title": "Makita 18 volt sawzall and hammer drill",
+    "price": "$125",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7939918367.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222213",
+    "title": "Makita Circular Saw 7-1/4\"",
+    "price": "$30",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-makita-circular-saw-1/7943222213.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941916980",
+    "title": "Makita EK6101 Cut-Off Saw",
+    "price": "$880",
+    "location": "New York",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/new-york-makita-ek6101-cut-off-saw/7941916980.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222283",
+    "title": "Makita Plate (Biscuit) Joiner PJ7000",
+    "price": "$150",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-makita-plate-biscuit-joiner/7943222283.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222352",
+    "title": "Makita SDS-Max Rotary Hammer",
+    "price": "$200",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-makita-sds-max-rotary-hammer/7943222352.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921156221",
+    "title": "Makita XMU04ZX Grass Shear with Hedge Trimmer Blade",
+    "price": "$140",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-makita-xmu04zx-grass/7921156221.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916392002",
+    "title": "Makita XMU04ZX Grass Shear with Hedge Trimmer Blade",
+    "price": "$140",
+    "location": "Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-makita-xmu04zx-grass/7916392002.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919407628",
+    "title": "Malco HVAC tin knockers duct hammer",
+    "price": "$40",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-malco-hvac-tin-knockers-duct/7919407628.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942358196",
+    "title": "Map/Pro tanks gas (TurboTorch) 2 for",
+    "price": "$35",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-map-pro-tanks-gas-turbotorch/7942358196.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938264863",
+    "title": "Massive Tool and Hardware Sale",
+    "price": "$1",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-massive-tool-and-hardware/7938264863.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7918537286",
+    "title": "Mechanix Wear SMP-91-010 - M-Pact Resistant Gloves Size: X Large",
+    "price": "$10",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-mechanix-wear-smp-pact/7918537286.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7923133329",
+    "title": "Merit 180 Grit 25,000 RPM 1/4\" Sanding Flap Wheels For Drill",
+    "price": "$20",
+    "location": "Woodside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/woodside-merit-180-grit-rpm-4-sanding/7923133329.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909419800",
+    "title": "Metabo 4 1/2 in angle grinder",
+    "price": "$55",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-metabo-in-angle-grinder/7909419800.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929237569",
+    "title": "Metal Counter Sinks",
+    "price": "$45",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-metal-counter-sinks/7929237569.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938564488",
+    "title": "Metal Machine Cutting Bit",
+    "price": "$25",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-metal-machine-cutting-bit/7938564488.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222040",
+    "title": "MetalTech Baker Rolling Scaffold",
+    "price": "$150",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-metaltech-baker-rolling/7943222040.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7914185988",
+    "title": "micro lath",
+    "price": "$2,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/corona-micro-lath/7914185988.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937978460",
+    "title": "MicroJig MATCHFIT Dado Stop DS-333 (Brand New)",
+    "price": "$20",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-microjig-matchfit-dado/7937978460.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921094115",
+    "title": "MILLERS FALLS NO 120 B HAND DRILL HEAVY DUTY \u00bd\" CHUCK TWO SPEED BREAST USA VTG",
+    "price": "$40",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-millers-falls-no-120-hand/7921094115.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918941615",
+    "title": "Milwaukee 18 volt 1/4 in impact kit",
+    "price": "$140",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-18-volt-4-in/7918941615.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941370450",
+    "title": "Milwaukee 18 volt compact 1/2 in drill kit",
+    "price": "$145",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-milwaukee-18-volt/7941370450.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7911640901",
+    "title": "Milwaukee 18V Tool Kit w/ 2 Drill Drivers, Charger, 2 Batteries & Bag",
+    "price": "$99",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-milwaukee-18v-tool-kit-2-drill/7911640901.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7910753856",
+    "title": "MILWAUKEE 2551-22 M12 FUEL\u2122 1/4\" HEX HYDRAULIC DRIVER KIT \u2013 NEW IN BOX",
+    "price": "$200",
+    "location": "OZONE PARK",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-m12-fuel-4-hex/7910753856.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929933284",
+    "title": "Milwaukee electric chainsaw",
+    "price": "$30",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-milwaukee-electric-chainsaw/7929933284.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557929",
+    "title": "Milwaukee Maximum Leverage Durable Grip and Hammer",
+    "price": "$31",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-maximum-leverage/7943557929.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924053470",
+    "title": "Milwaukee MX FUEL Lithium-Ion Cordless 1-1/8 in. Breaker with Battery",
+    "price": "$1,800",
+    "location": "College Point",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/college-point-milwaukee-mx-fuel-lithium/7924053470.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913020724",
+    "title": "Milwaukee rotary hammer drill",
+    "price": "$99",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913020724.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918365910",
+    "title": "Milwaukee rotary hammer drill",
+    "price": "$99",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-rotary-hammer-drill/7918365910.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913414278",
+    "title": "Milwaukee rotary hammer drill",
+    "price": "$99",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913414278.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913414356",
+    "title": "Milwaukee rotary hammer drill",
+    "price": "$99",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913414356.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943893135",
+    "title": "Milwaukee saw zall",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-milwaukee-saw-zall/7943893135.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222118",
+    "title": "Milwaukee Sawzall 12AMP Corded",
+    "price": "$40",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-sawzall-12amp-corded/7943222118.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222778",
+    "title": "Milwaukee Super Sawzall 15A Brand New",
+    "price": "$150",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-super-sawzall-15a/7943222778.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919407261",
+    "title": "Milwaukee utility knife",
+    "price": "$5",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-milwaukee-utility-knife/7919407261.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942932523",
+    "title": "Motor",
+    "price": "$20",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-motor/7942932523.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942936080",
+    "title": "Motor",
+    "price": "$20",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-motor/7942936080.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939137557",
+    "title": "MotorVac TransTech III Transmission Service System \u2013 MTT1000IIIP",
+    "price": "$1,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-motorvac-transtech-iii/7939137557.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912983886",
+    "title": "Multimeter Fluke",
+    "price": "$75",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-multimeter-fluke/7912983886.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924539504",
+    "title": "Naphtha - 32oz unopened container",
+    "price": "$13",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-naphtha-32oz-unopened-container/7924539504.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937841277",
+    "title": "Nespresso",
+    "price": "$12",
+    "location": "ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-nespresso/7937841277.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918371487",
+    "title": "New 2 sets plus extra SK Professional 86124 Combination Wrench Sets",
+    "price": "$300",
+    "location": "south ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/south-ozone-park-new-sets-plus-extra-sk/7918371487.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925975934",
+    "title": "New Dewalt 1/2 inch impact wrench",
+    "price": "$200",
+    "location": "south ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/south-ozone-park-new-dewalt-2-inch/7925975934.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939893978",
+    "title": "NEW PELICAN VAULT 370 TACTICAL RIFLE CASE + PADDING | CAMPING STORAGE",
+    "price": "$200",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-new-pelican-vault-370-tactical/7939893978.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7926374867",
+    "title": "New Safety Helmet New in box",
+    "price": "$40",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-new-safety-helmet-new-in-box/7926374867.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932652505",
+    "title": "Norton 1601BF-DA-689 Door Closer Delayed Action,",
+    "price": "$50",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-norton-1601bf-da-689-door/7932652505.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932651947",
+    "title": "Norton Door Closer 9303BCX9318A Regular Arm w/ Soffit Plate & Backcheck",
+    "price": "$50",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-norton-door-closer/7932651947.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936138133",
+    "title": "Pfanner Protos Integral Arborist / Forestry Helmet (Brand New)",
+    "price": "$260",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-pfanner-protos-integral/7936138133.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913436749",
+    "title": "Phototacometer TIF",
+    "price": "$120",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-phototacometer-tif/7913436749.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942779851",
+    "title": "Pioneerworks Sewar & Drain Cleaner",
+    "price": "$150",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-pioneerworks-sewar-drain/7942779851.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943588291",
+    "title": "plane",
+    "price": "$15",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-plane/7943588291.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558030",
+    "title": "Power Strip and Timer",
+    "price": "$15",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-power-strip-and-timer/7943558030.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943586064",
+    "title": "Powermatic 45 Wood Lathe",
+    "price": "$1,050",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-powermatic-45-wood-lathe/7943586064.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942744484",
+    "title": "Powermatic Tilt Table Mortiser, 1\" Chisel, 10-3/4\" Stroke, 115/230V 1Ph (719T)",
+    "price": "$750",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-powermatic-tilt-table-mortiser/7942744484.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930168891",
+    "title": "Powersmart Snowblower - 26 inch wide",
+    "price": "$160",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-powersmart-snowblower-26-inch/7930168891.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929819404",
+    "title": "Pro-Cut PFM 9.2 On-Car Brake Lathe",
+    "price": "$2,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-pro-cut-pfm-92-on-car-brake/7929819404.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913437207",
+    "title": "Refrigerant Charging Cylinder",
+    "price": "$25",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-refrigerant-charging-cylinder/7913437207.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939591254",
+    "title": "Ride1up ebike - salvage",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/east-elmhurst-ride1up-ebike-salvage/7939591254.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942203537",
+    "title": "Ridgid 100-B pro press tool and jaw set",
+    "price": "$500",
+    "location": "New York",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/new-york-ridgid-100-pro-press-tool-and/7942203537.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943076051",
+    "title": "RIDGID 300 PIPE THREADING MACHINE w/ STAND *****6-Month Warranty******",
+    "price": "$1,800",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-ridgid-300-pipe/7943076051.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942243695",
+    "title": "RIDGID 9-Amp 7 in. Blade Corded Wet Tile Saw with Stand",
+    "price": "$250",
+    "location": "South Richmond Hill",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/south-richmond-hill-ridgid-amp-in-blade/7942243695.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919635753",
+    "title": "RIDGID CA-25 Micro Visual Inspection",
+    "price": "$120",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-ridgid-ca-25-micro-visual/7919635753.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942980473",
+    "title": "Ridgid Foldable Mobile Miter Saw Stand",
+    "price": "$80",
+    "location": "fresh meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-ridgid-foldable-mobile/7942980473.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943214337",
+    "title": "Ridgid tile saw",
+    "price": "$150",
+    "location": "Howard beach",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/kew-gardens-ridgid-tile-saw/7943214337.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935263150",
+    "title": "Ridgid U 36 bolt cutters",
+    "price": "$25",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-ridgid-36-bolt-cutters/7935263150.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936139052",
+    "title": "RIDGID Wet/Dry Vac Pump Accessory VP2000 (Brand New)",
+    "price": "$80",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-ridgid-wet-dry-vac-pump/7936139052.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7914174162",
+    "title": "Ridgit cooper pipe cutter",
+    "price": "$59",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-ridgit-cooper-pipe-cutter/7914174162.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7914463399",
+    "title": "Ridgit cooper pipe cutter",
+    "price": "$59",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-ridgit-cooper-pipe-cutter/7914463399.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932456059",
+    "title": "Right Snips Stanley FatMax  FMHT73557",
+    "price": "$10",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-right-snips-stanley-fatmax/7932456059.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934395791",
+    "title": "Rigid 5/8 in electric hammer drill",
+    "price": "$85",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-8-in-electric-hammer/7934395791.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929437165",
+    "title": "Rigid dual 18 volt charger & 2 18 volt 4.0ah batteries",
+    "price": "$125",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-dual-18-volt-charger/7929437165.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909419849",
+    "title": "Rigid gen 5 brushless belt sander",
+    "price": "$65",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-gen-brushless-belt/7909419849.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943221881",
+    "title": "Rigid Jobsite Portable 10' Table Saw with Integrated Stand with wheels",
+    "price": "$250",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-rigid-jobsite-portable-10/7943221881.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943222611",
+    "title": "Rigid NXT HD Shop Vac 6HP, 14gal capacity",
+    "price": "$60",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/rego-park-rigid-nxt-hd-shop-vac-6hp/7943222611.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937105716",
+    "title": "Rockler Woodworking Glue Applicator Kit (Brand New)",
+    "price": "$20",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-rockler-woodworking/7937105716.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940930082",
+    "title": "Router.. complete with case. Dewalt DW618 Three Piece Combo Router kit",
+    "price": "$450",
+    "location": "Ozone park , Queens, NYC",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-router-complete-with-case/7940930082.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941825811",
+    "title": "Ryobi 1/2 in drill kit",
+    "price": "$95",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-2-in-drill-kit/7941825811.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919065452",
+    "title": "Ryobi 10 in electric buffer/polisher",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-10-in-electric-buffer/7919065452.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937742213",
+    "title": "Ryobi 18 volt charger",
+    "price": "$35",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-charger/7937742213.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918941703",
+    "title": "Ryobi 18 volt corner cat sander",
+    "price": "$40",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-corner-cat/7918941703.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934395991",
+    "title": "Ryobi 18 volt grass shear and shrubber trimmer",
+    "price": "$80",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-grass-shear/7934395991.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937741249",
+    "title": "Ryobi 18 volt sawzall kit",
+    "price": "$85",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-sawzall-kit/7937741249.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937741930",
+    "title": "Ryobi 18volt Electrostatic Sprayer",
+    "price": "$35",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18volt-electrostatic/7937741930.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927719812",
+    "title": "Ryobi 4 1/2 in 18 volt grinder",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-18-volt-grinder/7927719812.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7920983790",
+    "title": "Ryobi 4 1/2 in 18 volt grinder",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-18-volt-grinder/7920983790.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934396748",
+    "title": "Ryobi 4.0 ah 40 volt battery",
+    "price": "$100",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-ah-40-volt-battery/7934396748.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934396580",
+    "title": "Ryobi 40 volt 4.0 battery and rapid charger kit",
+    "price": "$140",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-volt-40-battery-and/7934396580.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934396276",
+    "title": "Ryobi 40 volt Rapid charger",
+    "price": "$85",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-volt-rapid-charger/7934396276.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927719479",
+    "title": "Ryobi 6 amp electric belt sander",
+    "price": "$75",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-amp-electric-belt/7927719479.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925812415",
+    "title": "Ryobi 6 amp electric belt sander",
+    "price": "$75",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-amp-electric-belt/7925812415.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7923818955",
+    "title": "Ryobi 6in electric buffer",
+    "price": "$45",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-6in-electric-buffer/7923818955.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934937930",
+    "title": "Ryobi 7 1/4 in carbide 24 teeth thin kerf saw blades",
+    "price": "$8",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-carbide-24-teeth/7934937930.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934397050",
+    "title": "Ryobi brushless hammer drill kit",
+    "price": "$150",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-brushless-hammer-drill/7934397050.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941818085",
+    "title": "Ryobi Brushless jigsaw",
+    "price": "$75",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-ryobi-brushless/7941818085.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936074434",
+    "title": "RYOBI CIRCULAR SAW",
+    "price": "$35",
+    "location": "GLENDALE",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-ryobi-circular-saw/7936074434.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943940115",
+    "title": "Ryobi CSB142LZ Corded Electric Circular Saw w free drill",
+    "price": "$30",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-ryobi-csb142lz-corded-electric/7943940115.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918941729",
+    "title": "Ryobi electric corner cat sander",
+    "price": "$50",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-electric-corner-cat/7918941729.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937180755",
+    "title": "Ryobi electric router",
+    "price": "$85",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-electric-router/7937180755.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935003296",
+    "title": "RYOBI JIG SAW",
+    "price": "$35",
+    "location": "GLENDALE",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ridgewood-ryobi-jig-saw/7935003296.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919361189",
+    "title": "Safety Tape Applicator",
+    "price": "$60",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-safety-tape-applicator/7919361189.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943504619",
+    "title": "Sand blaster",
+    "price": "$100",
+    "location": "Whitestone",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/whitestone-sand-blaster/7943504619.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913437736",
+    "title": "Scotch-Brite Hand Pads (4) for",
+    "price": "$10",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-scotch-brite-hand-pads-for/7913437736.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939900790",
+    "title": "SEALED NEW TRAVEL LOCKS TSA COMBI LOCK LUGGAGE BIKE KEYS STORAGE",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-sealed-new-travel-locks-tsa/7939900790.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912984347",
+    "title": "Shear Electric (Bosch)",
+    "price": "$150",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-shear-electric-bosch/7912984347.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913438321",
+    "title": "Sheet Metal Snip Tools Set",
+    "price": "$35",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-sheet-metal-snip-tools-set/7913438321.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7919163368",
+    "title": "Short Hatchet",
+    "price": "$10",
+    "location": "Ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-short-hatchet/7919163368.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943321443",
+    "title": "Signs",
+    "price": "$2,500",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-signs/7943321443.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557689",
+    "title": "Simpson 467 Digital Multi Meter",
+    "price": "$30",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-simpson-467-digital-multi/7943557689.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7934805578",
+    "title": "SK Wayne ratchet set",
+    "price": "$60",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-sk-wayne-ratchet-set/7934805578.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943895964",
+    "title": "Skil circular saw",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-skil-circular-saw/7943895964.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943154786",
+    "title": "SKIL Corded Multi-Function Detail Sander with Micro-Filter Dust Box",
+    "price": "$40",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-skil-corded-multi-function/7943154786.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943892368",
+    "title": "Skil router table with router",
+    "price": "$100",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/astoria-skil-router-table-with-router/7943892368.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939746045",
+    "title": "Snap on charger",
+    "price": "$45",
+    "location": "Ozone park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/springfield-gardens-snap-on-charger/7939746045.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7907130214",
+    "title": "Snap On John Bean V2400 Visualiner 3D/3D2 Alignment Machine",
+    "price": "$10,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-john-bean-v2400/7907130214.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940103612",
+    "title": "Snap On Torque Wrench -Inch Pounds- Needs Repair",
+    "price": "$60",
+    "location": "Glendale",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-snap-on-torque-wrench/7940103612.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943998377",
+    "title": "Snap-On 304D Wheel Balancer Used Excellent Working Condition",
+    "price": "$3,350",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-304d-wheel-balancer/7943998377.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942658030",
+    "title": "Snap-on MM250SL MIG Welder",
+    "price": "$1,500",
+    "location": "Astoria",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-snap-on-mm250sl-mig-welder/7942658030.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935755840",
+    "title": "Snap-On Polartek Plus Model EEAC331B R134a A/C Machine",
+    "price": "$7,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-polartek-plus-model/7935755840.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916528096",
+    "title": "Snap-On Wrenchs : Industrial GOEX Combination Wrench Set 11 pieces 2\" to 1 5/16\"",
+    "price": "$750",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-snap-on-wrenchs-industrial/7916528096.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7908785083",
+    "title": "SNOW JOE ION18SB-HYB-RM 40-VOLT IONMAX HYBRID SINGLE STAGE SNOW BLOWER",
+    "price": "$220",
+    "location": "OZONE PARK",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-snow-joe-ion18sb-hyb-rm-40/7908785083.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936589694",
+    "title": "Solder Wire: Kester SN63PB37 #66/44, 0.80mm/0.031\u201d",
+    "price": "$40",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-solder-wire-kester-sn63pb/7936589694.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913846922",
+    "title": "Soldering Gun (Weller)",
+    "price": "$59",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-soldering-gun-weller/7913846922.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943075316",
+    "title": "Spartan 1065 Sewer Machine w/Autofeed",
+    "price": "$2,000",
+    "location": "Queens Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/hollis-spartan-1065-sewer-machine/7943075316.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913652543",
+    "title": "Spectroline Lamp",
+    "price": "$89",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-spectroline-lamp/7913652543.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913934014",
+    "title": "SPRING COMPRESSER TOOL",
+    "price": "$10",
+    "location": "OZONE PARK",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-spring-compresser-tool/7913934014.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913438970",
+    "title": "Stay Brite #8 Soft Soldering 1 Lb.",
+    "price": "$49",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-stay-brite-soft-soldering-lb/7913438970.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937045585",
+    "title": "Stihl FSB-KM Curved Shaft Trimmer",
+    "price": "$50",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-stihl-fsb-km-curved/7937045585.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942816180",
+    "title": "Strainer",
+    "price": "$6",
+    "location": "ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-strainer/7942816180.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7939137530",
+    "title": "Sun Motorvac Carbon Clean System EEFS100A Fuel System Cleaning Machine",
+    "price": "$1,500",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/asbury-park-sun-motorvac-carbon-clean/7939137530.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943910398",
+    "title": "Super Nice Miller Tig Welder Synchrowave 200 / CJ Flex Torch",
+    "price": "$2,550",
+    "location": "New York",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/new-york-super-nice-miller-tig-welder/7943910398.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935572836",
+    "title": "T-Shirts Size XL,2X,2XL 100% Cotton, with Front Pocket Color \u2013 BLUE",
+    "price": "$4",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-shirts-size-xl2x2xl-100/7935572836.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7935574317",
+    "title": "T-Shirts Size XXL, 100% Cotton, with Front Pocket, Color \u2013 White 4Pc.",
+    "price": "$4",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-shirts-size-xxl-100-cotton/7935574317.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7925675881",
+    "title": "Tacktical Flashlight",
+    "price": "$8",
+    "location": "Kew gardens queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/kew-gardens-tacktical-flashlight/7925675881.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936217129",
+    "title": "Tacktical Flashlight",
+    "price": "$8",
+    "location": "Kew gardens queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/kew-gardens-tacktical-flashlight/7936217129.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913439950",
+    "title": "Temperature Chart Recorder (Dickson)",
+    "price": "$20",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-temperature-chart-recorder/7913439950.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913652985",
+    "title": "Thermometer by Cooper Instrument",
+    "price": "$130",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-thermometer-by-cooper/7913652985.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7933165380",
+    "title": "TICONN 13'' Rivet Gun Kit with Metric & SAE 7 Mandrels and Rivet Nuts",
+    "price": "$70",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-ticonn-13-rivet-gun-kit/7933165380.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916393523",
+    "title": "TICONN 13'' Rivet Gun Kit with Metric & SAE 7 Mandrels and Rivet Nuts",
+    "price": "$70",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-ticonn-13-rivet-gun-kit/7916393523.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7909246254",
+    "title": "Toro Leaf Blower",
+    "price": "$50",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-toro-leaf-blower/7909246254.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930521875",
+    "title": "Transport Moving Rolling Flat Cart",
+    "price": "$250",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-transport-moving-rolling-flat/7930521875.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937682719",
+    "title": "Tray",
+    "price": "$12",
+    "location": "ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-tray/7937682719.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7931857612",
+    "title": "Trimmer Head Dual Line Bump & Feed VP33 Rotary 10231",
+    "price": "$35",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-trimmer-head-dual-line/7931857612.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912984829",
+    "title": "Turbo Torch (Hand)",
+    "price": "$70",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-turbo-torch-hand/7912984829.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7912985286",
+    "title": "TurboTorch  A-5 Tip",
+    "price": "$75",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-turbotorch-5-tip/7912985286.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921052785",
+    "title": "Two (2) DeWalt Drill Driver and Hammer Drill Tools + Hard Case and Tool Bag",
+    "price": "$69",
+    "location": "Brooklyn",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-two-dewalt-drill-driver-and/7921052785.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7915808856",
+    "title": "Two (2) Milwaukee 18V Hammer Drill Drivers M18 Tool Only",
+    "price": "$59",
+    "location": "Ozone Park",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-two-milwaukee-18v-hammer/7915808856.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943557496",
+    "title": "Two 4 way Screwdrivers",
+    "price": "$15",
+    "location": "Queens, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-two-way-screwdrivers/7943557496.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937348980",
+    "title": "Two used Werner Portable Rolling Scaffold 500 lb. Load",
+    "price": "$80",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-two-used-werner-portable/7937348980.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7930098348",
+    "title": "Uboat Transport Cart Merchandise Utility Stock Rolling Cart",
+    "price": "$250",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/bayside-uboat-transport-cart/7930098348.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7932652082",
+    "title": "Universal Hardware 4013 Heavy-Duty Ivory Residential Door Closer",
+    "price": "$40",
+    "location": "Sunnyside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/sunnyside-universal-hardware-4013-heavy/7932652082.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7923631712",
+    "title": "USED HONDA EU2000 4SALE",
+    "price": "$1",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-used-honda-eu2000-4sale/7923631712.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7913847750",
+    "title": "Vacuum Pump",
+    "price": "$110",
+    "location": "Flushing",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-vacuum-pump/7913847750.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7942817114",
+    "title": "VACUUM Pump oil",
+    "price": "$10",
+    "location": "ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/maspeth-vacuum-pump-oil/7942817114.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943558736",
+    "title": "Vermont American Tap Set & Cutting Tools",
+    "price": "$25",
+    "location": "Ozone Park, NY",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/ozone-park-vermont-american-tap-set/7943558736.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7927465666",
+    "title": "VICE --- Medium size Vintage Bench VICE",
+    "price": "$60",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-vice-medium-size-vintage/7927465666.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7906875704",
+    "title": "Vintage Bear Hunter Pocket Knife",
+    "price": "$20",
+    "location": "Forest Hills",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-vintage-bear-hunter-pocket/7906875704.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938556468",
+    "title": "Vintage Craftsman Orbital Sander",
+    "price": "$45",
+    "location": "Fresh meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-craftsman-orbital/7938556468.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938557996",
+    "title": "Vintage Craftsman Pipe Tubing Cutter",
+    "price": "$25",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-craftsman-pipe/7938557996.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7938557691",
+    "title": "Vintage General Electric Jig Saw",
+    "price": "$65",
+    "location": "Fresh Meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-general-electric/7938557691.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916358232",
+    "title": "Vintage mini/rachet snap-on Gm-70m with 8mm socket",
+    "price": "$40",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/richmond-hill-vintage-mini-rachet-snap/7916358232.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7937690612",
+    "title": "Visegrip",
+    "price": "$20",
+    "location": "ridgewood",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/brooklyn-visegrip/7937690612.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936077265",
+    "title": "Wagner FLEXiO 590 Paint Sprayer Kit \u2013 Indoor & Outdoor HVLP Sprayer",
+    "price": "$65",
+    "location": "Bayside",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/oakland-gardens-wagner-flexio-590-paint/7936077265.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7921274659",
+    "title": "Wall Switch WSX WH PIR Occupancy Sensor, 1-Pole, 120/277 Volt, White",
+    "price": "$15",
+    "location": "queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/forest-hills-wall-switch-wsx-wh-pir/7921274659.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7940446303",
+    "title": "Wavetek BDM-40 Benchtop Meter",
+    "price": "$120",
+    "location": "BELLEROSE MANOR",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-wavetek-bdm-40-benchtop/7940446303.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7941282269",
+    "title": "Wavetek BDM-40 Benchtop Meter",
+    "price": "$120",
+    "location": "BELLEROSE MANOR",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/queens-village-wavetek-bdm-40-benchtop/7941282269.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943113601",
+    "title": "WEN 2.3-Amp 8-inch 5-speed cast iron benchtop drill press",
+    "price": "$90",
+    "location": "Maspeth",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/maspeth-wen-23-amp-inch-speed-cast-iron/7943113601.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7936215381",
+    "title": "Werner 22 ft. Aluminum Telescoping Multi-Position Ladder with 300 lbs.",
+    "price": "$250",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-werner-22-ft-aluminum/7936215381.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7916390311",
+    "title": "Werner 22 ft. Aluminum Telescoping Multi-Position Ladder with 300 lbs.",
+    "price": "$250",
+    "location": "Queens, Middle Village",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/middle-village-werner-22-ft-aluminum/7916390311.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7929237730",
+    "title": "Woods Powr Grip",
+    "price": "$35",
+    "location": "Fresh meadows",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/fresh-meadows-woods-powr-grip/7929237730.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7924053635",
+    "title": "Zipwall SLP2",
+    "price": "$125",
+    "location": "Queens",
+    "category": "tls",
+    "url": "https://newyork.craigslist.org/que/tls/d/flushing-zipwall-slp2/7924053635.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7943727152",
+    "title": "Element Lux Dark Amber Blue Light Blocking Glasses",
+    "price": "$15",
+    "location": "Long Island City",
+    "category": "vgm",
+    "url": "https://newyork.craigslist.org/que/vgm/d/long-island-city-element-lux-dark-amber/7943727152.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7940103604",
+    "title": "WTB: COMPUTER LAPTOP, PC & SERVER MEMORY/RAM + INTEL XEON CPUs/PROCESS",
+    "price": "",
+    "location": "WE BUY INTEL, MICRON, SK/HYNIX, SAMSUNG, DELL, CISCO, HP/HPE",
+    "category": "wad",
+    "url": "https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-computer-laptop-pc/7940103604.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941248108",
+    "title": "WTB: DATA CENTER, NETWORKING, COMPUTER SERVERS, GPUs, RAM/MEMORY-MORE!",
+    "price": "",
+    "location": "WE BUY CISCO, NVIDIA, JUNIPER, INTEL, DELL, HP, HPE & MORE $",
+    "category": "wad",
+    "url": "https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-data-center/7941248108.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7941239873",
+    "title": "WTB: DATA CENTER, NETWORKING, COMPUTER SERVERS, GPUs, RAM/MEMORY-MORE!",
+    "price": "",
+    "location": "WE BUY CISCO, NVIDIA, JUNIPER, INTEL, DELL, HP, HPE & MORE $",
+    "category": "wad",
+    "url": "https://newyork.craigslist.org/que/wad/d/jamaica-wtb-data-center-networking/7941239873.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942916508",
+    "title": "WTB: MICRON, SK/HYNIX, SAMSUNG, INTEL, CISCO, RAM, MEMORY, CPUs & MORE",
+    "price": "",
+    "location": "WE BUY COMPUTER PROCESSORS/CPU\u2019S, SERVER/PC/LAPTOP MEMORY",
+    "category": "wad",
+    "url": "https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-micron-sk-hynix/7942916508.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7942709388",
+    "title": "WTB: MICRON, SK/HYNIX, SAMSUNG, INTEL, CISCO, RAM, MEMORY, CPUs & MORE",
+    "price": "",
+    "location": "WE BUY COMPUTER PROCESSORS/CPU\u2019S, SERVER/PC/LAPTOP MEMORY",
+    "category": "wad",
+    "url": "https://newyork.craigslist.org/que/wad/d/jamaica-wtb-micron-sk-hynix-samsung/7942709388.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7911490949",
+    "title": "CASH FOR GIFT CARDS STORE CREDITS + ELECTRONICS + HAND TOOLS WANTED",
+    "price": "",
+    "location": "JAMAICA QUEENS, NY",
+    "category": "wan",
+    "url": "https://newyork.craigslist.org/que/wan/d/wyandanch-cash-for-gift-cards-store/7911490949.html",
+    "matched_query": "tools"
+  },
+  {
+    "pid": "7918103730",
+    "title": "FREE Scrap Electronics for Recycling in Rego Park",
+    "price": "$0",
+    "location": "Rego Park, Queens",
+    "category": "zip",
+    "url": "https://newyork.craigslist.org/que/zip/d/rego-park-free-scrap-electronics-for/7918103730.html",
+    "matched_query": "electronics"
+  },
+  {
+    "pid": "7938169744",
+    "title": "FREE \u2013 Hospital/Adjustable Bed with Mattress \u2013 You Haul",
+    "price": "$0",
+    "location": "New York",
+    "category": "zip",
+    "url": "https://newyork.craigslist.org/que/zip/d/astoria-free-hospital-adjustable-bed/7938169744.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7936290839",
+    "title": "Two-way (6-part) computer mailers",
+    "price": "$0",
+    "location": "Fresh Meadows/Jamaica",
+    "category": "zip",
+    "url": "https://newyork.craigslist.org/que/zip/d/fresh-meadows-two-way-part-computer/7936290839.html",
+    "matched_query": "computer"
+  },
+  {
+    "pid": "7937925940",
+    "title": "UPLIFT Ergonomic Adjustable Keyboard Tray",
+    "price": "$0",
+    "location": "Astoria",
+    "category": "zip",
+    "url": "https://newyork.craigslist.org/que/zip/d/astoria-uplift-ergonomic-adjustable/7937925940.html",
+    "matched_query": "hardware"
+  },
+  {
+    "pid": "7938324717",
+    "title": "Work or dining tables 72 x 18 Metal Legs - 35 available",
+    "price": "$0",
+    "location": "woodside",
+    "category": "zip",
+    "url": "https://newyork.craigslist.org/que/zip/d/woodside-work-or-dining-tables-72-18/7938324717.html",
+    "matched_query": "hardware"
+  }
+]

--- a/scripts/craigslist_flushing_listings.md
+++ b/scripts/craigslist_flushing_listings.md
@@ -1,0 +1,1428 @@
+# Flushing (Queens) Craigslist — for-sale snapshot
+
+**1421 unique listings** across queries: `hardware`, `tools`, `electronics`, `computer`, `appliances`
+
+| Price | Title | Cat | Location | Link |
+|------:|-------|-----|----------|------|
+| $100 | $100...POWERFUL WINDOW AIR CONDITIONER FOR SALE MUST GO !!  ASAP MOVIN | app | ROCKAWAY PARK | [link](https://newyork.craigslist.org/que/app/d/rockaway-park-100powerful-window-air/7941912503.html) |
+| $179 | (Instant Pot) PRESTO  Pressure cooker 7-in 1; $249.99; Sale only | app | queens ny | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-instant-pot-presto/7930650399.html) |
+| $100 | 0.90 Cubic Feet Magic Chef Portable Washer | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-090-cubic-feet-magic-chef/7915203692.html) |
+| $50 | 1 Air Conditioner Units AC - 5000 btu good condition | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-air-conditioner-units/7941061394.html) |
+| $849 | 1 glass door refrigerator | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-glass-door-refrigerator/7921114715.html) |
+| $150 | 10 inch table saw | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-10-inch-table-saw/7942376980.html) |
+| $80 | 10000 BTU windows air conditioner | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-btu-windows-air-conditioner/7940841947.html) |
+| $6,000 | 2 Cemetery Plots King David Memorial/Rose Hill Gardens Putnam Valley 10579 | app | queens | [link](https://newyork.craigslist.org/que/app/d/dewey-cemetery-plots-king-david/7942903298.html) |
+| $30 | 2 speakers for computer | app | Kew Gardens | [link](https://newyork.craigslist.org/que/app/d/kew-gardens-speakers-for-computer/7941892448.html) |
+| $15 | 2 Washing Machine/Dishwasher Hoses | app | Forest Hills, NY 11375 | [link](https://newyork.craigslist.org/que/app/d/forest-hills-washing-machine-dishwasher/7936547099.html) |
+| $400 | 24 INCH FRONT LOAD WASHER | app | woodside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-24-inch-front-load-washer/7942724559.html) |
+| $1,399 | 42" Deli case curve glass - | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-42-deli-case-curve-glass/7921104424.html) |
+| $0 | 48" refrigerator bakery case | app | Jackson Heights | [link](https://newyork.craigslist.org/que/app/d/east-elmhurst-48-refrigerator-bakery/7943847060.html) |
+| $350 | 800 Series Bosch | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-800-series-bosch/7928197271.html) |
+| $200 | A Sharp Air Conditioner 8000 BTU | app | Elmhurst | [link](https://newyork.craigslist.org/que/app/d/elmhurst-sharp-air-conditioner-8000-btu/7935027823.html) |
+| $0 | A/C FRIGIDAIRE 10,000 BTU WINDOW UNIT AIR COND ( BRAND NEW ) | app | Nassau County L.I /. Queens | [link](https://newyork.craigslist.org/que/app/d/lynbrook-c-frigidaire-btu-window-unit/7913387471.html) |
+| $25 | AC 6000 BTU \| Midea | app | Richmond Hill | [link](https://newyork.craigslist.org/que/app/d/richmond-hill-ac-6000-btu-midea/7944142514.html) |
+| $25 | AC Air conditioner for sale great working condition | app | Floral park | [link](https://newyork.craigslist.org/que/app/d/glen-oaks-ac-air-conditioner-for-sale/7939177632.html) |
+| $299 | air condition/heater, 2-in-1; its portable; Priced $699.99; Last Price | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-air-condition-heater-in/7930649927.html) |
+| $199 | Air conditioner  whirlpool: priced $299.99 | app | queens ny | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-air-conditioner/7930641307.html) |
+| $400 | Air Conditioner 12000 BTU Hisense AC | app | Park Slope Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-air-conditioner-btu-hisense-ac/7943365391.html) |
+| $60 | Air conditioner portable | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-air-conditioner-portable/7943051854.html) |
+| $35 | Air Conditioners | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-air-conditioners/7943848609.html) |
+| $50 | Air Cooler | app | Whitestone     NY | [link](https://newyork.craigslist.org/que/app/d/bayside-air-cooler/7943655678.html) |
+| $60 | AIR PURIFIER | app | queens | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-air-purifier/7908978848.html) |
+| $159 | Air-Conditioner | app | Corona | [link](https://newyork.craigslist.org/que/app/d/corona-air-conditioner/7943283323.html) |
+| $0 | all Appliances and Furniture must Go Inventory Sale; ASAP | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-all-appliances-and/7930640448.html) |
+| $700 | American Eagle AE-G12N Bench Model Meat Grinder For Commercial Kitchen | app | little neck | [link](https://newyork.craigslist.org/que/app/d/little-neck-american-eagle-ae-g12n/7906726424.html) |
+| $45 | Aquasana AQ-5300R Claryum 3-stage Under Sink Water Filter Replacement | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-aquasana-aq-5300r-claryum/7921094592.html) |
+| $75 | ArcticKing Window Air Conditioner  5,000 BTU | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/arcticking-window-air-conditioner-5000/7940849849.html) |
+| $20 | Batman Alarm Clock, New in Box | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-batman-alarm-clock-new/7937644260.html) |
+| $30 | BEAUTIFUL LOOMY BLOOM TRANSFORMABLE TABLE LAMP TENERGY | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-beautiful-loomy-bloom/7939913969.html) |
+| $25 | Bella Cucina X Large Electric Griddle NEW in Box 🔥 | app | Forest Hills, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-bella-cucina-large-electric/7930718574.html) |
+| $39 | BELLA PRO SERIES 4.2-QT. MANUAL AIR FRYER \| 90161 \| BLACK \| NEW | app | queens | [link](https://newyork.craigslist.org/que/app/d/saint-albans-bella-pro-series-42-qt/7914540178.html) |
+| $15 | Bella Waffle Maker (New without box) | app | Rego Park | [link](https://newyork.craigslist.org/que/app/d/rego-park-bella-waffle-maker-new/7942274268.html) |
+| $599 | Bertazoni KV30 Pro 1X | app | Bayside | [link](https://newyork.craigslist.org/que/app/d/bayside-bertazoni-kv30-pro-1x/7943133392.html) |
+| $1,199 | Beverage air 5 ft salad refrigerator | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-beverage-air-ft-salad/7921050326.html) |
+| $899 | Beverage air refrigerator glass door | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-beverage-air-refrigerator-glass/7921107288.html) |
+| $25 | Big Capacity Slow Cooker | app | Lower East Side | [link](https://newyork.craigslist.org/que/app/d/new-york-big-capacity-slow-cooker/7943378874.html) |
+| $2,000 | Big Green Egg Large with Table | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-big-green-egg-large/7943932440.html) |
+| $200 | BLACK and DECKER 0.9 Cu. Ft. Portable Washer, 6.6 lb Washing Machine | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-black-and-decker-09-cu/7938613335.html) |
+| $50 | Blaux Portable AC F832 with 3 Speed Fan & lonizer. | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-blaux-portable-ac-f832-with/7935035038.html) |
+| $249 | Blender with Auto-iQ™:  Priced $399.99; Sale Only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-blender-with-auto-iq/7930649493.html) |
+| $249 | Blender with Auto-iQ™:  Priced $399.99; Sale Only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-blender-with-auto-iq/7930649540.html) |
+| $79 | Blood Presssure Monitor | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-blood-presssure-monitor/7930648983.html) |
+| $100 | BMW 2023 X5 M50i rear bumper reinforcement impact bar re-bar | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-bmw-2023-x5-m50i-rear/7927160295.html) |
+| $69 | Book case | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-book-case/7908567923.html) |
+| $1,000 | Bosch 800 Series 18” ADA Compact Top Control 42dBA Dishwasher | app | queens | [link](https://newyork.craigslist.org/que/app/d/whitestone-bosch-800-series-18-ada/7943398963.html) |
+| $40 | Brand NEW - Hamilton Beach Air Fryer Toaster Oven | app | Bayside | [link](https://newyork.craigslist.org/que/app/d/bayside-brand-new-hamilton-beach-air/7933990764.html) |
+| $60 | BRAND NEW IN BOX MISEN 10" STAINLESS STEEL FRYING PAN | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-brand-new-in-box-misen-10/7939912916.html) |
+| $10 | BrassCraft Gas Connector | app | Forest Hills, NY 11375 | [link](https://newyork.craigslist.org/que/app/d/forest-hills-brasscraft-gas-connector/7936542807.html) |
+| $100 | Brondell Heated Multi Function Round Toilet Bidet Seat - Orig $249 | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-brondell-heated-multi/7939092308.html) |
+| $10 | Brookstone Reto Popcorn Maker Machine | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-brookstone-reto-popcorn-maker/7942718603.html) |
+| $60 | Bullet Express System with Bonus Juicer Express | app | Howard Beach | [link](https://newyork.craigslist.org/que/app/d/howard-beach-bullet-express-system-with/7943917681.html) |
+| $10,000 | CARPIGIANI Soft Serve Ice Cream Maker Machine with 2 Flavors and a Twi | app | queens | [link](https://newyork.craigslist.org/que/app/d/bayside-carpigiani-soft-serve-ice-cream/7916199784.html) |
+| $10,000 | CARPIGIANI Soft Serve Ice Cream Maker Machine with 2 Flavors and a Twi | app | queens | [link](https://newyork.craigslist.org/que/app/d/bayside-carpigiani-soft-serve-ice-cream/7921937834.html) |
+| $99 | Ceiling light Pendant; Brand New! Packed! | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-ceiling-light-pendant/7930649574.html) |
+| $15 | Chargeable LED Table Lamp USB/ 3 Color/ Stepless Dimmable Desk Lamp | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-chargeable-led-table-lamp/7918563653.html) |
+| $75 | ChillWell Deluxe Portable Model 18009 Two (2) Pack - New | app | Jamaica estates | [link](https://newyork.craigslist.org/que/app/d/jamaica-chillwell-deluxe-portable-model/7917824823.html) |
+| $25 | CHROME TOASTER | app | SEQ | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-chrome-toaster/7917466820.html) |
+| $19 | coffee grinder; Black n Decker; Priced $29.99; Sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-coffee-grinder-black/7930649361.html) |
+| $175 | COMFEE' 1.6 Cu.ft Portable Washing | app | Roosevelt Island | [link](https://newyork.craigslist.org/que/app/d/new-york-comfee-16-cuft-portable-washing/7943861995.html) |
+| $5 | Comfort Zone 4" personal fan | app | queens | [link](https://newyork.craigslist.org/que/app/d/flushing-comfort-zone-personal-fan/7922555557.html) |
+| $1,199 | Commercial 6 ft deli case remote (no compressor)- | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-commercial-ft-deli-case-remote/7921112055.html) |
+| $249 | Commercial microwave oven | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-commercial-microwave-oven/7910177358.html) |
+| $1,499 | commercial refrigerator | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-commercial-refrigerator/7936220157.html) |
+| $700 | Commercial Washer and dryer | app | east elmhurst | [link](https://newyork.craigslist.org/que/app/d/east-elmhurst-commercial-washer-and/7942676647.html) |
+| $29 | Computer Desk/Cart;Compact;Gently use, $49.99 ;  today only | app | si hablamos español e ingles | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-computer-desk/7930649427.html) |
+| $25 | Computer Monitor Wall Mount | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-computer-monitor-wall-mount/7909434254.html) |
+| $99 | Conair Garment Steamer for Clothes, reduced price to $79.99 for today | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-conair-garment-steamer/7930641014.html) |
+| $299 | Cordless Dyson Gen5 Detect Vacuum Cleaner Rechargeable | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-cordless-dyson-gen5-detect/7929935594.html) |
+| $25 | Crepe Maker | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-crepe-maker/7943257015.html) |
+| $59 | Crystal budoir lamps Brand New 2 available; each | app | jackson hts | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-crystal-budoir-lamps/7930640811.html) |
+| $39 | Crystal lamps each $79.99; sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-crystal-lamps-each-7999/7930649886.html) |
+| $100 | Cuckoo pressure rice cooker | app | queens | [link](https://newyork.craigslist.org/que/app/d/astoria-cuckoo-pressure-rice-cooker/7916603723.html) |
+| $129 | Cuisinart  Ice Cream Maker: Brand New, Packed; Priced $149.99; Sale | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-cuisinart-ice-cream/7930640900.html) |
+| $40 | Cuisinart Automatic Frozen Yogurt Ice & Sorbet Cream Maker | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-automatic-frozen/7920841368.html) |
+| $15 | Cuisinart Citrus Juicer | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-citrus-juicer/7920842285.html) |
+| $80 | Cuisinart Espresso Machine & Frother - Good condition ($216 New) - Moving Sale - | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-cuisinart-espresso-machine/7927073841.html) |
+| $50 | Cuisinart Ice Cream/Yogurt Maker - Brand new | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/howard-beach-cuisinart-ice-cream-yogurt/7913903442.html) |
+| $15 | cuisinart PowerBlend Duet parts | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-cuisinart-powerblend-duet/7920609804.html) |
+| $40 | Curtain Installation Kit 3127A20074X for Window AC | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-curtain-installation-kit/7935018610.html) |
+| $100 | Danby Designer Countertop Compact Refrigerator | app | queens | [link](https://newyork.craigslist.org/que/app/d/woodhaven-danby-designer-countertop/7907254583.html) |
+| $550 | Deep fryer 4 burners PITCO | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-deep-fryer-burners-pitco/7932963229.html) |
+| $1,299 | Deli case refrigerator 3 Ft | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-deli-case-refrigerator-ft/7921108337.html) |
+| $10 | DeLonghi oscillating Ceramic heater | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/middle-village-delonghi-oscillating/7917842715.html) |
+| $2,199 | Dough mixer, Thunderbird, 20 quarts made in USA | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-dough-mixer-thunderbird-20/7921075786.html) |
+| $30 | Dryer Screen Lint Filter Whirlpool, Kenmore, Maytag..... (Made In USA) | app | Queens, Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-dryer-screen-lint-filter/7907928121.html) |
+| $40 | Dynex LCD TV 27 inches NOT A SMART TV | app | Flushing | [link](https://newyork.craigslist.org/que/app/d/flushing-dynex-lcd-tv-27-inches-not/7920211623.html) |
+| $650 | Dyson v15s Detect Submarine | app | Atlantic Beach | [link](https://newyork.craigslist.org/que/app/d/atlantic-beach-dyson-v15s-detect/7942675657.html) |
+| $55 | Electric fireplace space heater | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/ridgewood-electric-fireplace-space/7939736171.html) |
+| $35 | Electric Knife Sharpener, Presto 08800 EverSharp 2-Stage System | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-electric-knife-sharpener/7942650231.html) |
+| $100 | Electrolux Deep Clean Power Head Brush | app | Forest Hills, NY 11375 | [link](https://newyork.craigslist.org/que/app/d/forest-hills-electrolux-deep-clean/7936538198.html) |
+| $40 | EXCELLENT - DASH QUARTZ EXPRES TOASTER OVEN | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-excellent-dash-quartz-expres/7939896093.html) |
+| $200 | EXCELLENT DYSON CYCLONE V10 ANIMAL+ CORDLESS  VACUUM PERFECT CONDITION | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-excellent-dyson-cyclone-v10/7939925484.html) |
+| $110 | excellent sewing machine | app | woodside | [link](https://newyork.craigslist.org/que/app/d/woodside-excellent-sewing-machine/7943753298.html) |
+| $129 | fabric steam ironing, brand new packed; Priced $279.99; Sale Today ONL | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-fabric-steam-ironing/7930646492.html) |
+| $15 | Fan | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-fan/7943601868.html) |
+| $30 | Fan | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-fan/7940406593.html) |
+| $0 | Fans/Vacuum cleaner/Garbage pail & more | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-fans-vacuum-cleaner-garbage/7943196950.html) |
+| $100 | fireplace | app | Freeport | [link](https://newyork.craigslist.org/que/app/d/freeport-fireplace/7912159395.html) |
+| $250 | For sale mini washer | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-for-sale-mini-washer/7943588580.html) |
+| $0 | FREE 21" Frigidaire Gas Range - Oven Not Working - Handyman Special | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/kew-gardens-free-21-frigidaire-gas/7942531700.html) |
+| $3,999 | freezer True 3 doors stainless steel | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-freezer-true-doors-stainless/7921077865.html) |
+| $599 | FRIDGIDAIR electric stove *BRAND NEW* | app | New York | [link](https://newyork.craigslist.org/que/app/d/new-york-fridgidair-electric-stove/7942228186.html) |
+| $160 | Friedrich Air Conditioner A/C 8,000 BTU | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-friedrich-air-conditioner/7942134719.html) |
+| $180 | Friedrich Air Conditioner AC 10,000 BTU | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-friedrich-air-conditioner/7940850145.html) |
+| $700 | Friedrich Kuhl 8000 btu - Smart AC- Commercial-Grade - Whisper-Quiet | app | College Point | [link](https://newyork.craigslist.org/que/app/d/college-point-friedrich-kuhl-8000-btu/7937424558.html) |
+| $300 | Friedrich window / wall air conditioner 12000btu | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-friedrich-window-wall-air/7943265262.html) |
+| $200 | Frigidaire 10,500 BTU In-Wall Window Air Conditioner | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/ridgewood-frigidaire-btu-in-wall-window/7943559698.html) |
+| $500 | Frigidaire 36 inches | app | Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-frigidaire-36-inches/7930267674.html) |
+| $255 | Frigidaire 8,000 BTU Window Conditioner | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-frigidaire-8000-btu-window/7941311670.html) |
+| $79 | Frigidaire Mini Skin-care Personal Fridge | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7914359910.html) |
+| $68 | Frigidaire Mini Skin-care Personal Fridge-BRAND NEW | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7909740246.html) |
+| $74 | Frigidaire Mini Skin-care Personal Fridge-BRAND NEW | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7924033520.html) |
+| $79 | Frigidaire Mini Skin-care Personal Fridge-BRAND NEW | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-mini-skin-care/7913095934.html) |
+| $0 | Frigidaire Refrigerator | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-frigidaire-refrigerator/7943051133.html) |
+| $450 | Frigidaire Side-By-Side Refrigerator | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-frigidaire-side-by-side/7939016719.html) |
+| $200 | Frigidaire Window air conditioner | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-frigidaire-window-air/7944186147.html) |
+| $1,500 | Gaggenau Range Hood | app | Rego Park | [link](https://newyork.craigslist.org/que/app/d/rego-park-gaggenau-range-hood/7931554244.html) |
+| $550 | gas stove -2 burners- | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-gas-stove-burners/7930483855.html) |
+| $550 | gas stove -2 burners- | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-gas-stove-burners/7912082338.html) |
+| $249 | GE 350 SQ FT 8500 BTU SMART PORTABLE AIR CONDITIONER \| APLS08WWB | app | or Best Offer | [link](https://newyork.craigslist.org/que/app/d/saint-albans-ge-350-sq-ft-8500-btu/7928808298.html) |
+| $249 | GE 350 SQ FT 8500 BTU SMART PORTABLE AIR CONDITIONER \| APLS08WWB | app | queens | [link](https://newyork.craigslist.org/que/app/d/saint-albans-ge-350-sq-ft-8500-btu/7906451929.html) |
+| $280 | GE 350-sq ft Window Air Conditioner with Remote (115-Volt, 8000-BTU) | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-ge-350-sq-ft-window-air/7935014485.html) |
+| $70 | GE 5000 BTU Air Conditioner | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-ge-5000-btu-air-conditioner/7910773589.html) |
+| $60 | GE AIR CONDITIONER -  GOOD CONDITION - $60 OBO - AHP06LZQ2 | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/ridgewood-ge-air-conditioner-good/7944124856.html) |
+| $120 | GE Air Conditioner 8200 BTU | app | New York | [link](https://newyork.craigslist.org/que/app/d/new-york-ge-air-conditioner-8200-btu/7942766884.html) |
+| $250 | GE Air Conditioner for Sale - 10,100 BTU | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-ge-air-conditioner-for/7943986057.html) |
+| $500 | GE Electric Stacked Laundry/ Top load Washer and | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-ge-electric-stacked-laundry-top/7943980262.html) |
+| $500 | GE Profile Series 18" Built In Dishwasher | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-ge-profile-series-18-built-in/7934563302.html) |
+| $700 | GE washer/dryer | app | New York | [link](https://newyork.craigslist.org/que/app/d/new-york-ge-washer-dryer/7941937302.html) |
+| $300 | General Electric Dryer | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-general-electric-dryer/7941232384.html) |
+| $65 | Hamilton Beach Dough & Bread Maker | app | queens | [link](https://newyork.craigslist.org/que/app/d/queens-village-hamilton-beach-dough/7922293561.html) |
+| $50 | Hamilton Beach Icecream Maker 4 Quart - Like New | app | Elmhurst | [link](https://newyork.craigslist.org/que/app/d/elmhurst-hamilton-beach-icecream-maker/7941177225.html) |
+| $26 | Hamilton Beach TrueAir Air Purifier | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7909740365.html) |
+| $29 | Hamilton Beach TrueAir Air Purifier | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7913099300.html) |
+| $29 | Hamilton Beach TrueAir Air Purifier | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7909747788.html) |
+| $29 | Hamilton Beach TrueAir Air Purifier | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/middle-village-hamilton-beach-trueair/7913099642.html) |
+| $25 | HAPPY FATHER's DAY - KEURIG K2.0-500  COFFEE MAKER & COFFEE PODS | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-happy-fathers-day-keurig/7942011009.html) |
+| $1,500 | Heavy duty, curve glass deli case 48" | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-heavy-duty-curve-glass-deli/7921111405.html) |
+| $299 | HeavyDuty Sewing Machine; Price $399.99; on sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-heavyduty-sewing/7930645169.html) |
+| $299 | HeavyDuty Sewing Machine; Price $399.99; on sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-heavyduty-sewing/7930640610.html) |
+| $150 | Hisense Portable Room Air Conditioner 8500 BTU. | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-hisense-portable-room-air/7937804582.html) |
+| $2,000 | Hobart bandsaw meat bone fish | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-hobart-bandsaw-meat/7918879448.html) |
+| $159 | Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909301831.html) |
+| $159 | Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909748077.html) |
+| $175 | Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7930309214.html) |
+| $135 | Honeywell Hepa200 Air Purifier SEALED, WITH BOX, BRAND NEW | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-honeywell-hepa200-air/7909742562.html) |
+| $99 | Hoover Steam Cleaner Carpet Cleaner Shampooer | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-hoover-steam-cleaner-carpet/7914741912.html) |
+| $99 | Hoover Windtunnel Self-propelled Bagless Upright Vacuum Cleaner | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-hoover-windtunnel-self/7914740589.html) |
+| $80 | HP LaserJet Pro 400 MFP M425dn | app | Woodhaven | [link](https://newyork.craigslist.org/que/app/d/woodhaven-hp-laserjet-pro-400-mfp-m425dn/7912836803.html) |
+| $900 | huge samsung stainless steelwide 36 width | app | Glendale | [link](https://newyork.craigslist.org/que/app/d/ridgewood-huge-samsung-stainless/7938055988.html) |
+| $79 | Ice Cream Maker: Brand New, Packed; Priced $149.99; Sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-ice-cream-maker-brand/7930641885.html) |
+| $79 | Ice Cream Maker; Was $99.99; Today only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-ice-cream-maker-was/7930649156.html) |
+| $200 | ice machine | app | Jackson Heights | [link](https://newyork.craigslist.org/que/app/d/east-elmhurst-ice-machine/7943657757.html) |
+| $200 | ice machine | app | Jackson Heights | [link](https://newyork.craigslist.org/que/app/d/east-elmhurst-ice-machine/7943856274.html) |
+| $29 | Ikea Pahl desk with add-on unit, 3 staged height | app | Lic | [link](https://newyork.craigslist.org/que/app/d/long-island-city-ikea-pahl-desk-with/7942377467.html) |
+| $29 | Ikea twin size mattress 6” | app | Lic | [link](https://newyork.craigslist.org/que/app/d/long-island-city-ikea-twin-size/7943441905.html) |
+| $350 | ilco tubular key cutting machine minus cutter | app | Bayside | [link](https://newyork.craigslist.org/que/app/d/flushing-ilco-tubular-key-cutting/7943697912.html) |
+| $199 | iRobot Roomba Max 705 Combo Robot + AutoWash Dock - Black Edition - Sealed | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-irobot-roomba-max-705-combo/7940216052.html) |
+| $199 | iRobot Roomba Max 705 Combo Robot + AutoWash Dock - Black Edition - Sealed | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-irobot-roomba-max-705-combo/7938031177.html) |
+| $250 | KENMORE COMMERCIAL COIN WASHER | app | Howard Beach | [link](https://newyork.craigslist.org/que/app/d/howard-beach-kenmore-commercial-coin/7942459978.html) |
+| $40 | Keurig K10 (Red) | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-keurig-k10-red/7913903178.html) |
+| $44 | Koto electric hotpot | app | Flushing | [link](https://newyork.craigslist.org/que/app/d/flushing-koto-electric-hotpot/7942562474.html) |
+| $20 | KRUPS GX5000 Electric Burr Coffee Grinder - 45 Settings | app | Broad Channel | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-krups-gx5000-electric-burr/7944138978.html) |
+| $10 | Lean Mean Fat Grilling Machine & cookbook | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-lean-mean-fat-grilling/7918986875.html) |
+| $120 | LG 8,000 BTU Window Air Conditioner | app | Elmhurst | [link](https://newyork.craigslist.org/que/app/d/elmhurst-lg-8000-btu-window-air/7940453678.html) |
+| $150 | LG 8000 BTU air conditioner for sale | app | queens | [link](https://newyork.craigslist.org/que/app/d/jamaica-lg-8000-btu-air-conditioner-for/7943671201.html) |
+| $100 | LG air conditioner | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-lg-air-conditioner/7943940538.html) |
+| $400 | LG front-load washer and gas dryer set | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-lg-front-load-washer-and-gas/7935098491.html) |
+| $100 | LG LW5016 Window Air Conditioner | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-lg-lw5016-window-air/7942909934.html) |
+| $150 | LG MICROWAVE - BRAND NEW | app | Long Island City | [link](https://newyork.craigslist.org/que/app/d/long-island-city-lg-microwave-brand-new/7939090075.html) |
+| $175 | LG Portable Air Conditioner Brand New Model LP0818WNR 8000 BTU | app | Forest Hills, Queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-lg-portable-air/7943480864.html) |
+| $399 | LG smart washing machine front load with steam | app | Maspeth | [link](https://newyork.craigslist.org/que/app/d/maspeth-lg-smart-washing-machine-front/7937865089.html) |
+| $120 | LG TV   good condition | app | queens | [link](https://newyork.craigslist.org/que/app/d/flushing-lg-tv-good-condition/7942237622.html) |
+| $325 | LG wall air conditioner | app | Rockaway Park | [link](https://newyork.craigslist.org/que/app/d/rockaway-park-lg-wall-air-conditioner/7943631648.html) |
+| $400 | LG Washing Machine | app | Far Rockaway | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-lg-washing-machine/7943948120.html) |
+| $69 | Light Ceiling Pendant: Fallsbrook; Priced $149.99; Sale Only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-light-ceiling-pendant/7930641253.html) |
+| $69 | Light Ceiling Pendant: Fallsbrook; Priced $149.99; Sale Only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-light-ceiling-pendant/7930641446.html) |
+| $449 | Like new patty warmer 36" w x (17 " d bottom 13" d top ) × 25 " h. | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-like-new-patty-warmer-36-x-17/7921483925.html) |
+| $1,399 | Low boy refrigerator with shelve 4 ft | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-low-boy-refrigerator-with/7921078828.html) |
+| $2,499 | Marble Curve Glass Deli Case Refrigerator 5 FT | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-marble-curve-glass-deli-case/7921109279.html) |
+| $1 | Marvel Professional 23-Bottle Wine Cellar | app | queens | [link](https://newyork.craigslist.org/que/app/d/new-york-marvel-professional-23-bottle/7943414432.html) |
+| $1,599 | Master-Bilt dipping freezer ( Ice cream cabinet) | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-master-bilt-dipping-freezer-ice/7921091336.html) |
+| $400 | MAYTAG "PERFORMA" APARTMENT SIZE FRIDGE (27.5" wide) | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-maytag-performa-apartment-size/7941029591.html) |
+| $50 | Maytag Atlantis MAV9750AWQ Washer Parts - Motor, Water Pumps, Electronics | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-maytag-atlantis-mav9750awq/7924833196.html) |
+| $75 | Melitta Aroma Enhance 10-Cup White Thermal Carafe Drip Coffee Maker | app | queens | [link](https://newyork.craigslist.org/que/app/d/saint-albans-melitta-aroma-enhance-10/7914533197.html) |
+| $49 | Melitta Aroma Tocco \| Thermal Drip - Programmable Coffee Machine | app | queens | [link](https://newyork.craigslist.org/que/app/d/hollis-melitta-aroma-tocco-thermal-drip/7914833329.html) |
+| $149 | Melitta Vision 12-Cup Drip Coffee Maker, Automatic Programmable, 96oz | app | or Best Offer | [link](https://newyork.craigslist.org/que/app/d/saint-albans-melitta-vision-12-cup-drip/7914534738.html) |
+| $25 | Mets Commemorative Hall of Fame Pin, Valentine Mazzilli | app | Floral Park | [link](https://newyork.craigslist.org/que/app/d/floral-park-mets-commemorative-hall-of/7938407681.html) |
+| $60 | Microwave | app | Queens | [link](https://newyork.craigslist.org/que/app/d/maspeth-microwave/7939832048.html) |
+| $50 | Microwave | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-microwave/7943503219.html) |
+| $250 | Midea 10000 BTU Air-conditioner with bracket and remote | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-midea-btu-air-conditioner-with/7943925566.html) |
+| $50 | Mini Fridge W/ Freezer | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-mini-fridge-freezer/7943740897.html) |
+| $115 | Mini Two Door Refrigerator | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-mini-two-door-refrigerator/7943943704.html) |
+| $50 | Multipurpose Cordless Pet Grooming Tool: Vacuum, Brush/Comb for Dog/Cat Hair Rem | app | College Point | [link](https://newyork.craigslist.org/que/app/d/college-point-multipurpose-cordless-pet/7942902438.html) |
+| $300 | NEW 8000 BTU Window Air Conditioner with Dehumidifier, 3 Fan Speeds | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-new-8000-btu-window-air/7943421338.html) |
+| $399 | New Dyson Gen5 Detect Cordless Rechargeable HEPA Vacuum Cleaner | app | Woodhaven | [link](https://newyork.craigslist.org/que/app/d/woodhaven-new-dyson-gen5-detect/7923172965.html) |
+| $299 | New Dyson Gen5 Outsize Cordless Rechargeable HEPA Vacuum Cleaner | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-new-dyson-gen5-outsize/7923173248.html) |
+| $375 | NEW gas grill, stainless steel burner | app | Flushing | [link](https://newyork.craigslist.org/que/app/d/fresh-meadows-new-gas-grill-stainless/7928876986.html) |
+| $300 | New LG Room AC 10000BTU with Window mounting bracket | app | Hollis Hills | [link](https://newyork.craigslist.org/que/app/d/oakland-gardens-new-lg-room-ac-10000btu/7938185370.html) |
+| $150 | NEW NEVER USED MIHIGH PORTABLE INDOOR INFRARED SAUNA BLANKET | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-new-never-used-mihigh-portable/7939895431.html) |
+| $30 | New two 15 inches Mac book pro covers for less. | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-new-two-15-inches-mac-book/7918747371.html) |
+| $199 | NEWAIR 90-CAN FREESTANDING MINI FRIDGE \| AB-850 NEW | app | queens | [link](https://newyork.craigslist.org/que/app/d/saint-albans-newair-90-can-freestanding/7914538594.html) |
+| $249 | Ninja IQ one touch intelligence; Priced $299.99;  Sale only for | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-ninja-iq-one-touch/7930641190.html) |
+| $55 | Norelco Headgroom Pro | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-norelco-headgroom-pro/7920609188.html) |
+| $4 | Nutribullet RX Blade Removal Tool | app | Broad Channel | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-nutribullet-rx-blade/7943358218.html) |
+| $99 | Onkyo subwoofer and receiver - | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-onkyo-subwoofer-and-receiver/7910261427.html) |
+| $300 | ONLY $300 AIR CONDITIONER BRAND NEW | app | queens | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-only-300-air-conditioner/7943865865.html) |
+| $400 | Open box, unused LG 8500 BTU window AC | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-open-box-unused-lg-8500-btu/7943756062.html) |
+| $70 | Oreck Magnesium upright vacuum cleaner (delivery extra) | app | woodside | [link](https://newyork.craigslist.org/que/app/d/woodside-oreck-magnesium-upright-vacuum/7943476446.html) |
+| $650 | Oven for sale | app | Jamaica Queens | [link](https://newyork.craigslist.org/que/app/d/jamaica-oven-for-sale/7942947143.html) |
+| $1,399 | Oven half side | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-oven-half-side/7921088366.html) |
+| $25 | Panini Press Indoor Grill | app | far rockaway | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-panini-press-indoor-grill/7912338571.html) |
+| $15 | Parini Sunny Side 6 Egg Cooker | app | Rego Park | [link](https://newyork.craigslist.org/que/app/d/rego-park-parini-sunny-side-egg-cooker/7942274391.html) |
+| $15 | Perfect Slicer; | app | si hablamos español e ingles | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-perfect-slicer/7930650264.html) |
+| $15 | Perfect Slicer; | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-perfect-slicer/7930649199.html) |
+| $49 | Personal Home Nebulizer; Brand New! Packed!  Last Price Sale | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-personal-home-nebulizer/7930649854.html) |
+| $49 | Personal Home Nebulizer; sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-personal-home-nebulizer/7939481163.html) |
+| $550 | plate warmer | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-plate-warmer/7936422968.html) |
+| $249 | Portable ac | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-portable-ac/7944133653.html) |
+| $200 | Portable AC | app | Glendale | [link](https://newyork.craigslist.org/que/app/d/ridgewood-portable-ac/7941893891.html) |
+| $320 | Portable Air Conditioner 8000 BTU | app | GLENDALE | [link](https://newyork.craigslist.org/que/app/d/ridgewood-portable-air-conditioner-8000/7942292666.html) |
+| $280 | Portable Air Conditioner clean - FRIEDRICH - 8k BTU | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-portable-air-conditioner-clean/7927680181.html) |
+| $65 | Portable TV DVD Player with built in Digital Tuner, in box | app | Floral Park | [link](https://newyork.craigslist.org/que/app/d/floral-park-portable-tv-dvd-player-with/7938405979.html) |
+| $50 | Power Air Fryer, Vegetable Cutter, Nextgrill BBQ Utensils | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-power-air-fryer-vegetable/7922641951.html) |
+| $625 | Power Generator 7.5 HP | app | Corona | [link](https://newyork.craigslist.org/que/app/d/corona-power-generator-75-hp/7943283052.html) |
+| $125 | Pre-owned Frigidaire 8,000 BTU Window Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-frigidaire-8000-btu/7935374023.html) |
+| $125 | Pre-owned GE 6,000 BTU Window Mounted Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-ge-6000-btu-window/7923017601.html) |
+| $175 | Pre-owned GE 8,000 BTU Window Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-ge-8000-btu-window/7923018831.html) |
+| $125 | Pre-owned LG 6,000 BTU Window Mounted Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-lg-6000-btu-window/7923017370.html) |
+| $90 | Pre-owned LG 6,000 BTU Window Mounted Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-lg-6000-btu-window/7935394505.html) |
+| $195 | Pre-owned Panasonic 9,800 BTU Window Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-panasonic-9800-btu/7923018470.html) |
+| $50 | Pre-owned Panasonic NC-EH22PC Water Boiler 2.3-Quart with Temperature | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-panasonic-nc-eh22pc/7917630620.html) |
+| $85 | Pre-owned Whirlpool 5,000 BTU Window Air Conditioner | app | Rego Park, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-pre-owned-whirlpool-5000-btu/7923021147.html) |
+| $500 | Premier 24" Gas Stove USED LIGHTLY | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-premier-24-gas-stove-used/7930955490.html) |
+| $199 | PRESTIGE; Priced $249.99 Sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-prestige-priced-sale/7930649281.html) |
+| $20 | Presto Electric Griddle NEW in Box 🔥 | app | Forest Hills, Queens | [link](https://newyork.craigslist.org/que/app/d/rego-park-presto-electric-griddle-new/7930718493.html) |
+| $199 | PRESTO; Priced $299.99; Last price for Sale today is only | app | si hablamos español e ingles | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-presto-priced-last/7930648907.html) |
+| $300 | PRICE FLEXIBLE Breville Barista Express | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-price-flexible-breville-barista/7942216743.html) |
+| $450 | PTAC air conditioner | app | nyc | [link](https://newyork.craigslist.org/que/app/d/long-island-city-ptac-air-conditioner/7943045016.html) |
+| $2,345 | Rare Vintage Snapon Tools Stickers Patches Pins Catalogs Models | app | little neck | [link](https://newyork.craigslist.org/que/app/d/bartlesville-rare-vintage-snapon-tools/7920460897.html) |
+| $5,000 | Rational Combioven Oven W Stand SCCWE62 with Stand | app | Queens | [link](https://newyork.craigslist.org/que/app/d/flushing-rational-combioven-oven-stand/7928187372.html) |
+| $50 | refridgerator | app | Freeport | [link](https://newyork.craigslist.org/que/app/d/freeport-refridgerator/7912366044.html) |
+| $50 | refridgerator dorm size | app | Freeport | [link](https://newyork.craigslist.org/que/app/d/freeport-refridgerator-dorm-size/7924337998.html) |
+| $50 | refridgerator dorm size | app | Freeport | [link](https://newyork.craigslist.org/que/app/d/freeport-refridgerator-dorm-size/7912974980.html) |
+| $50 | refridgerator/freezer across top | app | Freeport | [link](https://newyork.craigslist.org/que/app/d/freeport-refridgerator-freezer-across/7912425531.html) |
+| $1,499 | refrigerator | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-refrigerator/7931836305.html) |
+| $200 | Refrigerator for sale | app | queens | [link](https://newyork.craigslist.org/que/app/d/corona-refrigerator-for-sale/7943508270.html) |
+| $180 | REFRIGERATOR FOR SALE 24 INCHES WIDE 60 INCHES HEIGHT | app | queens | [link](https://newyork.craigslist.org/que/app/d/corona-refrigerator-for-sale-24-inches/7927541164.html) |
+| $1,099 | Refrigerator Imbera 1 glass door | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-refrigerator-imbera-glass-door/7921093176.html) |
+| $199 | Refrigerator, round cold drinks, led light. with wheels. | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-refrigerator-round-cold-drinks/7921113446.html) |
+| $0 | Rehome frenchie | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-rehome-frenchie/7942278679.html) |
+| $10 | Retractable Sun Shading Blinds 49.21x22.83 in. for Household / CARS | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-retractable-sun-shading/7943239138.html) |
+| $8 | Rival GCRVSW-100 Steam Wave Iron | app | Queens | [link](https://newyork.craigslist.org/que/app/d/flushing-rival-gcrvsw-100-steam-wave/7940309458.html) |
+| $199 | Roborock Saros 10R Robot Vacuum with Multifunctional Dock 4.0 - New and Sealed! | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-roborock-saros-10r-robot/7938029928.html) |
+| $199 | Roborock Saros 10R Robot Vacuum with Multifunctional Dock 4.0 - New and Sealed! | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-roborock-saros-10r-robot/7940079576.html) |
+| $29 | Room and board drawer/shelf/night stand combo for kids | app | Lic | [link](https://newyork.craigslist.org/que/app/d/long-island-city-room-and-board-drawer/7942384018.html) |
+| $20 | Rotary Fan, Antique Retro Collectible, All Metal, Green, Works | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-rotary-fan-antique-retro/7922184473.html) |
+| $40 | Samson "Silent" 6 Tray All Stainless Steel Dehydrator | app | Sunnyside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-samson-silent-tray-all/7943915012.html) |
+| $50 | SAMSUNG 32 inches LCD TV  NOT A SMART TV | app | flushing | [link](https://newyork.craigslist.org/que/app/d/flushing-samsung-32-inches-lcd-tv-not/7918337014.html) |
+| $900 | Samsung 5.4 cu. ft. Smart Top Load Washer | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-samsung-54-cu-ft-smart-top/7914336239.html) |
+| $900 | Samsung 7.4 cu. ft. Smart Vented Electric Dryer | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-samsung-74-cu-ft-smart/7914336343.html) |
+| $50 | Samsung BluRay Disc Player BD-E5400 | app | Broad Channel | [link](https://newyork.craigslist.org/que/app/d/far-rockaway-samsung-bluray-disc-player/7943358368.html) |
+| $499 | Samsung natural gas dryer in excellent conditions | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-samsung-natural-gas-dryer-in/7910262139.html) |
+| $150 | Samsung WV60M9900AV/A56.0 cu ft. Smart Washer with Flexwash in Black Stainless S | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-samsung-wv60m9900av-a560-cu/7941273828.html) |
+| $250 | SET OF SIX (6) BEAUTIFUL ALUMINUM AND GLASS CANDLE HOLDERS CANDELABRAS | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-set-of-six-beautiful-aluminum/7939925270.html) |
+| $250 | Shark Vertex AZ1500WM | app | Jackson Heights | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-shark-vertex-az1500wm/7940891606.html) |
+| $500 | Sharp Frigidaire | app | Flushing | [link](https://newyork.craigslist.org/que/app/d/college-point-sharp-frigidaire/7944120123.html) |
+| $15 | Sharpening/Honing Steel KK9990 9"- Kershaw Taskmaster 2 | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-sharpening-honing-steel-kk/7930914064.html) |
+| $249 | Singer Sewing Machine; Heavy Duty; priced $399.99; sale only | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-singer-sewing-machine/7930649745.html) |
+| $190 | Slide in self cleaning gas range | app | woodside | [link](https://newyork.craigslist.org/que/app/d/sunnyside-slide-in-self-cleaning-gas/7942723505.html) |
+| $20 | Slow Cooker Hamilton Beach, NEW | app | Floral Park | [link](https://newyork.craigslist.org/que/app/d/floral-park-slow-cooker-hamilton-beach/7909641846.html) |
+| $45 | Slow cooker unopened Slow cooker | app | New York | [link](https://newyork.craigslist.org/que/app/d/new-york-slow-cooker-unopened-slow/7943804616.html) |
+| $20 | Slow Cooker, Hamilton Beach Brand New | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-slow-cooker-hamilton/7938512528.html) |
+| $0 | small  appliances | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-small-appliances/7930643813.html) |
+| $18 | sodastream FIZZI | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-sodastream-fizzi/7920838566.html) |
+| $10,000 | Soft Serve Ice Cream Gelato Maker by Carpigiani | app | Bayside | [link](https://newyork.craigslist.org/que/app/d/bayside-soft-serve-ice-cream-gelato/7929359551.html) |
+| $15 | Solar Swimming Pool Thermometer Floating | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-solar-swimming-pool/7936234900.html) |
+| $99 | Space Heater;  priced $129.99; This Tuesday Only $79.99 | app | reasonably negotiable; phone number please:by appt Only | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-space-heater-priced/7930644026.html) |
+| $10 | Space-Heater 1500w brand new | app | Rockaway Beach | [link](https://newyork.craigslist.org/que/app/d/arverne-space-heater-1500w-brand-new/7915397281.html) |
+| $99 | Stand Mixer; Priced $99.99; reasonably negotiable | app | queens | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-stand-mixer-priced-9999/7930641076.html) |
+| $50 | Stove for Sale | app | Howard Beach | [link](https://newyork.craigslist.org/que/app/d/howard-beach-stove-for-sale/7942458475.html) |
+| $550 | stove gas stock pot 2 burner | app | East Elmhurst | [link](https://newyork.craigslist.org/que/app/d/jackson-heights-stove-gas-stock-pot/7930155485.html) |
+| $250 | Submersive pump | app | Flushing | [link](https://newyork.craigslist.org/que/app/d/flushing-submersive-pump/7944189781.html) |
+| $149 | SUMMIT SCR114L 14 Inch Reversible Compact Refrigerator BROKEN | app | READ CAREFULLY. NEEDS REPAIR | [link](https://newyork.craigslist.org/que/app/d/hollis-summit-scr114l-14-inch/7914833602.html) |
+| $30 | Sunbeam 700W Countertop Microwave (Model SBM7700W) – White | app | Queens | [link](https://newyork.craigslist.org/que/app/d/ridgewood-sunbeam-700w-countertop/7937964096.html) |
+| $275 | Tazpi TW-E30 Range Hood Wall Mount 30" 1200 CFM, Ducted/Ductless NIB | app | Kew Gardens | [link](https://newyork.craigslist.org/que/app/d/kew-gardens-tazpi-tw-e30-range-hood/7924762288.html) |
+| $275 | THREE (3) BRAND NEW IN BOX MISEN 18" 5PLY STAINLESS ROASTING PAN | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-three-brand-new-in-box-misen-18/7939913012.html) |
+| $250 | THREE (3) MADE IN CARBON STEEL NONSTICK FRYING PAN SET | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-three-made-in-carbon-steel/7939912771.html) |
+| $275 | THREE (3) OUR PLACE NONSTICK SHEETPAN STOVETOP GRIDDLE SETS MATS | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-three-our-place-nonstick/7939912315.html) |
+| $99 | Tokina 500mm F8 rmc for Nikon F mount. | app | queens | [link](https://newyork.craigslist.org/que/app/d/queens-village-tokina-500mm-f8-rmc-for/7922293449.html) |
+| $90 | Towel Warmer - NEW IN BOX | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/brooklyn-towel-warmer-new-in-box/7944066040.html) |
+| $400 | Traeger Pro 780 Wifi Smoker | app | Arverne | [link](https://newyork.craigslist.org/que/app/d/arverne-traeger-pro-780-wifi-smoker/7942158063.html) |
+| $70 | TUSHY Classic 3.0 Bidet Toilet Seat Attachment (Self Cleaning) | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-tushy-classic-30-bidet-toilet/7939896235.html) |
+| $250 | TV for sale - Hisense, 50 inch screen, 4K UHD Smart Google TV | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-tv-for-sale-hisense-50-inch/7942614906.html) |
+| $19 | Twin size bed warmer | app | Lic | [link](https://newyork.craigslist.org/que/app/d/long-island-city-twin-size-bed-warmer/7943840033.html) |
+| $25 | Twin size head board | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-twin-size-head-board/7919086417.html) |
+| $20 | TWO BEAUTIFUL LAMPS - DESK LAMP BEDROOM LAMP LIGHT | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-two-beautiful-lamps-desk-lamp/7939914069.html) |
+| $50 | Two Large Lilac Bush and Tree Plants - Exquisite Fragrance | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-two-large-lilac-bush-and-tree/7932551907.html) |
+| $2,199 | Two pull out glass doors freezer/ refrigerator | app | Jamaica | [link](https://newyork.craigslist.org/que/app/d/jamaica-two-pull-out-glass-doors/7921110492.html) |
+| $180 | Upright Vacuum Cleaner by Dyson | app | Forest Hills, NY | [link](https://newyork.craigslist.org/que/app/d/forest-hills-upright-vacuum-cleaner-by/7936164592.html) |
+| $1 | Used AC unit for sale for medium room | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-used-ac-unit-for-sale-for/7926197568.html) |
+| $1 | Used AC unit for small room for sale | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-used-ac-unit-for-small-room-for/7926192095.html) |
+| $0 | Used window A/C(Multiple pieces) | app | Jamaica Estates | [link](https://newyork.craigslist.org/que/app/d/jamaica-used-window-cmultiple-pieces/7944179805.html) |
+| $50 | Used window AC air conditioner 8000BTU | app | Hollis Hills | [link](https://newyork.craigslist.org/que/app/d/oakland-gardens-used-window-ac-air/7937864152.html) |
+| $125 | VACUUM LUX MODEL U162A IN EXCELLENT CONDITION | app | Whitestone | [link](https://newyork.craigslist.org/que/app/d/whitestone-vacuum-lux-model-u162a-in/7921619223.html) |
+| $5 | Variety of house plants for new home | app | Lic | [link](https://newyork.craigslist.org/que/app/d/long-island-city-variety-of-house/7943984467.html) |
+| $1,000 | Viking Open Burner Range Top (cooktop) Model VGRT4216 – NG or LP | app | Ridgewood | [link](https://newyork.craigslist.org/que/app/d/ridgewood-viking-open-burner-range-top/7942924428.html) |
+| $7 | Vintage Braun Citromatic Juicer | app | queens | [link](https://newyork.craigslist.org/que/app/d/ridgewood-vintage-braun-citromatic/7939237697.html) |
+| $250 | Vintage Burton Snowboards and bindings | app | Rockaway Beach | [link](https://newyork.craigslist.org/que/app/d/arverne-vintage-burton-snowboards-and/7919939167.html) |
+| $5 | Vintage Salton Drink Mixtir Blender Drink Mixer with Clear Glass | app | queens | [link](https://newyork.craigslist.org/que/app/d/ridgewood-vintage-salton-drink-mixtir/7939237737.html) |
+| $100 | Vissani Portable A/C - 8000 BTU | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-vissani-portable-c-btu/7943577110.html) |
+| $200 | Vissani Portable Air Conditioner | app | Queens | [link](https://newyork.craigslist.org/que/app/d/jamaica-vissani-portable-air-conditioner/7941951432.html) |
+| $250 | VITAMIX EXPLORIAN E 310 BLENDER - LIKE NEW LITTLE USE | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-vitamix-explorian-310-blender/7939916756.html) |
+| $250 | VITAMIX Foodcyler Eco 5 ($250 OBO) | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-vitamix-foodcyler-eco-obo/7909793538.html) |
+| $280 | Washer & Dryer Set — Sell Together or Separately 🧺 | app | WOODHAVEN | [link](https://newyork.craigslist.org/que/app/d/ozone-park-washer-dryer-set-sell/7938225859.html) |
+| $250 | Washing machine | app | Queens Village | [link](https://newyork.craigslist.org/que/app/d/queens-village-washing-machine/7927860765.html) |
+| $0 | Water dispenser | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-water-dispenser/7942285881.html) |
+| $500 | Webber Genesis Grill E435 | app | Oakland Gardens | [link](https://newyork.craigslist.org/que/app/d/oakland-gardens-webber-genesis-grill/7943337436.html) |
+| $7 | West Bend Poppery II 2 Hot Air Popcorn Popper 1200W Made In USA | app | queens | [link](https://newyork.craigslist.org/que/app/d/ridgewood-west-bend-poppery-ii-hot-air/7939237643.html) |
+| $15 | Westinghouse Fan Ceiling Light Kit | app | Forest Hills, NY 11375 | [link](https://newyork.craigslist.org/que/app/d/forest-hills-westinghouse-fan-ceiling/7936546699.html) |
+| $75 | Whirlpool  rv, travel trailer, camper,microwave | app | Astoria | [link](https://newyork.craigslist.org/que/app/d/astoria-whirlpool-rv-travel-trailer/7910506560.html) |
+| $350 | Whirlpool Electric Dryer | app | queens | [link](https://newyork.craigslist.org/que/app/d/ridgewood-whirlpool-electric-dryer/7937652137.html) |
+| $35 | Whirlpool Gold Accudry dehumidifier | app | queens | [link](https://newyork.craigslist.org/que/app/d/glen-rock-whirlpool-gold-accudry/7928366819.html) |
+| $5 | Whirlpool OEM Gas Stove Burner Grate Rubber Foot Pads - 814383 / 81432 | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-whirlpool-oem-gas-stove/7928744606.html) |
+| $70 | White Electric Standing Desk with Digital Preset Controller + Matching 3-Tier St | app | Bedstuy | [link](https://newyork.craigslist.org/que/app/d/brooklyn-white-electric-standing-desk/7943777249.html) |
+| $90 | Who needs the boot removed ? | app | Brooklyn | [link](https://newyork.craigslist.org/que/app/d/brooklyn-who-needs-the-boot-removed/7942964932.html) |
+| $50 | Window air conditioner | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-window-air-conditioner/7944185394.html) |
+| $50 | Window air conditioner | app | Ozone Park | [link](https://newyork.craigslist.org/que/app/d/ozone-park-window-air-conditioner/7942206727.html) |
+| $55 | Window Fan, Bionaire BWF0502M-WM - White | app | queens | [link](https://newyork.craigslist.org/que/app/d/forest-hills-window-fan-bionaire/7943204741.html) |
+| $999 | Wine cooler | app | Forest Hills | [link](https://newyork.craigslist.org/que/app/d/forest-hills-wine-cooler/7918534696.html) |
+| $70 | ❄️ 🌬️ Window Air Conditioner 🔴 several available! | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-window-air-conditioner/7935278794.html) |
+| $450 | 🔴 🟢 FRIEDRICH IN WALL A/C 18000 BTU - MINT! | app | Middle Village | [link](https://newyork.craigslist.org/que/app/d/middle-village-friedrich-in-wall-c-btu/7922926974.html) |
+| $100 | $640 Restoration Hardware Military Chalkboard World Map | art | Long Island City | [link](https://newyork.craigslist.org/que/art/d/long-island-city-640-restoration/7916819121.html) |
+| $255 | 169 Various size Art Mattes beveled precut (single/dual color) | art | Forest Hills | [link](https://newyork.craigslist.org/que/art/d/forest-hills-169-various-size-art/7910249950.html) |
+| $40 | Art Deco Style Woman in Red Dress – Canvas Wall Art (Ready to Hang) | art | Ridgewood | [link](https://newyork.craigslist.org/que/art/d/ridgewood-art-deco-style-woman-in-red/7944098071.html) |
+| $20 | Believe Dream Imagine Wall Art – Vertical Canvas Decor | art | Ridgewood | [link](https://newyork.craigslist.org/que/art/d/ridgewood-believe-dream-imagine-wall/7944209179.html) |
+| $40 | Pineapple Canvas Wall Art – Tropical / Coastal Decor (20” x 16”) | art | Ridgewood | [link](https://newyork.craigslist.org/que/art/d/ridgewood-pineapple-canvas-wall-art/7911452399.html) |
+| $20 | Two Ikea Multi Picture Frames (NEW) | art | Forest Hills | [link](https://newyork.craigslist.org/que/art/d/forest-hills-two-ikea-multi-picture/7939154165.html) |
+| $130 | Vintage Chinese Lacquer Wall Panels – Hand-Carved Soapstone Figures | art | Ridgewood | [link](https://newyork.craigslist.org/que/art/d/ridgewood-vintage-chinese-lacquer-wall/7926334622.html) |
+| $500 | Antique Ice Box Wooden Oak Chest w/Shelves -Gibson Cambria early 1900s | atq | Ridgewood, Queens | [link](https://newyork.craigslist.org/que/atq/d/brooklyn-antique-ice-box-wooden-oak/7943609488.html) |
+| $4,400 | Custom Vintage Mid-Century Modern Mahogany Glass Front Hutch | atq | New York | [link](https://newyork.craigslist.org/que/atq/d/new-york-custom-vintage-mid-century/7917110850.html) |
+| $10 | OLD TOOLS& STUFF $10 FOR ALL | atq | OZONE PARK | [link](https://newyork.craigslist.org/que/atq/d/ozone-park-old-tools-stuff-10-for-all/7913936377.html) |
+| $0 | Parents Moving - Must Sell: Hutch, Wardrobe, File Cabinet & Table | atq | Queens | [link](https://newyork.craigslist.org/que/atq/d/woodside-parents-moving-must-sell-hutch/7935784391.html) |
+| $130 | Babyletto Mercer 3-in-1 Convertible Crib | bab | Bay Terrace | [link](https://newyork.craigslist.org/que/bab/d/bayside-babyletto-mercer-in-convertible/7938545823.html) |
+| $100 | Like new crib | bab | Forest Hills | [link](https://newyork.craigslist.org/que/bab/d/forest-hills-like-new-crib/7939568279.html) |
+| $225 | Computer desk | bfs | Brooklyn ridgewood was | [link](https://newyork.craigslist.org/que/bfs/d/brooklyn-computer-desk/7939355960.html) |
+| $50 | Desk for computer | bfs | Brooklyn ridgewood was | [link](https://newyork.craigslist.org/que/bfs/d/brooklyn-desk-for-computer/7939354735.html) |
+| $0 | Lab Cleanup – Vacuum Deposition / ALD / Thin Film Research Equipment | bfs | LIC | [link](https://newyork.craigslist.org/que/bfs/d/astoria-lab-cleanup-vacuum-deposition/7943369573.html) |
+| $1,799 | Ricoh Aficio MP C2800 Color Laser Multifunction Printer Copier | bfs | Jamaica | [link](https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-mp-c2800-color/7941274391.html) |
+| $1,799 | Ricoh Aficio MP C2800 Color Laser Multifunction Printer Copier | bfs | Jamaica | [link](https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-mp-c2800-color/7928065751.html) |
+| $899 | Ricoh Aficio Sp C430dn Color Laser Printer | bfs | Jamaica | [link](https://newyork.craigslist.org/que/bfs/d/jamaica-ricoh-aficio-sp-c430dn-color/7921508535.html) |
+| $25 | Student computer chair | bfs | Jamaica | [link](https://newyork.craigslist.org/que/bfs/d/jamaica-student-computer-chair/7910240007.html) |
+| $2,199 | Toshiba e-Studio 3540C Copier Printer | bfs | Jamaica | [link](https://newyork.craigslist.org/que/bfs/d/jamaica-toshiba-studio-3540c-copier/7920493316.html) |
+| $240 | 24 Speed SPECIALIZED CROSSTRAILS Mountain Bicycle 21 inch frame | bik | Commack | [link](https://newyork.craigslist.org/que/bik/d/commack-24-speed-specialized/7943391578.html) |
+| $375 | Specialized Allez Elite 52CM | bik | Astoria | [link](https://newyork.craigslist.org/que/bik/d/astoria-specialized-allez-elite-52cm/7943376940.html) |
+| $15 | Lightning Noir | bks | Queens, New York City | [link](https://newyork.craigslist.org/que/bks/d/forest-hills-lightning-noir/7915040720.html) |
+| $27 | Turn up your marketing with AI | bks | queens | [link](https://newyork.craigslist.org/que/bks/d/south-ozone-park-turn-up-your-marketing/7933206486.html) |
+| $1 | Trim tab blades | bpo | Maspeth | [link](https://newyork.craigslist.org/que/bpo/d/maspeth-trim-tab-blades/7920784078.html) |
+| $10 | Brenthaven Prostyle carrying case | clo | Kew Gardens | [link](https://newyork.craigslist.org/que/clo/d/jamaica-brenthaven-prostyle-carrying/7928333169.html) |
+| $125 | Coach Black Bag Signature Collection Limited Edition Satchel | clo | Hollis | [link](https://newyork.craigslist.org/que/clo/d/hollis-coach-black-bag-signature/7938485077.html) |
+| $150 | Donna Karen New York BRAND NEW Bag | clo | Maspeth | [link](https://newyork.craigslist.org/que/clo/d/maspeth-donna-karen-new-york-brand-new/7940447871.html) |
+| $95 | Dooney&Bourke All Weather Vintage Saddle Bag | clo | jackson heights | [link](https://newyork.craigslist.org/que/clo/d/jackson-heights-dooneybourke-all/7939626748.html) |
+| $120 | Jet Set Charm Md Conv Pouchette Xbody Black | clo | Flushing | [link](https://newyork.craigslist.org/que/clo/d/flushing-jet-set-charm-md-conv/7938208715.html) |
+| $50 | LEVEL8 Laptop Backpack, Work Backpack Computer Bag | clo | queens | [link](https://newyork.craigslist.org/que/clo/d/brooklyn-level8-laptop-backpack-work/7938860784.html) |
+| $40 | Litto Howler - 1.5" Collar with Handle LIMITED EDITION Tortugas Seafoa | clo | Bayside | [link](https://newyork.craigslist.org/que/clo/d/oakland-gardens-litto-howler-15-collar/7915000576.html) |
+| $15 | Lululemon Core Computer Backpack 20L Heather Gray Out of Range | clo | Long island city | [link](https://newyork.craigslist.org/que/clo/d/long-island-city-lululemon-core/7939729368.html) |
+| $80 | Michael Kors Jet Set Large Sig logo Bag | clo | Valley Stream | [link](https://newyork.craigslist.org/que/clo/d/valley-stream-michael-kors-jet-set/7938012795.html) |
+| $50 | Michael Kors jet set tote | clo | Oakland Gardens | [link](https://newyork.craigslist.org/que/clo/d/oakland-gardens-michael-kors-jet-set/7924244131.html) |
+| $100 | Michael Kors Leather Shoulder Bag | clo | Hollis | [link](https://newyork.craigslist.org/que/clo/d/hollis-michael-kors-leather-shoulder-bag/7938484620.html) |
+| $10 | Miniseti Black Canvas Bag | clo | Jackson Heights | [link](https://newyork.craigslist.org/que/clo/d/jackson-heights-miniseti-black-canvas/7934559345.html) |
+| $50 | New DKMY Black Saffiano Leather Satchel Crossbody bag | clo | queens | [link](https://newyork.craigslist.org/que/clo/d/bayside-new-dkmy-black-saffiano-leather/7938715723.html) |
+| $900 | Prada Twin Pocket Tote Glace Calf BN2619 | clo | queens | [link](https://newyork.craigslist.org/que/clo/d/oakland-gardens-prada-twin-pocket-tote/7912733085.html) |
+| $20 | Red Suede Wedge Heels with Ankle Strap | clo | Sunnyside | [link](https://newyork.craigslist.org/que/clo/d/sunnyside-red-suede-wedge-heels-with/7910877330.html) |
+| $39 | Rolling Backpack/Wheeled Laptop Backpac | clo | Queens | [link](https://newyork.craigslist.org/que/clo/d/long-island-city-rolling-backpack/7944115419.html) |
+| $30 | Seal Line Laptop Waterproof Computer Sleeve Large Padded | clo | astoria | [link](https://newyork.craigslist.org/que/clo/d/astoria-seal-line-laptop-waterproof/7926558969.html) |
+| $125 | Solid wood and black leather modern computer chair!!! originally $300! | clo | queens | [link](https://newyork.craigslist.org/que/clo/d/flushing-solid-wood-and-black-leather/7939962152.html) |
+| $240 | 2 IMAC's for sale | clt | queens | [link](https://newyork.craigslist.org/que/clt/d/maspeth-imacs-for-sale/7938204591.html) |
+| $650 | 40" Vintage Chinese Hand Carved Camphor Wood Chest Blanket Trunk | clt | Sunnyside | [link](https://newyork.craigslist.org/que/clt/d/sunnyside-40-vintage-chinese-hand/7940770906.html) |
+| $65 | Smokeing pipes (3) 3 pipe tools / cigarette wood box | clt | Kew Gardens Queens | [link](https://newyork.craigslist.org/que/clt/d/kew-gardens-smokeing-pipes-3-pipe-tools/7924666735.html) |
+| $8,950 | 2017 Ford Escape Titanium 4WD SUV | ctd | Floral Park | [link](https://newyork.craigslist.org/que/ctd/d/floral-park-2017-ford-escape-titanium/7942090123.html) |
+| $10,995 | 2019 Nissan Sentra - Great Deal!-queens | ctd | Woodside | [link](https://newyork.craigslist.org/que/ctd/d/woodside-2019-nissan-sentra-great-deal/7942095817.html) |
+| $34,550 | 7 SEATER MODEL Y COMP 4 AWD 63KMILES | cto | QUEENS NY | [link](https://newyork.craigslist.org/que/cto/d/oakland-gardens-seater-model-comp-awd/7942442627.html) |
+| $6,500 | Mercedes Benz ML350 4Matic | cto | queens | [link](https://newyork.craigslist.org/que/cto/d/flushing-mercedes-benz-ml350-4matic/7943108048.html) |
+| $50 | * NEW * JBL Tune 125TWS Ear Buds headphones Wireless Bluetooth | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-jbl-tune-125tws-ear/7914768705.html) |
+| $140 | * NEW * Ooma Smart Security Starter Pack | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-ooma-smart-security/7914768955.html) |
+| $130 | * NEW * Pixel Buds Pro (Corel) * Earbud Headphones Ear Bud | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-pixel-buds-pro-corel/7914768403.html) |
+| $199 | 10.1" Planet Audio P100CPAC Bluetooth Multimedia Player/ Rear Camera | ele | Carplay and Android Auto | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-101-planet-audio-p100cpac/7918249927.html) |
+| $50 | 116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-116-peace-screwdriver/7931408380.html) |
+| $15 | 2 Kensington headphones classic USB-A connection | ele | Forest Hills, Queens | [link](https://newyork.craigslist.org/que/ele/d/rego-park-kensington-headphones-classic/7940103990.html) |
+| $99 | 2- APPLE I-PADS ONE WORKS, ONE DOESN'T POWER ON! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-apple-pads-one-works/7938036768.html) |
+| $50 | 24" DELL COMPUTER MONITOR (no base stand!) | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-dell-computer/7920272303.html) |
+| $65 | 24" VIZIO LED SMART TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-vizio-led-smart-tv/7920271542.html) |
+| $65 | 24" VIZIO LED SMART TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-24-vizio-led-smart-tv/7921513387.html) |
+| $75 | 32" APEX LCD TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-apex-lcd-tv-remote/7918789096.html) |
+| $70 | 32" PHILLIPS FLAT SCREEN TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-phillips-flat-screen/7923891718.html) |
+| $70 | 32" PHILLIPS FLAT SCREEN TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-phillips-flat-screen/7920271720.html) |
+| $85 | 32" SAMSUNG LCD FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-lcd-flat/7923646977.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7919432544.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7922222367.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7912957128.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7936784232.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7911614397.html) |
+| $85 | 32" SAMSUNG LED FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-samsung-led-flat/7913706345.html) |
+| $45 | 32" TV | ele | bayside | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-32-tv/7929731077.html) |
+| $40 | 40 inch Samsung TV, HDTV model. Works and looks perfect | ele | Kew Gardens | [link](https://newyork.craigslist.org/que/ele/d/flushing-40-inch-samsung-tv-hdtv-model/7933291243.html) |
+| $199 | 43 Inch Smart Monitor M7 M70F | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-43-inch-smart-monitor/7943147367.html) |
+| $65 | 4k camera with lots of accessories -Waterproof Underwater Diving + | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-4k-camera-with-lots-of/7917102366.html) |
+| $199 | ACCUVOICE AV155 TV SPEAKER WITH HEARING AID TECHNOLOGY | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/forest-hills-accuvoice-av155-tv-speaker/7928058629.html) |
+| $50 | ACER 19" LCD COMPUTER MONITOR WORKS GREAT MODEL# A1916W | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-acer-19-lcd-computer/7918789488.html) |
+| $50 | ACER 19" LCD COMPUTER MONITOR WORKS GREAT MODEL# A1916W | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-acer-19-lcd-computer/7920271887.html) |
+| $325 | Adcom GFA-7400 Power Amplifier 5 Channel (100 WPC) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-adcom-gfa-7400-power-amplifier/7927559231.html) |
+| $380 | ADZEN AUDIO MIXER | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-adzen-audio-mixer/7909972500.html) |
+| $75 | Aiwa Boombox Plays CDS Cassettes & AM/FM Radio | ele | Flushing Queens NY | [link](https://newyork.craigslist.org/que/ele/d/new-york-aiwa-boombox-plays-cds/7921542257.html) |
+| $200 | AJA IO HD MEDIA CONVERTER ANALOG/DIGITAL | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/astoria-aja-io-hd-media-converter/7933646444.html) |
+| $99 | ALPINE S-SERIES MONO SUBWOOFER AMPLIFIER \| S-A60M | ele | 600w @2ohms | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-alpine-series-mono/7911290622.html) |
+| $19 | Altec Lansing High Definition Wifi Security Camera | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-altec-lansing-high/7913087248.html) |
+| $18 | Altec Lansing High Definition Wifi Security Camera | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-altec-lansing-high/7909743155.html) |
+| $269 | Amazon Fire TV 50” 4K  4-Series Alexa | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7913087081.html) |
+| $269 | Amazon Fire TV 50” 4K  4-Series Alexa | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7913097526.html) |
+| $255 | Amazon Fire TV 50” 4K  4-Series Alexa | ele | Middle Village | [link](https://newyork.craigslist.org/que/ele/d/middle-village-amazon-fire-tv-50-4k/7909741549.html) |
+| $99 | AMX ACV-2100BL Acendo Vibe Conferencing Echo Cancellation BT Sound Bar | ele | Bluetooth | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-amx-acv-2100bl-acendo-vibe/7912403751.html) |
+| $80 | anker soundcore rave neo | ele | Jackson Heights | [link](https://newyork.craigslist.org/que/ele/d/jackson-heights-anker-soundcore-rave-neo/7936432813.html) |
+| $15 | Apple 60-Watt MagSafe Power Adapter Wall Charger | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-60-watt-magsafe-power/7942754823.html) |
+| $175 | Apple iMac 21.5” Intel Quad-Core i5 2.8GHz 8GB RAM 1TB + 24GB | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-imac-215-intel-quad/7942755158.html) |
+| $35 | Apple iPod 32gb w/extras | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-apple-ipod-32gb-extras/7922595032.html) |
+| $7 | Apple Mac Mini A1188 110W 18.5V 6.0A and A1105 85W 18.5V 4.6A Adapters | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-mini-w-185v-60a-and/7942755623.html) |
+| $233 | Apple Mac Pro 3.5GHz 6-Core Intel Xeon E5, 16GB RAM 512GB SSD | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-pro-35ghz-core/7942749755.html) |
+| $213 | Apple Mac Pro 3.7GHz Intel Xeon E5, 16GB RAM 251GB SSD | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-mac-pro-37ghz-intel/7942753470.html) |
+| $19 | Apple MacBook 65 Watt Portable Power Adapter A1021 | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-65-watt/7942755963.html) |
+| $195 | Apple MacBook Pro 13.3” Retina Intel Core i5 2.7GHz 8GB RAM 128GB SSD. | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-pro-133-retina/7942756002.html) |
+| $249 | Apple MacBook Pro13.3” Retina NEW BATTERY | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-macbook-pro133-retina/7942748074.html) |
+| $35 | Apple Magic Keyboard Bluetooth | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-magic-keyboard-bluetooth/7942761249.html) |
+| $29 | Apple slim USB Wired Keyboard | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-slim-usb-wired-keyboard/7943560617.html) |
+| $24 | Apple Trackpad Silver Multi-Touch Dual Sensor Wireless / Bluetooth | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-trackpad-silver-multi/7942754524.html) |
+| $23 | Apple Wireless Bluetooth Keyboard, Silver | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-apple-wireless-bluetooth/7942750583.html) |
+| $79 | Art 4330937335 C1 Cardiod FET USB Condenser Dynamic Range Microphone | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-art-c1-cardiod-fet-usb/7914559340.html) |
+| $160 | ASUS 4K Gaming / Work Monitor - 28" - Adjustable Height / Rotate | ele | Financial district | [link](https://newyork.craigslist.org/que/ele/d/new-york-asus-4k-gaming-work-monitor/7944202944.html) |
+| $99 | Atlas Sound FAP4OT Ceiling Speaker System (pair) | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-atlas-sound-fap4ot-ceiling/7914834459.html) |
+| $299 | Atlas Sound IPDC-DSE+ Sided Wall or Ceiling Mount 16 x 64 LED Display | ele | or Best Offer | [link](https://newyork.craigslist.org/que/ele/d/jamaica-atlas-sound-ipdc-dse-sided-wall/7914794120.html) |
+| $15 | Audio & Video Cables | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/corona-audio-video-cables/7933091402.html) |
+| $175 | AudioQuest Type 6 Bi-Wire Speaker Cables (LGC Copper;10ft & 13ft Pair) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-audioquest-type-bi-wire/7923019066.html) |
+| $10 | B&W Speaker Spikes (Set of 4; Opened Box) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-bw-speaker-spikes-set-of/7921650667.html) |
+| $30 | Baby blue ceramic lamps with shades pair | ele | Arverne | [link](https://newyork.craigslist.org/que/ele/d/arverne-baby-blue-ceramic-lamps-with/7940949165.html) |
+| $150 | Bang and Olufsen Beoplay S3 Bluetooth/Wired Speaker | ele | Broad Channel | [link](https://newyork.craigslist.org/que/ele/d/far-rockaway-bang-and-olufsen-beoplay/7911815751.html) |
+| $30 | Beats Flex Wireless Earphones | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-beats-flex-wireless/7917104355.html) |
+| $55 | Beats mixed wired headset with 2.0 with  MP3 | ele | Queens ny | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixed-wired-headset/7916744813.html) |
+| $65 | Beats mixer headset with Sansa am/fm mp/3 player | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixer-headset-with/7936498631.html) |
+| $25 | Beats mixer wired headset | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-mixer-wired-headset/7942971267.html) |
+| $25 | Beats wires stereo headphones | ele | Queens ny | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-beats-wires-stereo/7939302971.html) |
+| $125 | Belkin PureAV PF60 Power Conditioner (Great Condition) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-belkin-pureav-pf60-power/7914832951.html) |
+| $350 | Black 50 Inch Samsung 4K LED UHD 2020 Smart TV Television UN50TU7000F | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/woodside-black-50-inch-samsung-4k-led/7944029087.html) |
+| $10 | Black Metal Speaker Spikes – Set of 8 – New (No Box) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-black-metal-speaker-spikes-set/7921654202.html) |
+| $79 | Blue Screen, Green Screen, Grey Screen White/Black Backdrop and Tripod | ele | Astoria | [link](https://newyork.craigslist.org/que/ele/d/astoria-blue-screen-green-screen-grey/7934029295.html) |
+| $30 | Bosch Optikon Binoculars Coated Lens Complete with Compass Lens Caps | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-bosch-optikon-binoculars/7935424551.html) |
+| $55 | BOSE 161 SPEAKERS | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-bose-161-speakers/7942753996.html) |
+| $111 | Bose 161 Speakers & Bose VCS-10 Center Channel Speaker Surround Sound | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-bose-161-speakers-bose-vcs-10/7942751733.html) |
+| $250 | BOSE Acoustimass 16 Home Entertainment Center. | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-bose-acoustimass-16-home/7941869829.html) |
+| $70 | Bose Acoustimass 3 Series III Subwoofer & Satellite Speakers | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-bose-acoustimass-series-iii/7941981166.html) |
+| $100 | Bose Acoustimass 7 Speaker System Subwoofer & 3 Satellites Wall Mounts | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-bose-acoustimass-speaker/7941980194.html) |
+| $25 | BOSE Acoustimass*5 Series II Speaker System | ele | Glendale | [link](https://newyork.craigslist.org/que/ele/d/rego-park-bose-acoustimass5-series-ii/7925708470.html) |
+| $45 | Bose Companion 2 Series II Multimedia Powered Computer Speakers Nice | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-bose-companion-series-ii/7936795349.html) |
+| $55 | BOSE VCS-10 CENTER CHANNEL SPEAKER | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-bose-vcs-10-center-channel/7942754649.html) |
+| $65 | Bose wired headset w/case | ele | Queens ny | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-bose-wired-headset-case/7924666676.html) |
+| $20 | Bose wired headset.      W/case ….. | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-bose-wired-headset-case/7910133765.html) |
+| $90 | Boston Acoustics A60 Bookshelf Speakers New Foam Surrounds Black | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-boston-acoustics-a60/7926984249.html) |
+| $38 | Brand New Bissell 1974 SmartClean Robot Vacuum | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-brand-new-bissell-1974/7941638572.html) |
+| $35 | Brand New Blend Jet In Box | ele | Flushing Queens NY | [link](https://newyork.craigslist.org/que/ele/d/new-york-brand-new-blend-jet-in-box/7921814823.html) |
+| $500 | Brand new Dell u3225q 32in 4k 120htz monitor | ele | Woodhaven | [link](https://newyork.craigslist.org/que/ele/d/woodhaven-brand-new-dell-u3225q-32in-4k/7944134506.html) |
+| $0 | Brand new HID and led Headlights  🚗 | ele | 18 months warranty - Queens | [link](https://newyork.craigslist.org/que/ele/d/queens-village-brand-new-hid-and-led/7917173518.html) |
+| $100 | brand new HP monitor V24i FHD never open | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/new-york-brand-new-hp-monitor-v24i-fhd/7943404779.html) |
+| $69 | Brand new JBL Tune 660NC On-ear noise canceling wireless headphones | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/maspeth-brand-new-jbl-tune-660nc-on-ear/7913098738.html) |
+| $150 | Brand New Yamaha YAS-201 Sound Bar + Wireless Subwoofer | ele | Brooklyn | [link](https://newyork.craigslist.org/que/ele/d/brooklyn-brand-new-yamaha-yas-201-sound/7944204978.html) |
+| $40 | Brother MFC-7840W All-In-One Laser Printer - for repair. Toner include | ele | Forest Hills | [link](https://newyork.craigslist.org/que/ele/d/forest-hills-brother-mfc-7840w-all-in/7943974822.html) |
+| $130 | Camera bag - WANDRD PRVKE 21L v3 | ele | corona | [link](https://newyork.craigslist.org/que/ele/d/corona-camera-bag-wandrd-prvke-21l-v3/7941486021.html) |
+| $120 | Canon PC940 Copier/Printer in Good Condition! | ele | Douglaston | [link](https://newyork.craigslist.org/que/ele/d/little-neck-canon-pc940-copier-printer/7944148552.html) |
+| $75 | CANON PIXMA TR4720 WIRELESS ALL-IN-ONE INKJET PRINTER \| 5074C002 \| NEW | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-canon-pixma-tr4720/7912211780.html) |
+| $199 | Cerwin-Vega B52 – Stealth Bomber Series 2-Channel Class D Amplifier | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-cerwin-vega-b52-stealth/7916490377.html) |
+| $15 | Charger Dock Compatible with Fitbit | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-charger-dock/7917103890.html) |
+| $235 | Classic marantz stereo receiver 2230 ( no-cabinet) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-classic-marantz-stereo/7911305528.html) |
+| $10 | COBY HI-FI STEREO EARPHONES CV-E20 (NEW IN PACKAGE) | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/coby-hi-fi-stereo-earphones-cv-e20-new/7909772098.html) |
+| $40 | COBY Progressive DVD player | ele | Glendale | [link](https://newyork.craigslist.org/que/ele/d/rego-park-coby-progressive-dvd-player/7925715880.html) |
+| $20 | COMPUTER CONTROL CENTER | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-control-center/7930284925.html) |
+| $20 | COMPUTER CONTROL CENTER | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-control-center/7923219119.html) |
+| $10 | Computer Keyboard | ele | Rego Park | [link](https://newyork.craigslist.org/que/ele/d/rego-park-computer-keyboard/7938484798.html) |
+| $10 | Computer Keyboard Apple | ele | Rego Park | [link](https://newyork.craigslist.org/que/ele/d/rego-park-computer-keyboard-apple/7938485325.html) |
+| $30 | Computer Monitors | ele | Ozone Park | [link](https://newyork.craigslist.org/que/ele/d/ozone-park-computer-monitors/7913902641.html) |
+| $0 | COMPUTER MONITORS: 15" 17" & 19" & DELL, HP | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7924503553.html) |
+| $0 | COMPUTER MONITORS: 15" 17" & 19" & DELL, HP | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7923218778.html) |
+| $0 | COMPUTER MONITORS: 15" 17" & 19" & DELL, HP | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-computer-monitors-dell/7922219484.html) |
+| $289 | Crown D75 Power Amp | ele | Forest Hills | [link](https://newyork.craigslist.org/que/ele/d/forest-hills-crown-d75-power-amp/7944121660.html) |
+| $125 | Dayton Audio APA150 150W Power Amplifier/Subwoofer Amp/Monoblock | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-dayton-audio-apa-power/7931322020.html) |
+| $45 | Definitive Technology ProCenter 60 Center Speaker | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-definitive-technology/7909804400.html) |
+| $350 | Definitive Technology SM55 Bookshelf speakers | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/forest-hills-definitive-technology-sm55/7944120924.html) |
+| $160 | Denon AVR-3806 7.1 Channel AV Receiver (Phono Support; Made in Japan) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-denon-avr-channel-av-receiver/7942923477.html) |
+| $499 | DIGITAL PROJECTION TITAN HD-500 720P CONFERENCE ROOM PROJECTOR | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-digital-projection-titan/7914524659.html) |
+| $6 | Doll | ele | ridgewood | [link](https://newyork.craigslist.org/que/ele/d/doll/7905892953.html) |
+| $300 | Don't miss this.. 2 in 1 touchscreen HP. Laptop | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-dont-miss-this-in/7941904390.html) |
+| $39 | DUKANE I-PRO 456-8806 Replacement 300Watts & 2000 Hours Projector Lamp | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-dukane-pro-replacement/7914532160.html) |
+| $125 | Dyson Zone Active Noise-Cancelling headphones WP01 - ULTRA BLUE - New | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/hollis-dyson-zone-active-noise/7942230716.html) |
+| $9 | EA Sports UFC for Sony PlayStation 4, PS4. | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-ea-sports-ufc-for-sony/7942753775.html) |
+| $35 | EERO 6 Router | ele | New York | [link](https://newyork.craigslist.org/que/ele/d/new-york-eero-router/7921071460.html) |
+| $140 | Elgato Collapsible Green Screen Chroma Key Panel - Like New | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-elgato-collapsible/7934166769.html) |
+| $125 | Elgato Wave XLR USB-C Audio Interface Like New | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-elgato-wave-xlr-usb/7934166796.html) |
+| $175 | Episode 2-Channel Power Amplifier (Class D Amp; 95 WPC) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-episode-channel-power/7937970936.html) |
+| $300 | Excellent 2 in 1 HP touchscreen laptop | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-excellent-in-hp/7924319721.html) |
+| $250 | EXP 48 PRO Medical Grade Battery | ele | Ozone Park | [link](https://newyork.craigslist.org/que/ele/d/ozone-park-exp-48-pro-medical-grade/7908187453.html) |
+| $150 | Facial Recognition record + Temperature Scan - perfect for business | ele | Astoria | [link](https://newyork.craigslist.org/que/ele/d/astoria-facial-recognition-record/7940104273.html) |
+| $110 | Fender American Stratocaster pickups post 2000 Staggered | ele | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/ele/d/queens-village-fender-american/7917446931.html) |
+| $210 | Fender custom Shop Texas Specials Pickup set | ele | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/ele/d/queens-village-fender-custom-shop-texas/7921737837.html) |
+| $60 | FIRESTICK Movies Shows and over 1500 Games (SPECIAL SETUP) | ele | NY | [link](https://newyork.craigslist.org/que/ele/d/floral-park-firestick-movies-shows-and/7940424348.html) |
+| $69 | FITBIT CHARGE 3, EXCELLENT CONDITION | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-fitbit-charge-excellent/7913089454.html) |
+| $69 | FITBIT CHARGE 3, EXCELLENT CONDITION | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-fitbit-charge-excellent/7909739564.html) |
+| $97 | Fitbit Versa 4 Advanced Health & Fitness Tracker Smartwatch | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/new-york-fitbit-versa-advanced-health/7941490425.html) |
+| $3,000 | Friedman Twin Sister and 2x12 Bottom | ele | Queens Village | [link](https://newyork.craigslist.org/que/ele/d/queens-village-friedman-twin-sister-and/7918595570.html) |
+| $99 | FSR T3-MJ+1B-BLACK Table Top Microphone Insert box (1-Button/1-LED) | ele | or Best Offer | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-fsr-t3-mj1b-black-table/7914796241.html) |
+| $100 | Garmin Edge 705 cycling computer | ele | Howard Beach | [link](https://newyork.craigslist.org/que/ele/d/howard-beach-garmin-edge-705-cycling/7941632505.html) |
+| $65 | Gen sound vintage preamp | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7942342023.html) |
+| $40 | Gen sound vintage preamp | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7920873478.html) |
+| $65 | Gen sound vintage preamp | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7940953342.html) |
+| $65 | Gen sound vintage preamp | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-gen-sound-vintage-preamp/7914588006.html) |
+| $35 | Google AC-1304 1 Port 1200Mbps Wireless Router | ele | Sunnyside | [link](https://newyork.craigslist.org/que/ele/d/sunnyside-google-ac-port-1200mbps/7932652583.html) |
+| $30 | Guitar Transmitter Receiver Wireless | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-guitar-transmitter/7917100985.html) |
+| $9 | H&M Wired Headphones Girl Kids Pink | ele | Howard Beach | [link](https://newyork.craigslist.org/que/ele/d/howard-beach-hm-wired-headphones-girl/7906519074.html) |
+| $19 | Heygelo Drone S90 for adults | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-heygelo-drone-s90-for/7913098047.html) |
+| $20 | HFT 12 Volt Heater / Defroster With Light | ele | Whitestone NY | [link](https://newyork.craigslist.org/que/ele/d/bayside-hft-12-volt-heater-defroster/7943657817.html) |
+| $199 | Hifonics ZD-2550.1D Zeus Delta 2500 Watt Mono Block Amplifier | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-hifonics-zd-25501d-zeus/7931316472.html) |
+| $100 | Hisense 50” U6 Quantum ULED 4K Fire TV - $100 | ele | Ridgewood | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-hisense-50-u6-quantum-uled-4k/7937610500.html) |
+| $50 | Honeywell home alarm components & IP Cam $150 obo | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/corona-honeywell-home-alarm-components/7937608519.html) |
+| $25 | HP  LAPTOP BAG | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-hp-laptop-bag/7917103705.html) |
+| $60 | Hubbell CFB2G25RCRE 2‑Gang Floor Box Assembly – New | ele | middle village | [link](https://newyork.craigslist.org/que/ele/d/middle-village-hubbell-cfb2g25rcre/7939634392.html) |
+| $199 | IC REALTIME VANDAL DOME NETWORK CAMERA \| IPFX-D40V-IRW2 \| NEW OPEN BOX | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-ic-realtime-vandal-dome/7914531466.html) |
+| $50 | IKEA LAMP COOL LOOKING WHITE FLORSCENT TYPE | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-ikea-lamp-cool-looking/7918790403.html) |
+| $35 | Illuminated Address Light Fixture | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-illuminated-address-light/7934004463.html) |
+| $10 | Inspire Ladies Cotton Underwear 2  In Package X 5 Size  M | ele | Flushing Queens NY | [link](https://newyork.craigslist.org/que/ele/d/new-york-inspire-ladies-cotton/7923182142.html) |
+| $5 | InspireVinyl Exsmination Gloves Size M Box 100 CT | ele | Flushing Queens NY | [link](https://newyork.craigslist.org/que/ele/d/new-york-inspirevinyl-exsmination/7923179654.html) |
+| $110 | IPhone 7 32gb like new unlocked | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-iphone-32gb-like-new/7920871825.html) |
+| $110 | IPhone 7 32gb like new unlocked | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-iphone-32gb-like-new/7915868201.html) |
+| $60 | Jabra Evolve2 65 | ele | Forest hills | [link](https://newyork.craigslist.org/que/ele/d/rego-park-jabra-evolve2-65/7937627013.html) |
+| $25 | Jbl Bluetooth headset with charge cable and plug | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7941072343.html) |
+| $25 | Jbl Bluetooth headset with charge cable and plug | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7943369193.html) |
+| $25 | Jbl Bluetooth headset with charge cable and plug | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-jbl-bluetooth-headset-with/7918836234.html) |
+| $99 | JBL COMPACT DESKTOP REFERENCE MONITOR SPEAKERS  JBL104BT | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-jbl-compact-desktop/7914075234.html) |
+| $199 | JBL CONTROL 45C/T 5.25" COAXIAL CEILING LOUDSPEAKER PAIR WHITE NEW | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-jbl-control-45c-525/7927963336.html) |
+| $69 | JBL Tune 660NC On-ear noise canceling wireless headphones | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/maspeth-jbl-tune-660nc-on-ear-noise/7913087790.html) |
+| $77 | JBL Tune 660NC On-ear noise canceling wireless headphones | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/maspeth-jbl-tune-660nc-on-ear-noise/7909738327.html) |
+| $125 | JVC 6.8" BLUETOOTH DIGITAL MULTIMEDIA RECEIVER KW-M180BT | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-68-bluetooth-digital/7914216273.html) |
+| $199 | JVC 6.8" DIGITAL BLUETOOTH MULTIMEDIA RECEIVER KW-M590BT | ele | Apple Carplay/Android Auto | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-68-digital-bluetooth/7933092824.html) |
+| $139 | JVC 6.8" MULTIMEDIA DVD RECEIVER WITH BLUETOOTH KW-V850BT | ele | Carplay and Android Auto | [link](https://newyork.craigslist.org/que/ele/d/hollis-jvc-68-multimedia-dvd-receiver/7939778670.html) |
+| $199 | JVC Arsenal KW-NT800HDT  Audio/Video GPS Navigation System CD/DVD. B/T | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-jvc-arsenal-kw-nt800hdt/7925072457.html) |
+| $25 | JVC XV-N650 DVD Player (Tested and Working) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-jvc-xv-n650-dvd-player-tested/7927553897.html) |
+| $100 | K 903 XD Karaoke Stereo Intergrated Mixer | ele | Whitestone  NY | [link](https://newyork.craigslist.org/que/ele/d/bayside-903-xd-karaoke-stereo/7943657595.html) |
+| $100 | KEF  Speakers | ele | Whitestone  NY | [link](https://newyork.craigslist.org/que/ele/d/bayside-kef-speakers/7943657706.html) |
+| $30 | Kenwood CD-404 5 Disc CD Changer No Remote | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-kenwood-cd-disc-cd-changer/7926796507.html) |
+| $125 | KENWOOD CLASS D BRIDGEABLE 600W 4CH /MULTICHANNEL AMPLIFIER KAC-314 | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-class-bridgeable/7924673394.html) |
+| $199 | Kenwood DMX706S Digitial Multimedia Bluetooth Double Din Receiver | ele | AppleCarplay and Android Auto | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-dmx706s-digitial/7926873098.html) |
+| $199 | KENWOOD DOUBLE DIN DVD BLUETOOTH CAR STEREO DDX5707S | ele | Carplay and Android Auto | [link](https://newyork.craigslist.org/que/ele/d/hollis-kenwood-double-din-dvd-bluetooth/7941589451.html) |
+| $129 | Kenwood KAC-511 Class D Mono Digital Bass Boost Power Amplifier 1000 W | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-kenwood-kac-511-class-mono/7929565415.html) |
+| $10 | Kenwood KT-56 AM/FM Stereo Tuner (Made in Japan; Read) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-kenwood-kt-56-am-fm-stereo/7918545487.html) |
+| $75 | KJB SC7150 Smoke Detector Camera | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-kjb-sc7150-smoke-detector-camera/7914792489.html) |
+| $275 | Klipsch KV-4 Center Speaker - Audiophile Grade | ele | Elmhurst | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-klipsch-kv-center-speaker/7927598319.html) |
+| $65 | Klipsch SC.5 - High-Performance Center Channel Speaker | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-klipsch-sc5-high-performance/7924259918.html) |
+| $25 | Knöll ll Systems 4 Zone Stereo Speakers Multiroom Interface NOS | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-knll-ll-systems-zone-stereo/7942751655.html) |
+| $10 | large calculator - solar powered | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-large-calculator-solar/7917102816.html) |
+| $150 | Lenovo ThinkVision P24h-20 flat screen Hi-Def Monitor (New in box) | ele | Ozone Park | [link](https://newyork.craigslist.org/que/ele/d/ozone-park-lenovo-thinkvision-p24h-20/7927438866.html) |
+| $50 | LEVOIT SMART TRUE HEAP AIR PURIFIER MODEL# LV-PUP131S | ele | bayside/queens | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-levoit-smart-true-heap/7919433424.html) |
+| $125 | LG RN5 XBOOM AUDIO SYSTEM WITH BLUETOOTH | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/hollis-lg-rn5-xboom-audio-system-with/7935187158.html) |
+| $125 | LG RP4 XBOOM 360 PORTABLE WIRELESS BLUETOOTH SPEAKER BURGUNDY | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-lg-rp4-xboom-360-portable/7927963149.html) |
+| $125 | LG RP4 XBOOM 360 PORTABLE WIRELESS BLUETOOTH SPEAKER BURGUNDY | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-lg-rp4-xboom-360-portable/7914867194.html) |
+| $69 | LG Tablet for sale (LG-LK430) | ele | maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-lg-tablet-for-sale-lg/7913096867.html) |
+| $199 | LG XBOOM AUDIO SYSTEM WITH BLUETOOTH \| RNC5 \| NEW | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-lg-xboom-audio-system-with/7914535539.html) |
+| $28 | Logitech NASCAR Racing Steering Wheel & Pedals for Playstation 2, PS2 | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-logitech-nascar-racing/7942751067.html) |
+| $99 | LOT OF (10) BOOM BOXES AS-IS! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-lot-of-10-boom-boxes-as/7915516750.html) |
+| $99 | LOT OF (10) BOOM BOXES AS-IS! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-lot-of-10-boom-boxes-as/7913705444.html) |
+| $39 | LTS CMD726W 480TVL Color Dome Camera Heavy Duty Vandal Weather Proof | ele | each | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-lts-cmd726w-480tvl-color/7914539408.html) |
+| $0 | MANY FLAT SCREEN TV'S FOR SALE | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-many-flat-screen-tvs/7942569957.html) |
+| $50 | MARANTZ STEREOPHONIC (FACE PLATE) FOR MODEL 2270 | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-marantz-stereophonic/7917929238.html) |
+| $80 | Matrix Audio Series 6 S6.8 MultiRoom Audio Distribution Amp/Controller | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-matrix-audio-series-s68/7932497177.html) |
+| $40 | Memorex DBS 90 cassettes 10-Pack NOS still-sealed! 90s | ele | Bayside | [link](https://newyork.craigslist.org/que/ele/d/bayside-memorex-dbs-90-cassettes-10/7921892213.html) |
+| $495 | Meta Quest 3 512GB (Brand New) | ele | Oakland Gardens | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-meta-quest-512gb-brand/7944159121.html) |
+| $65 | METRA 12" DUAL SEALED SUBWOOFER ENCLOSURE \| TCBX-212 | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-metra-12-dual-sealed/7914532727.html) |
+| $15 | Monster Interlink 250 Stereo RCA Audio Cable / Subwoofer Cable (13 ft) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-monster-interlink-250-stereo/7921661461.html) |
+| $85 | Monster Power HTS 3500 Power Conditioner | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-monster-power-hts-3500-power/7914831887.html) |
+| $5 | Monster ScreenClean Screen Cleaner - Small 1.52FL OZ 45ML | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-monster-screenclean-screen/7914219108.html) |
+| $950 | MSI Claw 8AI+ | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-msi-claw-8ai/7944206900.html) |
+| $350 | Music Hall Maverick CD25.2 Player | ele | Queens Village | [link](https://newyork.craigslist.org/que/ele/d/queens-village-music-hall-maverick/7915693402.html) |
+| $185 | Nakamichi Receiver 2 (Phono Support; Excellent Sound) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-nakamichi-receiver-phono/7940829507.html) |
+| $50 | Netgear Wifi range extender | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/middle-village-netgear-wifi-range/7944058607.html) |
+| $80 | New Amazon Alexa Echo 2nd Generation(70), and Google Home Mini(30) | ele | rego park | [link](https://newyork.craigslist.org/que/ele/d/south-richmond-hill-new-amazon-alexa/7927133579.html) |
+| $12 | NEW Case MacBook Air 15 inch 2024 2023 M3 M2 Model A3114 A2941 | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-new-case-macbook-air-15-inch/7942751932.html) |
+| $160 | NEW Galaxy Watch6 44mm Graphite BT | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-galaxy-watch6-44mm/7921629699.html) |
+| $250 | NEW Garmin Forerunner 245 Music Running GPS Watch | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-garmin-forerunner-245/7927253702.html) |
+| $330 | NEW Garmin Forerunner 265 Running GPS Watch | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-garmin-forerunner-265/7906443746.html) |
+| $12 | New Genuine For Hisense Fire TV Voice Remote Control W DirecTv Peacock Netflix | ele | Sunnyside | [link](https://newyork.craigslist.org/que/ele/d/sunnyside-new-genuine-for-hisense-fire/7926794739.html) |
+| $300 | New in the original box Apple iPad 11th Gen (A16) - 11" WiFi Blue | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-new-in-the-original-box-apple/7941930408.html) |
+| $120 | NEW Samsung Galaxy Buds Pro Wireless Earbud Headphones Phantom Black | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-samsung-galaxy-buds/7914769283.html) |
+| $90 | NEW Samsung Galaxy Buds2 True Wireless Earbud Headphones Phantom Black | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-new-samsung-galaxy-buds2/7914768491.html) |
+| $110 | NEW WD  Easystore 4TB External USB 3.0 Portable Hard Drive - Black | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-new-wd-easystore-4tb-external/7943403794.html) |
+| $85 | NHT VS-1.4 Center Channel Speaker | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-nht-vs-14-center-channel/7924449223.html) |
+| $64 | NILES MULTIPURPOSE MP5 IN-WALL  CEILING SPEAKERS | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-niles-multipurpose-mp5-in/7942753902.html) |
+| $30 | Niles Svl-2 Speaker Selection Volume Control System | ele | Sunnyside | [link](https://newyork.craigslist.org/que/ele/d/sunnyside-niles-svl-speaker-selection/7921094175.html) |
+| $15 | Nintendo GameCube GameStop Controller Wired Black | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-nintendo-gamecube-gamestop/7942751157.html) |
+| $199 | Nintendo Switch 2 Racer's Bundle + Accessories | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/ozone-park-nintendo-switch-racers/7944003058.html) |
+| $18 | Nintendo Wii/Wii U Super Mario Wired Fight Pad Controller | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-nintendo-wii-wii-super-mario/7942751041.html) |
+| $69 | Noctua NH-U12A, Premium CPU Cooler with High-Performance Quiet NF-A12x25 PWM Fan | ele | Kew Gardens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-noctua-nh-u12a-premium-cpu/7929584999.html) |
+| $99 | Omnimount Dcm DUAL Ceiling Mount 37" - 63" Flat Panels Tvs - Up to 400 | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/hollis-omnimount-dcm-dual-ceiling-mount/7914216002.html) |
+| $29 | ONKYO CENTER CHANNEL SPEAKER SKC-100 | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-onkyo-center-channel-speaker/7942755744.html) |
+| $29 | ONKYO CENTER CHANNEL SPEAKER SKC-100 Black Wood 100 WATT, 8 Ohm, | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-onkyo-center-channel-speaker/7942751502.html) |
+| $60 | Onkyo TX-SR304 5.1 Channel AV Receiver | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-onkyo-tx-sr-channel-av-receiver/7931321257.html) |
+| $70 | OTTERBOX DEFENDER CASE FOR IPAD PRO 12.9" | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/medford-otterbox-defender-case-for-ipad/7924512874.html) |
+| $0 | PA SYSTEM PORTABLE MODEL# SG-15000 | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-pa-system-portable/7934452299.html) |
+| $85 | PAC-MAN Countertop ARCADE | ele | Massapequa | [link](https://newyork.craigslist.org/que/ele/d/massapequa-park-pac-man-countertop/7942750363.html) |
+| $75 | PANASONIC 32" FLAT SCREEN TV & REMOTE CONTROL | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-32-flat/7913705505.html) |
+| $10 | Panasonic DVD-RV32 DVD/CD Player | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-panasonic-dvd-rv32-dvd-cd/7938349497.html) |
+| $70 | Panasonic sound system | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-panasonic-sound-system/7930386452.html) |
+| $20 | PANASONIC VCR 4-HEADS (NEEDS REPAIR) | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-vcr-heads/7925374147.html) |
+| $50 | PANASONIC VINTAGE PORTABLE RADIO MODEL RF-728 | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-panasonic-vintage/7934218724.html) |
+| $90 | PC Case - Hyte Y40 ATX Mid Tower Case - White - $100 > $90 | ele | Ridgewood | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-pc-case-hyte-y40-atx-mid/7941579213.html) |
+| $25 | Philips DVP5982 1080p Upscaling CD/DVD Player (USB Direct Playback) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-philips-dvp-upscaling-cd-dvd/7939740796.html) |
+| $20 | Philips DVP642 DVD/CD Player – Tested & Working | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-philips-dvp642-dvd-cd-player/7923004391.html) |
+| $99 | PIONEER DIGITAL AUDIO/VIDEO STEREO 100 WATTS RECIVER  VSX-516 | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-pioneer-digital-audio/7935307995.html) |
+| $50 | Pioneer Elite PRO-R05U Media Receiver - for PRO-1120HD / PRO-920HD | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-pioneer-elite-pro-r05u-media/7932491854.html) |
+| $125 | Pioneer GM-D8601 Mono subwoofer amplifier — 800 watts RMS at 1 ohm | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-pioneer-gm-d8601-mono/7924896289.html) |
+| $99 | Pioneer Kuro PDP-6010FD 60" 1080p HD Plasma Television | ele | Bayside | [link](https://newyork.craigslist.org/que/ele/d/bayside-pioneer-kuro-pdp-6010fd-hd/7942390885.html) |
+| $45 | Pioneer PD-M502 6 Disc CD Changer No Remote Untested Read | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-pioneer-pd-m502-disc-cd/7937388022.html) |
+| $99 | Pioneer PDP-503CMX 50" Commercial Plasma Display FOR REPAIR | ele | READ DESCRIPTION, NEEDS REPAIR | [link](https://newyork.craigslist.org/que/ele/d/jamaica-pioneer-pdp-503cmx-50/7914793207.html) |
+| $49 | PLATINUM 3MP WIFI VIDEO DOORBELL \| DB3W \| WHITE \| NEW OPEN BOX | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-platinum-3mp-wifi-video/7914866236.html) |
+| $40 | Polk Audio M3 Speakers Series II M3II Bookshelf | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-polk-audio-m3-speakers/7926797535.html) |
+| $95 | Polk Audio Monitor 30 bookshelf speakers | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-polk-audio-monitor-30/7942489391.html) |
+| $150 | Polk Audio RM705 5.1 Powered Subwoofer with Satellie Speaker | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-polk-audio-rm-powered/7941986350.html) |
+| $250 | Pre-owned Iphone XS Max 64 GB Unlocked | ele | Rego Park, Queens | [link](https://newyork.craigslist.org/que/ele/d/rego-park-pre-owned-iphone-xs-max-64-gb/7916161607.html) |
+| $130 | Pre-owned SHURE VP83F LensHopper Shotgun Microphone with Audio | ele | Rego Park, Queens | [link](https://newyork.craigslist.org/que/ele/d/rego-park-pre-owned-shure-vp83f/7916161133.html) |
+| $275 | PSB Stratus C6 Audiophile Center Speaker - Rare Piano Black Finish | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-psb-stratus-c6-audiophile/7936038151.html) |
+| $250 | Quad 11L Audiophile Bookshelf Speakers - Piano Black | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-quad-11l-audiophile-bookshelf/7935819963.html) |
+| $19 | Quartet Glass Dry Erase White Board Desktop Computer Pad for Notetakin | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-quartet-glass-dry/7911630333.html) |
+| $29 | RAYOVAC 9v ultra pro alkaline pack of 30 | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-rayovac-9v-ultra-pro/7913099889.html) |
+| $55 | RCA RT2600 650W 5.1CH SILVER HOME THEATER AUDIO VIDEO RECEIVER SYSTEM | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-rca-rt-51ch-silver-home/7942759904.html) |
+| $1,199 | REALWEAR HANDS FREE INTRINSICALLY SAFE WEARABLE TABLET  HMT-1Z1 T1100S | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-realwear-hands-free/7911893555.html) |
+| $130 | Rejuvenation Fenton GFCI Switch Plates – Solid Brass – Set of 4 – New | ele | middle village | [link](https://newyork.craigslist.org/que/ele/d/middle-village-rejuvenation-fenton-gfci/7939613904.html) |
+| $175 | Rotel RTC-950AX Preamplifier (Clean and Detailed Sound) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-rotel-rtc-950ax-preamplifier/7932207222.html) |
+| $50 | SAMSUNG STEREO SYSTEM WITH SPEAKERS | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-samsung-stereo-system/7912957443.html) |
+| $60 | SAMSUNG VCR-DVD-COMBO (DVD NOT WORKING!) | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-samsung-vcr-dvd-combo/7933803635.html) |
+| $20 | Sanus Sonos Era 300 wall mounts | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-sanus-sonos-era-300/7930811855.html) |
+| $29 | SARAMONIC VMIC MINI COMPACT CONDENSER VIDEO MICROPHONE  VMIC MINI NEW | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-saramonic-vmic-mini/7914216068.html) |
+| $47 | SCHOOLHOUSE ELECTRIC Light Chrome Wall Sconce 7in White Muslin Glass | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-light/7942760474.html) |
+| $36 | SCHOOLHOUSE ELECTRIC Light Chrome Wall Sconce White Muslin Glass | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-light/7942761171.html) |
+| $115 | SCHOOLHOUSE ELECTRIC Sconce Bronze White Opal Glass Light 7 Inch Width | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-schoolhouse-electric-sconce/7942760739.html) |
+| $100 | Signal Generator | ele | Flushing | [link](https://newyork.craigslist.org/que/ele/d/flushing-signal-generator/7944009040.html) |
+| $75 | Smartwatch.. Samsung Galaxy watch 4 | ele | Fresh Meadows | [link](https://newyork.craigslist.org/que/ele/d/fresh-meadows-smartwatch-samsung-galaxy/7915538099.html) |
+| $150 | Sonance PS-P83T-BL 8" Pendant Speaker High-Performance Commercial | ele | each | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-sonance-ps-p83t-bl-pendant/7910883555.html) |
+| $149 | Sonance PS-P83WT-BL Professional Series 8 Pendant Woofer Speaker | ele | NO GRILLE | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-sonance-ps-p83wt-bl/7928907794.html) |
+| $20 | Sonance Sonamp 260 Amplifier (One Channel Not Working) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sonance-sonamp-260-amplifier/7927595095.html) |
+| $250 | Sonos Playbase - Premium TV Sound Base (Excellent Condition) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sonos-playbase-premium-tv/7940828479.html) |
+| $50 | SONY 10" Woofers 1-544-191-11 | ele | Sunnyside | [link](https://newyork.craigslist.org/que/ele/d/sunnyside-sony-10-woofers/7931785790.html) |
+| $75 | SONY 3-WAY SPEAKERS | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-way-speakers/7919028415.html) |
+| $80 | Sony 55 inch Tv with Rocu | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-sony-55-inch-tv-with-rocu/7930384439.html) |
+| $349 | SONY 6.95" DIGITAL BLUETOOTH MULTIMEDIA RECEIVER XAV-AX4000 | ele | Carplay and Android Auto | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-sony-695-digital-bluetooth/7929797161.html) |
+| $875 | Sony A7ii | ele | Rego Park | [link](https://newyork.craigslist.org/que/ele/d/rego-park-sony-a7ii/7944099092.html) |
+| $75 | SONY AUDIO/VIDEO 5.1 STEREO RECEIVER 100 WATTS PER CH MODEL# STR-K740P | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-audio-video-51/7923223221.html) |
+| $60 | Sony CDP-CE375 5-DISC CD Changer w/Remote May Be New | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-sony-cdp-ce375-disc-cd/7926796251.html) |
+| $95 | Sony CDP-CE375 5-Disc CD Changer – Tested & Working | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sony-cdp-ce375-disc-cd-changer/7924471605.html) |
+| $20 | Sony DVP-NS50P DVD/CD Player – Tested & Working | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sony-dvp-ns50p-dvd-cd-player/7923006254.html) |
+| $230 | Sony FE 35mm | ele | corona | [link](https://newyork.craigslist.org/que/ele/d/corona-sony-fe-35mm/7937899613.html) |
+| $65 | SONY HOME THEATER | ele | Massapequa | [link](https://newyork.craigslist.org/que/ele/d/massapequa-park-sony-home-theater/7942750061.html) |
+| $39 | Sony LTS - CMD718W 36 IR LED Color Dome Camera | ele | each | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-sony-lts-cmd718w-36-ir-led/7914833051.html) |
+| $110 | Sony PlayStation 3 Video Game System Fat Console only | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/maspeth-sony-playstation-video-game/7931530747.html) |
+| $50 | SONY PORTABLE AM-FM- C/D PLAYER | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-sony-portable-am-fm-d/7918790725.html) |
+| $59 | Sony Portable Bluetooth Speaker – Extra Bass, Waterproof, Party Ready | ele | Jackson Heights | [link](https://newyork.craigslist.org/que/ele/d/jackson-heights-sony-portable-bluetooth/7919877226.html) |
+| $75 | Sony portable dvd w/Bose headset won’t seperate sold together | ele | Kew Gardens Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7943825138.html) |
+| $0 | Sony portable dvd w/Bose headset won’t seperate sold together | ele | Kew Gardens Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7940572576.html) |
+| $0 | Sony portable dvd w/Bose headset won’t seperate sold together | ele | Kew Gardens Queens | [link](https://newyork.craigslist.org/que/ele/d/kew-gardens-sony-portable-dvd-bose/7925100494.html) |
+| $1,200 | Sony SCD-777ES | ele | Rego Park | [link](https://newyork.craigslist.org/que/ele/d/rego-park-sony-scd-777es/7944098680.html) |
+| $209 | Sony STJ75 FM Tuner | ele | Forest Hills | [link](https://newyork.craigslist.org/que/ele/d/forest-hills-sony-stj75-fm-tuner/7944118662.html) |
+| $115 | Sony TA-AV531 Integrated Amplifier (Phono Support; 100 WPC) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sony-ta-av531-integrated/7942924856.html) |
+| $550 | Sony TA-E77ESD Preamp (Flagship ES Preamplifier; Made in Japan) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-sony-ta-e77esd-preamp-flagship/7918293592.html) |
+| $25 | Sony, Panasonic and Samsung TVs cheap must sell ASAP | ele | Ozone Park | [link](https://newyork.craigslist.org/que/ele/d/ozone-park-sony-panasonic-and-samsung/7915589927.html) |
+| $70 | Sound Bar | ele | Saint Albans | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-sound-bar/7917201165.html) |
+| $599 | Spectra Series LED PAR 100W RGBA - White (120v-220v) SPOT/STAGE LIGHT/ | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/hollis-spectra-series-led-par-100w-rgba/7914798594.html) |
+| $12 | Star Trek Scene It The DVD Game Deluxe Edition New with real Star Trek | ele | RIDGEWOOD 11385 | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-star-trek-scene-it-the-dvd/7942759866.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7918566226.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7923439373.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-t0shiba-24-led-tv-and/7911948138.html) |
+| $295 | Tandberg TR-2025 Stereo Receiver (Made in Norway; Everything Works) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-tandberg-tr-2025-stereo/7934852281.html) |
+| $99 | TechLogix Networx TL-TP70-HDC HDMI & Cable Extender set | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/saint-albans-techlogix-networx-tl-tp70/7914835210.html) |
+| $40 | Teeran Android Auto Wireless Adapter for OEM Factory Wired Android Aut | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-teeran-android-auto/7917108719.html) |
+| $30 | Texas Instruments BA II Plus Financial Calculator, Black Medium | ele | Long Island City | [link](https://newyork.craigslist.org/que/ele/d/long-island-city-texas-instruments-ba/7917101673.html) |
+| $0 | Tools electric or battery and more. | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/maspeth-tools-electric-or-battery-and/7938781595.html) |
+| $44 | TOSHIBA 24" 24L4200U Full HD | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-toshiba-24-24l4200u-full-hd/7942518187.html) |
+| $45 | TOSHIBA 24" 24L4200U HDTV | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-toshiba-24-24l4200u-hdtv/7942754594.html) |
+| $90 | Toshiba D-R400 DVD Recorder (VCR/Camcorder to DVD; w/ Remote) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-toshiba-r400-dvd-recorder-vcr/7939740079.html) |
+| $40 | TOSHIBA HQ VCR WORKS ONLY ON 2- HOUR SPEED | ele | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/ele/d/oakland-gardens-toshiba-hq-vcr-works/7937501571.html) |
+| $90 | Towel Warmer - NEW IN BOX | ele | Ridgewood | [link](https://newyork.craigslist.org/que/ele/d/brooklyn-towel-warmer-new-in-box/7944065898.html) |
+| $50 | TP-Link AC1750 Wireless Dual Band Gigabit Router | ele | SunnySide | [link](https://newyork.craigslist.org/que/ele/d/sunnyside-tp-link-ac1750-wireless-dual/7925133697.html) |
+| $20 | TV bracket loctek  14"-40"articulating flat panel TV bracket | ele | Astoria | [link](https://newyork.craigslist.org/que/ele/d/astoria-tv-bracket-loctek-14/7913452460.html) |
+| $80 | Tv stand | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-tv-stand/7930385719.html) |
+| $75 | Vanguard Dynamics  6 Zone Speaker Selector | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-vanguard-dynamics-zone-speaker/7914219482.html) |
+| $59 | Vanguard Dynamics FLC-600 6 1/2" 2-Way Flangeless In Ceiling Speaker | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/jamaica-vanguard-dynamics-flc-way/7914526126.html) |
+| $10 | Velodyne vLeve On-Ear Headphones - New Open Box + Free Skins | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-velodyne-vleve-on-ear/7915652891.html) |
+| $20 | ViewSonic VP930b 19" LCD Swivel Computer Monitor | ele | Astoria | [link](https://newyork.craigslist.org/que/ele/d/astoria-viewsonic-vp930b-19-lcd-swivel/7920446029.html) |
+| $200 | Vintage Adcom GTP-500 II Preamp-Tuner with Remote Works Great | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-vintage-adcom-gtp-500-ii/7930213146.html) |
+| $14 | Vintage Argus Supplementary Wide Angle & Telephoto Lens with Case | ele | Ridgewood 11385 Queens | [link](https://newyork.craigslist.org/que/ele/d/ridgewood-vintage-argus-supplementary/7942751471.html) |
+| $90 | Vintage KEF Coda 70  Bookshelf Speakers | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/flushing-vintage-kef-coda-70-bookshelf/7933318950.html) |
+| $40 | Vintage Koss M65 Plus Dina-Mite Bookshelf Speakers | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-vintage-koss-m65-plus-dina/7922618238.html) |
+| $90 | Vintage NHT Super Zero Bookshelf Speakers A450 Very Nice! | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-vintage-nht-super-zero/7936744912.html) |
+| $25 | Vintage Pioneer T-3300 Cassette Deck Needs Repair | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-vintage-pioneer-3300/7926807916.html) |
+| $125 | Vintage Technics SA-EX500 NOS Surround Sound Stereo Receiver | ele | queens | [link](https://newyork.craigslist.org/que/ele/d/floral-park-vintage-technics-sa-ex500/7936745412.html) |
+| $150 | Vintage Wharfedale Speakers | ele | Elmhurst | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-vintage-wharfedale-speakers/7944139403.html) |
+| $25 | Vizio 22 inch 1080p TV with power cable and programmable remote | ele | Rego Park | [link](https://newyork.craigslist.org/que/ele/d/rego-park-vizio-22-inch-1080p-tv-with/7942493402.html) |
+| $19 | Westek 3 pack adjustable white battery operated LED Light | ele | Maspeth | [link](https://newyork.craigslist.org/que/ele/d/middle-village-westek-pack-adjustable/7913099141.html) |
+| $225 | Yamaha AVENTAGE RX-A780 7.2 Channel Receiver (4K Video;Burr-Brown DAC) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-aventage-rx-channel/7942488401.html) |
+| $15 | Yamaha CDC-597 CD Changer (for parts or repair) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-cdc-597-cd-changer-for/7928365340.html) |
+| $20 | Yamaha Center Speaker | ele | Whitestone  NY | [link](https://newyork.craigslist.org/que/ele/d/bayside-yamaha-center-speaker/7943657512.html) |
+| $55 | Yamaha NS-C210 Center Channel Speaker | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-yamaha-ns-c210-center-channel/7932206165.html) |
+| $95 | YamahaNatural Sound CD Player (Made in Japan; Audiophile Grade) | ele | Queens | [link](https://newyork.craigslist.org/que/ele/d/elmhurst-yamahanatural-sound-cd-player/7928698281.html) |
+| $70 | █ JDM Made in Japan Xenon light HID Kit | ele | 18 mths warranty queens | [link](https://newyork.craigslist.org/que/ele/d/queens-village-jdm-made-in-japan-xenon/7917172985.html) |
+| $2,969 | Custom Driveway Gates (USA Made) – Easy DIY Install + FREE Delivery | fod | queens | [link](https://newyork.craigslist.org/que/fod/d/floral-park-custom-driveway-gates-usa/7938442512.html) |
+| $3,000 | 10 Vintage Retractable and 1 Fixed Non-Retractable Aluminum Awnings | for | queens | [link](https://newyork.craigslist.org/que/for/d/astoria-10-vintage-retractable-and/7943898450.html) |
+| $255 | 169 Various size Art Mattes beveled precut (single/dual color) | for | Forest Hills | [link](https://newyork.craigslist.org/que/for/d/forest-hills-169-various-size-art/7910247990.html) |
+| $65 | 24" VIZIO LED SMART TV & REMOTE CONTROL | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-24-vizio-led-smart-tv/7937418524.html) |
+| $75 | 32" APEX LCD TV & REMOTE CONTROL | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-32-apex-lcd-tv-remote/7918789377.html) |
+| $85 | 32" SAMSUNG LCD FLAT SCREEN TV & REMOTE CONTROL WORKS GREAT L | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-32-samsung-lcd-flat/7924506303.html) |
+| $35 | Apollo 2-Pack 180 Degree Frameless Shower Door Hinges Chrome for 8-12mm Glass | for | Flushing | [link](https://newyork.craigslist.org/que/for/d/flushing-apollo-pack-180-degree/7942123393.html) |
+| $15 | Canon MicroPrinter 90 | for | Flatbush | [link](https://newyork.craigslist.org/que/for/d/brooklyn-canon-microprinter-90/7924269716.html) |
+| $75 | CRL Vienna V1E045CH 135 Degree Glass-to-Glass Hinge Polished Chrome New | for | Flushing | [link](https://newyork.craigslist.org/que/for/d/flushing-crl-vienna-v1e045ch-135-degree/7942122379.html) |
+| $15 | Dartboard 18 inch | for | Bayside | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-dartboard-18-inch/7938495033.html) |
+| $13 | Defiant Collection Satin Nickel Closet Door Handle | for | Forest Hills | [link](https://newyork.craigslist.org/que/for/d/forest-hills-defiant-collection-satin/7920609408.html) |
+| $0 | everything must go  offer best price  By appointment; phone # | for | queens | [link](https://newyork.craigslist.org/que/for/d/jackson-heights-everything-must-go/7930640346.html) |
+| $10 | Exterior Light Fixtures | for | Whitestone | [link](https://newyork.craigslist.org/que/for/d/whitestone-exterior-light-fixtures/7928586117.html) |
+| $2 | garage sale things | for | forest hills | [link](https://newyork.craigslist.org/que/for/d/forest-hills-garage-sale-things/7914121583.html) |
+| $2 | gifts | for | forest hills | [link](https://newyork.craigslist.org/que/for/d/rego-park-gifts/7914122353.html) |
+| $0 | Grainfather and Homebrewing equipment | for | Sunnyside Queens | [link](https://newyork.craigslist.org/que/for/d/sunnyside-grainfather-and-homebrewing/7943926489.html) |
+| $50 | IKEA Stave Mirror Rectangular Black Brown | for | Ridgewood | [link](https://newyork.craigslist.org/que/for/d/ridgewood-ikea-stave-mirror-rectangular/7914517096.html) |
+| $30 | ITM Tools 750TE210 1" X 18" SDS-plus X-cutter Rotary Hammer Bit | for | queens | [link](https://newyork.craigslist.org/que/for/d/forest-hills-itm-tools-750te210-x-18/7929261788.html) |
+| $145 | Jabra Engage 75 Wireless Headset (OBO) | for | Forest Hills Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-jabra-engage-75-wireless/7917661091.html) |
+| $20 | Medeco lock cylinder, keys, mounting hardware. Brand new | for | Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-medeco-lock-cylinder-keys/7930726546.html) |
+| $0 | NEW Kate Spade Staci Lily Blooms Bag | for | Elmhurst | [link](https://newyork.craigslist.org/que/for/d/elmhurst-new-kate-spade-staci-lily/7937463359.html) |
+| $85 | Pre-owned Chromacast Acoustic Guitar Hard Case | for | Rego Park, Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-chromacast-acoustic/7933460229.html) |
+| $225 | Pre-owned Epiphone Dreadnought FT-350 Guitar with Case + Accessories | for | Rego Park, Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-epiphone/7907984077.html) |
+| $150 | Pre-owned Onkyo TX-8020 Receiver and (2) TWO Micca MB42X Speakers | for | Rego Park, Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-onkyo-tx-8020/7923318177.html) |
+| $100 | Pre-owned Sound Percussion Labs Lil 3 Piece Junior Drum Set + Hardware | for | Rego Park, Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-sound-percussion/7925755136.html) |
+| $80 | Pre-owned TP-Link G1500 Whole Home Mesh WiFi 6 System | for | Rego Park, Queens | [link](https://newyork.craigslist.org/que/for/d/rego-park-pre-owned-tp-link-g1500-whole/7942510542.html) |
+| $15 | ProMaster Camera Bag | for | Whitestone | [link](https://newyork.craigslist.org/que/for/d/whitestone-promaster-camera-bag/7921339774.html) |
+| $45 | SHARP 22" LCD FLAT SCREEN TV | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-sharp-22-lcd-flat/7919881662.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7923647086.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7924507748.html) |
+| $75 | T0SHIBA 24" LED TV And REMOTE  CONTROL! | for | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/for/d/oakland-gardens-t0shiba-24-led-tv-and/7919432236.html) |
+| $25 | Three 2” White Vinyl Blinds | for | Astoria | [link](https://newyork.craigslist.org/que/for/d/astoria-three-white-vinyl-blinds/7917666720.html) |
+| $79 | Vintage Floral Glass Touch Table Lamp | for | Rego Park | [link](https://newyork.craigslist.org/que/for/d/rego-park-vintage-floral-glass-touch/7943185049.html) |
+| $180 | WANDRD PRVKE Backpack Rhone Burgundy 15L BRAND NEW | for | Long Island City | [link](https://newyork.craigslist.org/que/for/d/long-island-city-wandrd-prvke-backpack/7934166729.html) |
+| $40 | Zapbox 4 \| Next-gen iPhone VR Headset - TWO NEW SETS | for | Long Island City | [link](https://newyork.craigslist.org/que/for/d/long-island-city-zapbox-next-gen-iphone/7928800554.html) |
+| $6,900 | ★ 7th Avenue / Restoration Hardware Cloud Couch Modular Sectional Sofa | fud | queens | [link](https://newyork.craigslist.org/que/fud/d/new-york-7th-avenue-restoration/7943603588.html) |
+| $20 | 2 Computer Chairs | fuo | Greenpoint | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-computer-chairs/7926953520.html) |
+| $125 | 30" W x 12" D x 30" H Plywood Shaker Wall Kitchen Cabinet in Alpine Wh | fuo | Long Island City | [link](https://newyork.craigslist.org/que/fuo/d/long-island-city-30-x-12-x-30-plywood/7943008490.html) |
+| $75 | Art N Craft Mobile;Priced $199.99; without drop leaf only 50, $99.99 | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/jackson-heights-art-craft-mobilepriced/7930649711.html) |
+| $20 | Bedside table + Bed Computer desk | fuo | Oakland Gardens | [link](https://newyork.craigslist.org/que/fuo/d/oakland-gardens-bedside-table-bed/7941231671.html) |
+| $89 | COMPUTER / WRITING TABLE, SOLID WOOD, NEW INPLASTIC | fuo | woodside | [link](https://newyork.craigslist.org/que/fuo/d/astoria-computer-writing-table-solid/7909407862.html) |
+| $9 | Computer chair | fuo | Flushing | [link](https://newyork.craigslist.org/que/fuo/d/jamaica-computer-chair/7916900133.html) |
+| $20 | Computer Desk | fuo | Brooklyn | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-computer-desk/7944015833.html) |
+| $99 | COMPUTER TABLE, SOLID WOOD IRON FRAME, NEW | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/astoria-computer-table-solid-wood-iron/7930515405.html) |
+| $0 | Contemporary office desks computer workstations furniture | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/flushing-contemporary-office-desks/7936777099.html) |
+| $750 | Custom Architected Solid Maplewood Desk | fuo | Secaucus, New Jersey | [link](https://newyork.craigslist.org/que/fuo/d/new-york-custom-architected-solid/7930084168.html) |
+| $8 | Decorative Rod | fuo | Forest Hills, NY 11375 | [link](https://newyork.craigslist.org/que/fuo/d/forest-hills-decorative-rod/7936543181.html) |
+| $40 | Delta-brand gray crib | fuo | astoria | [link](https://newyork.craigslist.org/que/fuo/d/astoria-delta-brand-gray-crib/7940154866.html) |
+| $550 | Double Front Entry door MUST SELL | fuo | Howard Beach, NY | [link](https://newyork.craigslist.org/que/fuo/d/howard-beach-double-front-entry-door/7938939866.html) |
+| $25 | Foldable Desk | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/little-neck-foldable-desk/7906996146.html) |
+| $40 | Folding Computer Desk | fuo | Ridgewood | [link](https://newyork.craigslist.org/que/fuo/d/ridgewood-folding-computer-desk/7935276950.html) |
+| $150 | FOR SALE: Dark Espresso Wood L-Shaped Corner Computer Desk | fuo | Brooklyn, Queens, Bronx | [link](https://newyork.craigslist.org/que/fuo/d/jackson-heights-for-sale-dark-espresso/7939696389.html) |
+| $100 | Furniture Sale | fuo | Greenpoint | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-furniture-sale/7929130300.html) |
+| $100 | Furniture Sale | fuo | Williamsburg | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-furniture-sale/7929422344.html) |
+| $50 | Glass Computer Desk with Grey Trim | fuo | Queens | [link](https://newyork.craigslist.org/que/fuo/d/jamaica-glass-computer-desk-with-grey/7938201343.html) |
+| $5,600 | Harold Traditional Solid Rosewood Pedestal Dining Table Set For 12 | fuo | Arverne | [link](https://newyork.craigslist.org/que/fuo/d/arverne-harold-traditional-solid/7941069735.html) |
+| $750 | Machinto Restoration Hardware Dining Table and Chairs | fuo | Hempstead, NY | [link](https://newyork.craigslist.org/que/fuo/d/hempstead-machinto-restoration-hardware/7939078668.html) |
+| $30 | Mirror (reduced price!) | fuo | Ridgewood | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-mirror-reduced-price/7938698445.html) |
+| $1,000 | Mirror dresser and a gentleman chest | fuo | Brooklyn | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-mirror-dresser-and-gentleman/7940919509.html) |
+| $49 | Modern White Computer Desk with Storage – Great for Home Office / Gami | fuo | long island city | [link](https://newyork.craigslist.org/que/fuo/d/long-island-city-modern-white-computer/7941882329.html) |
+| $75 | Nesting Coffee Tables - Glass and gold table base | fuo | Long Island City | [link](https://newyork.craigslist.org/que/fuo/d/long-island-city-nesting-coffee-tables/7938977419.html) |
+| $1 | New dressing table, Queens bed, sofa, coffee table, computer chair | fuo | Elmhurst | [link](https://newyork.craigslist.org/que/fuo/d/elmhurst-new-dressing-table-queens-bed/7914069113.html) |
+| $0 | Office Furniture Lot | fuo | Ozone Park | [link](https://newyork.craigslist.org/que/fuo/d/ozone-park-office-furniture-lot/7942351315.html) |
+| $0 | Office storage cabinets and filing solutions furnriture | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/jamaica-office-storage-cabinets-and/7936780733.html) |
+| $20 | OXO Kitchen Tools, Cheese Cutter, Pastry Cutter, Apple Corer | fuo | New York | [link](https://newyork.craigslist.org/que/fuo/d/new-york-oxo-kitchen-tools-cheese/7932913685.html) |
+| $1,000 | Prescott dresser and mirror and Cambridge gentleman chest | fuo | Ridgewood queens | [link](https://newyork.craigslist.org/que/fuo/d/brooklyn-prescott-dresser-and-mirror/7940897196.html) |
+| $40 | Privacy screen, room divider, outdoor patio furniture | fuo | Long Island City | [link](https://newyork.craigslist.org/que/fuo/d/long-island-city-privacy-screen-room/7937259167.html) |
+| $25 | Professional Computer Desk for Sale | fuo | Howard Beach | [link](https://newyork.craigslist.org/que/fuo/d/howard-beach-professional-computer-desk/7940866605.html) |
+| $150 | Restoration Hardware Dining Chairs (Set of 8) | fuo | Fresh Meadows | [link](https://newyork.craigslist.org/que/fuo/d/fresh-meadows-restoration-hardware/7935117154.html) |
+| $2,350 | Restoration Hardware Dresser | fuo | Whitestone | [link](https://newyork.craigslist.org/que/fuo/d/whitestone-restoration-hardware-dresser/7942779934.html) |
+| $100 | Restoration Hardware(RH) furnitures | fuo | Bayside | [link](https://newyork.craigslist.org/que/fuo/d/bayside-restoration-hardwarerh/7933720760.html) |
+| $310 | Rh Emery Track Arm Fabric Dining Armchairs (Set of 4) | fuo | Fresh Meadows | [link](https://newyork.craigslist.org/que/fuo/d/fresh-meadows-rh-emery-track-arm-fabric/7935137219.html) |
+| $650 | RH Modern Industrial 5-Shelf Bookcase — Solid Wood & Steel — Nearly 8 Fee | fuo | Ridgewood | [link](https://newyork.craigslist.org/que/fuo/d/ridgewood-rh-modern-industrial-shelf/7937406663.html) |
+| $4,760 | San Francisco Solid Wood China Cabinet Dining Room Hutch with Iron Grill Door | fuo | Arverne | [link](https://newyork.craigslist.org/que/fuo/d/arverne-san-francisco-solid-wood-china/7941166655.html) |
+| $400 | Solid Wood Dresser / Buffet – Cream & Cherry Finish/$400 OBO | fuo | Elmhurst | [link](https://newyork.craigslist.org/que/fuo/d/elmhurst-solid-wood-dresser-buffet/7944028693.html) |
+| $60 | Stainless Steel Drawers | fuo | queens | [link](https://newyork.craigslist.org/que/fuo/d/sunnyside-stainless-steel-drawers/7943121411.html) |
+| $50 | Studio Closing Sale - Furniture & Kitchen Appliances | fuo | Long Island City | [link](https://newyork.craigslist.org/que/fuo/d/long-island-city-studio-closing-sale/7942926466.html) |
+| $350 | West Elm Reclaimed Wood 3-Drawer Console | fuo | Little Neck | [link](https://newyork.craigslist.org/que/fuo/d/little-neck-west-elm-reclaimed-wood/7943663865.html) |
+| $0 | Huge yard sale | gms | queens | [link](https://newyork.craigslist.org/que/gms/d/ridgewood-huge-yard-sale/7942048697.html) |
+| $0 | Moving Sale  all furniture and everything else | gms | queens ny | [link](https://newyork.craigslist.org/que/gms/d/jackson-heights-moving-sale-all/7937561494.html) |
+| $0 | Tools for sale | gms | queens | [link](https://newyork.craigslist.org/que/gms/d/brooklyn-tools-for-sale/7943579119.html) |
+| $0 | Workbench, tv stand, cb2 table | gms | Long island city | [link](https://newyork.craigslist.org/que/gms/d/long-island-city-workbench-tv-stand-cb2/7942304034.html) |
+| $103 | 🐠 29 Gallon Aquarium Stand – Steel & MDF – Built-In Power Panel – 242 | grd | queens | [link](https://newyork.craigslist.org/que/grd/d/sunnyside-29-gallon-aquarium-stand/7938650636.html) |
+| $1 | Steel Buildings - Hay Storage - Equipment Storage - Grain Storage | grq | Talk To An Expert Now! | [link](https://newyork.craigslist.org/que/grq/d/floral-park-steel-buildings-hay-storage/7938221771.html) |
+| $12 | Bolt hardware | hab | Ridgewood | [link](https://newyork.craigslist.org/que/hab/d/sunnyside-bolt-hardware/7926002619.html) |
+| $450 | RED LIGHT PANEL - LIKE NEW - HOOGA HG 1000 | hab | QUEENS | [link](https://newyork.craigslist.org/que/hab/d/long-island-city-red-light-panel-like/7936487882.html) |
+| $50 | Walking Pad | hab | queens | [link](https://newyork.craigslist.org/que/hab/d/ridgewood-walking-pad/7943117127.html) |
+| $255 | 169 Various size Art Mattes beveled precut (single/dual color) | hsh | Forest Hills | [link](https://newyork.craigslist.org/que/hsh/d/forest-hills-169-various-size-art/7910249100.html) |
+| $45 | Black Crystal Semi-Flush Chandelier – Like New, Never Installed | hsh | queens | [link](https://newyork.craigslist.org/que/hsh/d/woodhaven-black-crystal-semi-flush/7940780550.html) |
+| $250 | Bose Lifestyle 28 Series III DVD Media Center AV18 w/ Speakers & Sub P | hsh | Jamaica | [link](https://newyork.craigslist.org/que/hsh/d/jamaica-bose-lifestyle-28-series-iii/7943827942.html) |
+| $250 | Bose Lifestyle 28 Series III DVD Media Center AV18 w/ Speakers & Sub P | hsh | Jamaica | [link](https://newyork.craigslist.org/que/hsh/d/jamaica-bose-lifestyle-28-series-iii/7937837040.html) |
+| $5 | computer stool chair | hsh | Woodhaven | [link](https://newyork.craigslist.org/que/hsh/d/woodhaven-computer-stool-chair/7934229012.html) |
+| $40 | Decopolitan White Adjustable Curtain Rods 1' diameter - (2) Sets | hsh | ASTORIA | [link](https://newyork.craigslist.org/que/hsh/d/astoria-decopolitan-white-adjustable/7913618274.html) |
+| $30 | Everbilt Plast Hardware Cloth Roll Black, 1/2" Square Mesh, 3' X 15' | hsh | queens | [link](https://newyork.craigslist.org/que/hsh/d/corona-everbilt-plast-hardware-cloth/7929799250.html) |
+| $15 | Lampshade | hsh | Woodside | [link](https://newyork.craigslist.org/que/hsh/d/woodside-lampshade/7936697385.html) |
+| $15 | Lampshade black | hsh | Woodside | [link](https://newyork.craigslist.org/que/hsh/d/woodside-lampshade-black/7936697650.html) |
+| $15 | Lampshade pleated vintage cone shape | hsh | Woodside | [link](https://newyork.craigslist.org/que/hsh/d/woodside-lampshade-pleated-vintage-cone/7936697147.html) |
+| $90 | Regina Andrew wall sconce 15-1014 PN | hsh | queens | [link](https://newyork.craigslist.org/que/hsh/d/east-meadow-regina-andrew-wall-sconce-pn/7938659660.html) |
+| $40 | Sanus VML10-B1 Ultra Low Profile TV wall mount 26"-47" | hsh | BROOKLYN | [link](https://newyork.craigslist.org/que/hsh/d/brooklyn-sanus-vml10-b1-ultra-low/7917637524.html) |
+| $15 | Solid Oak Flat Panel Cabinet Doors / Frame | hsh | Ozone Park | [link](https://newyork.craigslist.org/que/hsh/d/ozone-park-solid-oak-flat-panel-cabinet/7943119521.html) |
+| $10 | Style Selections Tension Shower Curtain Rod (24”–40”) | hsh | Bayside | [link](https://newyork.craigslist.org/que/hsh/d/oakland-gardens-style-selections/7924777638.html) |
+| $149 | Tools of the Trade, Cookware set; brand new packed | hsh | Jackson Heights | [link](https://newyork.craigslist.org/que/hsh/d/jackson-heights-tools-of-the-trade/7930650043.html) |
+| $20 | Vintage American Tourister Escort Suitcase | hsh | jackson heights | [link](https://newyork.craigslist.org/que/hsh/d/jackson-heights-vintage-american/7939598824.html) |
+| $37 | Vintage Asian Wicker Basket, Purse with Asian Style Accent Closure and | hsh | Queens | [link](https://newyork.craigslist.org/que/hsh/d/college-point-vintage-asian-wicker/7922883610.html) |
+| $190 | West Elm Seamless Medicine Cabinet 16.5x27.5 Antique Brass - NEW IN BO | hsh | Forest Hills | [link](https://newyork.craigslist.org/que/hsh/d/forest-hills-west-elm-seamless-medicine/7928739402.html) |
+| $50 | Black iron sliding barndoor hardware 72” | hvo | Astoria | [link](https://newyork.craigslist.org/que/hvo/d/astoria-black-iron-sliding-barndoor/7938270308.html) |
+| $1 | Heavy Stainless Scientific Equipment – Vacuum Chambers, Pumps, Cooling | hvo | Astoria | [link](https://newyork.craigslist.org/que/hvo/d/astoria-heavy-stainless-scientific/7943369704.html) |
+| $77 | Polar Hardware 301 Hinge | hvo | queens | [link](https://newyork.craigslist.org/que/hvo/d/bayside-polar-hardware-301-hinge/7942562353.html) |
+| $50 | #EXIT DOOR HARDWARE | mat | Long Island CITY | [link](https://newyork.craigslist.org/que/mat/d/long-island-city-exit-door-hardware/7940915775.html) |
+| $60 | Garden Craft 36 in. H X 25 ft. L Galvanized Steel Hardware Cloth 1/2 i | mat | queens | [link](https://newyork.craigslist.org/que/mat/d/brooklyn-garden-craft-36-in-x-25-ft/7912228489.html) |
+| $400 | UNDERMOUNT SS DOUBLE SINK BLANCO WAVE NEW RETAIL $648 | mat | queens | [link](https://newyork.craigslist.org/que/mat/d/whitestone-undermount-ss-double-sink/7943409331.html) |
+| $65 | PS5 HDMI Port  Repair | mob | Oakland Gardens | [link](https://newyork.craigslist.org/que/mob/d/oakland-gardens-ps5-hdmi-port-repair/7942328346.html) |
+| $0 | High-Performance Sound Absorption Rockwool Bass Traps & Acoustic Panel | msd | Mention this ad for a discount! | [link](https://newyork.craigslist.org/que/msd/d/floral-park-high-performance-sound/7943687205.html) |
+| $0 | Professional Acoustic Panels & Bass Traps for Studios | msd | Mention this ad for a discount! | [link](https://newyork.craigslist.org/que/msd/d/floral-park-professional-acoustic/7942233880.html) |
+| $0 | Professional Acoustic Panels & Bass Traps for Studios | msd | Mention this ad for a discount! | [link](https://newyork.craigslist.org/que/msd/d/floral-park-professional-acoustic/7940686663.html) |
+| $0 | Superior Sound Absorption with Acoustic Panels & Bass Traps | msd | Mention this ad for a discount! | [link](https://newyork.craigslist.org/que/msd/d/floral-park-superior-sound-absorption/7937949970.html) |
+| $1,550 | Arbiter drum set - very unique and hard to find - Clear Teal Gloss | msg | Whitestone | [link](https://newyork.craigslist.org/que/msg/d/whitestone-arbiter-drum-set-very-unique/7920167249.html) |
+| $225 | ART PRO VLA II | msg | Brooklyn | [link](https://newyork.craigslist.org/que/msg/d/brooklyn-art-pro-vla-ii/7943921772.html) |
+| $100 | Drum hardware snare,cymbal,hi hat | msg | Astoria | [link](https://newyork.craigslist.org/que/msg/d/astoria-drum-hardware-snarecymbalhi-hat/7910757992.html) |
+| $1,300 | DW Design Series w/ Collector's Bell Brass Snare & Massive Extras! | msg | Forest Hills | [link](https://newyork.craigslist.org/que/msg/d/forest-hills-dw-design-series/7940161908.html) |
+| $950 | Fender Prosonic 2x10 (electronically restored)Combo Mint | msg | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/msg/d/queens-village-fender-prosonic-2x10/7915088150.html) |
+| $950 | Fender Prosonic Amp MINT Clean Bill of Health | msg | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/msg/d/queens-village-fender-prosonic-amp-mint/7914864938.html) |
+| $3,000 | Groove Synthesis 3rd Wave 24m Desktop 24-voice 4-parts | msg | Queens | [link](https://newyork.craigslist.org/que/msg/d/queens-village-groove-synthesis-3rd/7936222593.html) |
+| $3,200 | Heritage H-150 CUSTOM CORE (H-150) | msg | Jamaica | [link](https://newyork.craigslist.org/que/msg/d/queens-village-heritage-150-custom-core/7914864960.html) |
+| $3,200 | HERITGE H-150 CUSTOM CORE | msg | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/msg/d/queens-village-heritge-150-custom-core/7917674115.html) |
+| $519 | Hohner G3T headless Steinberger-style guitar | msg | Bayside | [link](https://newyork.craigslist.org/que/msg/d/bayside-hohner-g3t-headless-steinberger/7937042780.html) |
+| $175 | Ibanez Hollow Body Bass Guitar Case Hard Shell AGB Artcore | msg | Bayside | [link](https://newyork.craigslist.org/que/msg/d/bayside-ibanez-hollow-body-bass-guitar/7928023253.html) |
+| $440 | Ludwig double pedal | msg | Astoria | [link](https://newyork.craigslist.org/que/msg/d/astoria-ludwig-double-pedal/7944160788.html) |
+| $1,950 | Peavey RadialPro 1000 - Yellow - Near Mint | msg | Whitestone | [link](https://newyork.craigslist.org/que/msg/d/whitestone-peavey-radialpro-yellow-near/7941580903.html) |
+| $5,500 | Pensa Suhr Jazz Bass 1993 built by Masu Hino | msg | Great Neck, Long Island | [link](https://newyork.craigslist.org/que/msg/d/great-neck-pensa-suhr-jazz-bass-1993/7925818105.html) |
+| $335 | QSC CX204V
+4-Channel Power Amplifier, 200W Per Channel at 70V | msg | Flushing | [link](https://newyork.craigslist.org/que/msg/d/flushing-qsc-cx204v-channel-power/7929336632.html) |
+| $420 | The RODS David Rock Feinstein Harley Benton DC-Junior Melody Maker | msg | Queens | [link](https://newyork.craigslist.org/que/msg/d/whitestone-the-rods-david-rock/7928407817.html) |
+| $6,000 | WAVES LV1 SYSTEM "Turn Key System"  3 Server included ( PLUG / PLAY ) | msg | BROOKLYN | [link](https://newyork.craigslist.org/que/msg/d/brooklyn-waves-lv1-system-turn-key/7910664655.html) |
+| $0 | Camera, Grip, Electric, Lighting Equipment (continuously updated) | pho | queens | [link](https://newyork.craigslist.org/que/pho/d/astoria-camera-grip-electric-lighting/7920365653.html) |
+| $45 | Columbus nGPS GPS for Nikon Digital SLRs Cameras | pho | astoria | [link](https://newyork.craigslist.org/que/pho/d/astoria-columbus-ngps-gps-for-nikon/7926760906.html) |
+| $40 | Kingston Workflow SD Reader Micro Sd, Compact Flash readers | pho | astoria | [link](https://newyork.craigslist.org/que/pho/d/astoria-kingston-workflow-sd-reader/7926554797.html) |
+| $0 | Lot Of Video Gear (Hero Pro Gear and Others) and Assorted Electronics | pho | Flushing | [link](https://newyork.craigslist.org/que/pho/d/flushing-lot-of-video-gear-hero-pro/7944121017.html) |
+| $0 | 1999-2025 FORD SUPERDUTY PARTS- PARTS REQUEST | ptd | queens | [link](https://newyork.craigslist.org/que/ptd/d/lorain-ford-superduty-parts-parts/7940514101.html) |
+| $500 | 2018 - 2023 Buick enclave oem running Boards | pts | Astoria | [link](https://newyork.craigslist.org/que/pts/d/astoria-buick-enclave-oem-running-boards/7940389784.html) |
+| $90 | Dodge Grand Caravan Starter and Computer | pts | Ridgewood Queens | [link](https://newyork.craigslist.org/que/pts/d/ridgewood-dodge-grand-caravan-starter/7936320602.html) |
+| $1 | Mercedes Brake Rotor AMG GT - C192 R232 X254 - Front Right | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-mercedes-brake-rotor-amg-gt-c192/7926096295.html) |
+| $1 | Mercedes C192 AMG GT - Upper Grille Shell - #A1928880400 | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-mercedes-c192-amg-gt-upper/7925710832.html) |
+| $1 | Mercedes GLE/GLS AMG - Compound Brake Rotor - Front Left #A1674213600 | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-mercedes-gle-gls-amg-compound/7926095325.html) |
+| $1 | Mercedes W167 GLE63 AMG - Front Grille - Panamericana #A1678887000 | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-mercedes-w167-gle63-amg-front/7925709179.html) |
+| $1 | Mercedes W167 X167 GLE/GLS - OE Front Windshield Glass - #A1676703001 | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-mercedes-w167-x167-gle-gls-oe/7925714112.html) |
+| $1 | Porsche Macan - Brushed Silver License Plate Frame - Genuine OE | pts | Corona | [link](https://newyork.craigslist.org/que/pts/d/corona-porsche-macan-brushed-silver/7925019747.html) |
+| $100 | Rooftop Rack Cargo Carrier Basket  with Waterproof Cargo Bag | pts | South Richmond Hill | [link](https://newyork.craigslist.org/que/pts/d/south-richmond-hill-rooftop-rack-cargo/7941735851.html) |
+| $6,500 | Subrau Forester 2.0 swap | pts | South Ozone Park | [link](https://newyork.craigslist.org/que/pts/d/south-ozone-park-subrau-forester-20-swap/7914436216.html) |
+| $10 | Toyota Tacoma OEM Trailer Wiring Receptacle Cover | pts | Bayside | [link](https://newyork.craigslist.org/que/pts/d/oakland-gardens-toyota-tacoma-oem/7932736920.html) |
+| $100 | #NEW VINTAGE APPLE EXTENDED KEYBOARD | sop | LIC | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7937868625.html) |
+| $100 | #NEW VINTAGE APPLE EXTENDED KEYBOARD | sop | LIC | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7941550472.html) |
+| $30 | * NEW * Solid Gear Basix Series 600 Watt Power Supply | sop | Fresh Meadows | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-new-solid-gear-basix/7914769147.html) |
+| $15 | **Keyboards and Mouses** | sop | Whitestone | [link](https://newyork.craigslist.org/que/sop/d/whitestone-keyboards-and-mouses/7941878614.html) |
+| $50 | 116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW | sop | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-116-peace-screwdriver/7934451278.html) |
+| $80 | 16gb (8x2) ddr4 3000 ram kit | sop | Ridgewood | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-16gb-8x2-ddr-ram-kit/7944170593.html) |
+| $35 | 2 Logitech mice | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-logitech-mice/7919633322.html) |
+| $30 | 2009 mac pro single CPU tray | sop | Elmhurst | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-2009-mac-pro-single-cpu-tray/7917431884.html) |
+| $20 | 2010 macbook box with manual and install DVd | sop | Elmhurst | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-2010-macbook-box-with-manual/7913949091.html) |
+| $25 | 24 inch display, HP brand 1920 by 1200 resolution, DP, DVI | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-24-inch-display-hp-brand-1920/7930234707.html) |
+| $20 | 2x ARCTIC P9 Max 92mm PWM High Static Pressure Fans – New | sop | Sunnyside, NY | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-2x-arctic-p9-max-92mm-pwm/7940733965.html) |
+| $30 | 3 OEM Apple video adapters | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-oem-apple-video-adapters/7915032942.html) |
+| $40 | 32GB RAM A-TECH | sop | Ridgewood Glendale | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-32gb-ram-tech/7930997165.html) |
+| $925 | 34"+29" DELL curved ips 2 screen setup with monitor stand + LED Lights | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-3429-dell-curved-ips/7921899094.html) |
+| $925 | 34"+29" DELL curved ips 2 screen setup with monitor stand + LED Lights | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-3429-dell-curved-ips/7917101328.html) |
+| $700 | 4-in-1 combo mobo+cpu+cooler+ram | sop | bayside | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-in-combo/7943960247.html) |
+| $200 | 43" LG 4k Monitor (LG43UD79-B) | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-43-lg-4k-monitor-lg43ud79/7917336925.html) |
+| $20 | 5 Port Ethernet Switch | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-port-ethernet-switch/7939035542.html) |
+| $20 | 902XL 2pk. Higher Yield Cartridges | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-902xl-2pk-higher-yield/7911345838.html) |
+| $0 | ACER 12" LAPTOP COMPUTER AS-IS!! MODEL V5 | sop | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-acer-12-laptop-computer/7925393385.html) |
+| $72 | Acer 21.5" HD LCD Monitor Black | sop | astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-acer-215-hd-lcd-monitor-black/7909880228.html) |
+| $25 | Acer display 23 inch G235H in perfect condition | sop | Rego Park | [link](https://newyork.craigslist.org/que/sop/d/rego-park-acer-display-23-inch-g235h-in/7935182124.html) |
+| $50 | Adobe Creative Suite 3 Web Premium Upgrade version | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-adobe-creative-suite-web/7918126861.html) |
+| $360 | APC Smart-UPS 1000VA, Tower, LCD 120V with SmartConnect Port | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-apc-smart-ups-1000va/7917100792.html) |
+| $2,500 | Apple 32" Pro Display XDR 16:9 Retina 6K HDR IPS Display (Nano-Texture Glass) wi | sop | Newyork | [link](https://newyork.craigslist.org/que/sop/d/brooklyn-apple-32-pro-display-xdr-169/7942079582.html) |
+| $20 | Apple ADC to DVI adapter. Model: A1006 | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-apple-adc-to-dvi-adapter/7942737004.html) |
+| $55 | Apple iMac 24-Inch M1" 2021 Models (A2439) OEM EMPTY BOX ONLY. | sop | Queens, Middle Village | [link](https://newyork.craigslist.org/que/sop/d/middle-village-apple-imac-24-inch/7909246184.html) |
+| $55 | Apple iMac 24-Inch M1" 2021 Models (A2439) OEM EMPTY BOX ONLY. | sop | Queens, Middle Village | [link](https://newyork.craigslist.org/que/sop/d/middle-village-apple-imac-24-inch/7916393801.html) |
+| $5 | Apple iWork '06 CD unopened | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-apple-iwork-06-cd-unopened/7919430274.html) |
+| $50 | Apple Keyboard, wireless bluetooth,  French AZERTY layout | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-apple-keyboard-wireless/7914344850.html) |
+| $60 | Apple Magic Mouse 2 - White (Renewed) | sop | Bayside | [link](https://newyork.craigslist.org/que/sop/d/bayside-apple-magic-mouse-white-renewed/7935142976.html) |
+| $30 | Apple magic mouse v2 | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/east-elmhurst-apple-magic-mouse-v2/7922982146.html) |
+| $10 | Apple MD826ZM/A Lightning Digital AV Adapter | sop | Queens, Middle Village | [link](https://newyork.craigslist.org/que/sop/d/middle-village-apple-md826zm-lightning/7925568375.html) |
+| $10 | Apple MD826ZM/A Lightning Digital AV Adapter | sop | Middle Village | [link](https://newyork.craigslist.org/que/sop/d/middle-village-apple-md826zm-lightning/7916400819.html) |
+| $25 | Apple Mini DisplayPort to VGA Adapter | sop | Whitestone | [link](https://newyork.craigslist.org/que/sop/d/whitestone-apple-mini-displayport-to/7919016624.html) |
+| $150 | ASRock Fatal1ty Gaming Z170aming K6 Motherboard | sop | QUEENS | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-asrock-fatal1ty-gaming/7938949678.html) |
+| $20 | ASUS  B360M-A mobo with IO plate | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-asus-b360m-mobo-with-io-plate/7933042062.html) |
+| $40 | ASUS 24" computer monitor | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-asus-24-computer-monitor/7911513039.html) |
+| $200 | ASUS Gaming 240hrz Monitor | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-asus-gaming-240hrz-monitor/7931409515.html) |
+| $200 | ASUS Gaming 240hrz Monitor | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-asus-gaming-240hrz-monitor/7932883996.html) |
+| $250 | Belden 2413 Cat6 Plenum Solid Copper 1000ft Ethernet Cable | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-belden-2413-cat6-plenum/7927326145.html) |
+| $18 | BenQ RC-1331 Circular Remote Control for Projector Genuine Original | sop | Sunnyside | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-benq-rc-1331-circular-remote/7910009694.html) |
+| $20 | Besign Aluminum Laptop Stand | sop | Forest Hills, Queens | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-besign-aluminum-laptop/7912966269.html) |
+| $20 | Black Laptop (business) bag | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/rego-park-black-laptop-business-bag/7940109051.html) |
+| $50 | Bluetooth keyboard and mouse | sop | New York | [link](https://newyork.craigslist.org/que/sop/d/new-york-bluetooth-keyboard-and-mouse/7943800740.html) |
+| $30 | Brand new bamboo portable podium 20 x 14 | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-brand-new-bamboo-portable/7917127626.html) |
+| $15 | Canon FX3 cartridge | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/far-rockaway-canon-fx3-cartridge/7913903274.html) |
+| $0 | Canon gpr 58 5 sets c/y/m/b 20 pcs total | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-canon-gpr-58-sets-y-b-20/7939661144.html) |
+| $0 | CDRW unit | sop | Glendale | [link](https://newyork.craigslist.org/que/sop/d/middle-village-cdrw-unit/7927227709.html) |
+| $200 | Classic Syntrex Word Processor | sop | Ridgewood | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-classic-syntrex-word-processor/7940141614.html) |
+| $5 | coax and ethernet cable | sop | woodside | [link](https://newyork.craigslist.org/que/sop/d/maspeth-coax-and-ethernet-cable/7910436393.html) |
+| $20 | Computer Power Supplies - 2 NEW in Box  $20 each or $30 for both | sop | Bayside, Queens | [link](https://newyork.craigslist.org/que/sop/d/bayside-computer-power-supplies-new-in/7929591898.html) |
+| $0 | Computer programs  etc | sop | Glendale | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-computer-programs-etc/7927226152.html) |
+| $55 | COOLER MASTER silent pro 850w For Gaming | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-cooler-master-silent-pro-850w/7934356021.html) |
+| $70 | Corsair CX650M power supply | sop | Springfield Gardens | [link](https://newyork.craigslist.org/que/sop/d/springfield-gardens-corsair-cx650m/7941490517.html) |
+| $130 | Crucial 16GB DDR5-4800 RAM — Used | sop | Sunnyside, NY | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-crucial-16gb-ddr-ram-used/7940723155.html) |
+| $75 | Crucial 2.5inch Solid State Drive 500GB | sop | East Elmhurst | [link](https://newyork.craigslist.org/que/sop/d/east-elmhurst-crucial-25inch-solid/7929078747.html) |
+| $5 | DEFCON™ Compact Serialized Combo Cable Lock | sop | Jackson Heights | [link](https://newyork.craigslist.org/que/sop/d/jackson-heights-defcon-compact/7938357533.html) |
+| $20 | Dell 45W Replacement AC Adapter for Dell | sop | Sunnyside | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-dell-45w-replacement-ac/7931783700.html) |
+| $45 | Dell Dual-Monitor Stand | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-dell-dual-monitor-stand/7941678681.html) |
+| $25 | Dell monitor E1913C in perfect condition, Power cable, VGA cable | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-dell-monitor-e1913c-in-perfect/7908057881.html) |
+| $100 | Dell optiplex aio 7420 35W W32C all in one - Cracked screen NO HD & Me | sop | Bayside | [link](https://newyork.craigslist.org/que/sop/d/bayside-dell-optiplex-aio-w32c-all-in/7942913568.html) |
+| $70 | DELL THUNDERBOLDT 4 DOCK -LIKE NEW | sop | FOREST HILLS | [link](https://newyork.craigslist.org/que/sop/d/new-york-dell-thunderboldt-dock-like-new/7941347035.html) |
+| $60 | Dell WD19 Docking station, | sop | Rego Park | [link](https://newyork.craigslist.org/que/sop/d/rego-park-dell-wd19-docking-station/7931338747.html) |
+| $50 | ECS KBN-I/5200 AMD A6-5200 Quad Core processor Mini ITX Motherboard | sop | Rego Park | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-ecs-kbn-5200-amd-quad-core/7943118623.html) |
+| $100 | Elgato - Stream Deck MK.2 Full-size Wired USB Keypad | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-elgato-stream-deck-mk2/7917103218.html) |
+| $900 | EVGA Classified Super Record 2 SR-2 Dual Xeon X5650 DDR3 G-Skill 48GB | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-evga-classified-super-record-sr/7923159007.html) |
+| $70 | Gas Spring Desk Mount for Single Monitor 13" to 34" | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-gas-spring-desk-mount/7942642410.html) |
+| $20 | gateway 17 inch monitor with VGA and power cable | sop | Rego Park | [link](https://newyork.craigslist.org/que/sop/d/rego-park-gateway-17-inch-monitor-with/7923010720.html) |
+| $0 | GENUINE LEXMARK 1361215 PHOTOCONDUCTOR | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/flushing-genuine-lexmark-photoconductor/7905819837.html) |
+| $90 | Gigabyte B760M C V3 DDR5 Motherboard - LGA1700 + Intel 12/13/14 Gen | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-gigabyte-b760m-v3-ddr5/7938562930.html) |
+| $220 | Gigabyte GeForce RTX 4060 OC GPU | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/flushing-gigabyte-geforce-rtx-4060-oc/7940682046.html) |
+| $15 | GPU cables. 6 pin female to 8 pin male. New. | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-gpu-cables-pin-female-to-pin/7934146924.html) |
+| $45 | Hawaiian 🌺 tikki Mug 🤞 | sop | Kew Gardens | [link](https://newyork.craigslist.org/que/sop/d/kew-gardens-hawaiian-tikki-mug/7940053855.html) |
+| $10 | Headset with Microphone | sop | Whitestone | [link](https://newyork.craigslist.org/que/sop/d/whitestone-headset-with-microphone/7915237016.html) |
+| $50 | HP 24mh Monitor, perfect condition | sop | Kew Gardens | [link](https://newyork.craigslist.org/que/sop/d/flushing-hp-24mh-monitor-perfect/7933056507.html) |
+| $245 | HP 952XL/952 Black High Yield and Cyan/Magenta/Yellow Standard Yleld Ink Cartrid | sop | Bayside | [link](https://newyork.craigslist.org/que/sop/d/bayside-hp-952xl-952-black-high-yield/7943735821.html) |
+| $10 | HP Compaq LA2205wg 22" DVI VGA DisplayPort LCD Monitor USB HUB +Stand & Cables | sop | Ozone Park | [link](https://newyork.craigslist.org/que/sop/d/ozone-park-hp-compaq-la2205wg-22-dvi/7932711686.html) |
+| $40 | HP Poly Savi 7300 Office Wireless Headset for sale. | sop | Jackson Heights | [link](https://newyork.craigslist.org/que/sop/d/jackson-heights-hp-poly-savi-7300/7938352676.html) |
+| $60 | HP TONER 304A - CYAN/MAGENTA/YELLOW - $60 EACH | sop | OZONE PARK | [link](https://newyork.craigslist.org/que/sop/d/ozone-park-hp-toner-304a-cyan-magenta/7908785015.html) |
+| $50 | HP USB-C Dock G5 (L64086-001) for sale. | sop | Jackson Heights | [link](https://newyork.craigslist.org/que/sop/d/jackson-heights-hp-usb-dock-g5-for-sale/7938355093.html) |
+| $20 | hp xw9400 | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/jamaica-hp-xw9400/7910470341.html) |
+| $50 | Humanscale CPU600 Under Desk Mount PC Computer Case Bracket Holder | sop | Gravesend, Brooklyn | [link](https://newyork.craigslist.org/que/sop/d/brooklyn-humanscale-cpu600-under-desk/7933703952.html) |
+| $160 | HYTE Revolt 3 ITX Case + 700W PSU + Wavlink WiFi 6 Adapter | sop | Sunnyside, NY | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-hyte-revolt-itx-case-700w-psu/7940724547.html) |
+| $40 | ID-COOLING CORSAIR COOLER, GREAT CONDITION(NO FANS) | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/saint-albans-id-cooling-corsair-cooler/7942719110.html) |
+| $25 | Ide/pata hard drive 160GB. NOT a SATA drive! | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-ide-pata-hard-drive-160gb-not/7918141993.html) |
+| $1 | iMac late 2013 parts. Logicboard 2.9GHz, power supply, more NO DISPLAY | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-imac-late-2013-parts/7917431904.html) |
+| $30 | Kensington Targus Combination Laptop Lock security cable lock | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-kensington-targus-combination/7910313350.html) |
+| $9 | Keyboard, Dell Power Adapter | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-keyboard-dell-power-adapter/7920060172.html) |
+| $110 | Kingston DDR4 RAM 32GB (2x16GB) DIMM SODIMM | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-kingston-ddr4-ram-32gb-2x16gb/7908730028.html) |
+| $160 | Kingston DDR4 RAM 32GB (2x16GB) DIMM SODIMM NEW SEALED | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-kingston-ddr4-ram-32gb-2x16gb/7908729318.html) |
+| $10 | Lenovo 42T4438 Original AC 100-240V Adapter 20V 4.5A 7.9mm OD Plug | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-lenovo-42t4438-original-ac/7936223255.html) |
+| $30 | Lian Li O11 Dynamic ATX Computer Case Tempered Glass | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-lian-li-o11-dynamic/7938315864.html) |
+| $40 | Logitech C930E 1080p HD Video Webcam | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-logitech-c930e-1080p/7917101836.html) |
+| $25 | Logitech G105 Call of Duty MW3 USB Gaming Keyboard - Pre-owned | sop | Glendale, Queens | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-logitech-g105-call-of-duty/7913114411.html) |
+| $14 | Logitech USB Wired Mouse | sop | astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-logitech-usb-wired-mouse/7909879855.html) |
+| $10 | Logitech webcam , 720p | sop | Kew Gardens | [link](https://newyork.craigslist.org/que/sop/d/kew-gardens-logitech-webcam-720p/7940483250.html) |
+| $20 | Mac G5 video card with dual DVI ports | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-mac-g5-video-card-with-dual/7917947926.html) |
+| $20 | Mac OS X Tiger 10.4 Install DVD | sop | Queens center mall | [link](https://newyork.craigslist.org/que/sop/d/jackson-heights-mac-os-tiger-104/7934147188.html) |
+| $40 | Mac Pro 2010 single CPU tray | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/flushing-mac-pro-2010-single-cpu-tray/7934146153.html) |
+| $60 | Macally 3.5" SATA Hard Drive Enclosure NEW PC MAC | sop | Woodside | [link](https://newyork.craigslist.org/que/sop/d/woodside-macally-35-sata-hard-drive/7923133127.html) |
+| $20 | Mechanical gaming keyboard | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/rego-park-mechanical-gaming-keyboard/7910493402.html) |
+| $5 | Memorex DVD-R 50 pack brand new unopned | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-memorex-dvd-50-pack-brand/7940451249.html) |
+| $15 | Memory Card SanDisk Extreme III 2.0GB | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-memory-card-sandisk-extreme/7941953675.html) |
+| $15 | Microsoft LifeCam HD3000 | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-microsoft-lifecam-hd3000/7938447950.html) |
+| $25 | Miscellaneous RAM | sop | Ridgewood Glendale | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-miscellaneous-ram/7931000077.html) |
+| $30 | Monitor VESA mount 18" to top, 10.5" x 13.5" base | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-monitor-vesa-mount-18-to/7915032867.html) |
+| $600 | Montclair waist | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-montclair-waist/7918534581.html) |
+| $80 | Mycloud NAS, 2 TB | sop | Sunnyside | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-mycloud-nas-tb/7941990477.html) |
+| $20 | Netgear DS104 4-Port Dual Speed Hub + Power Supply | sop | Sunnyside | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-netgear-ds104-port-dual-speed/7921094797.html) |
+| $70 | New Magic keyboard apple | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-new-magic-keyboard-apple/7942321266.html) |
+| $100 | NEW VINTAGE APPLE EXTENDED KEYBOARD | sop | LIC | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-new-vintage-apple/7937868399.html) |
+| $225 | Nvidia GeForce RTX 3070 FE | sop | Fresh Meadows | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-nvidia-geforce-rtx-3070-fe/7938562463.html) |
+| $20 | Nvidia GT 120 graphics card Mac Pro | sop | Queens | [link](https://newyork.craigslist.org/que/sop/d/fresh-meadows-nvidia-gt-120-graphics/7934199551.html) |
+| $3,200 | NVidia RTX 5090 FE Founders Edition NEW CLEAN | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-nvidia-rtx-5090-fe-founders/7943248484.html) |
+| $10 | OMOTON Vertical Laptop Stand Holder – Aluminum Desktop Dock | sop | Bayside | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-omoton-vertical-laptop/7932738901.html) |
+| $100 | PC Case - Hyte Y40 ATX Mid Tower Case - White | sop | Ridgewood | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-pc-case-hyte-y40-atx-mid/7939723387.html) |
+| $20 | PCIe card to connect Apple SSDs to Mac Pro 2009 - 2012 | sop | Briarwood | [link](https://newyork.craigslist.org/que/sop/d/jamaica-pcie-card-to-connect-apple-ssds/7934199714.html) |
+| $20 | PCIe card with 4  USB3 ports | sop | Elmhurst | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-pcie-card-with-usb3-ports/7934146391.html) |
+| $100 | Quad Monitor Stand for Desktop | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/east-elmhurst-quad-monitor-stand-for/7943856192.html) |
+| $40 | ROCKSPACE 1200MBPS WIFI RANGE EXTENDER | sop | QUEENS NY | [link](https://newyork.craigslist.org/que/sop/d/east-elmhurst-rockspace-1200mbps-wifi/7942450875.html) |
+| $19 | Router Wireless (Netgear) | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-router-wireless-netgear/7913651963.html) |
+| $150 | RX 5600 XT 6gb Vram | sop | Jamaica | [link](https://newyork.craigslist.org/que/sop/d/jamaica-rx-5600-xt-6gb-vram/7943139796.html) |
+| $70 | rx 580 rx580 8gb gpu | sop | Ridgewood | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-rx-580-rx580-8gb-gpu/7944149029.html) |
+| $550 | RX 7800XT | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/east-elmhurst-rx-7800xt/7939903601.html) |
+| $150 | rx6600 rx 6600 gpu | sop | Ridgewood | [link](https://newyork.craigslist.org/que/sop/d/ridgewood-rx6600-rx-6600-gpu/7944153404.html) |
+| $12 | Sabrent 2.5 SSd and sata converter to 3.5 Desktop. NEW | sop | Elmhurst | [link](https://newyork.craigslist.org/que/sop/d/elmhurst-sabrent-25-ssd-and-sata/7934145753.html) |
+| $160 | Samsung 990 2 tb ssd | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-samsung-tb-ssd/7944181018.html) |
+| $20 | Seagate Barracuda 7,200 RPM 80Gb Hard Drive | sop | Cambria Heights | [link](https://newyork.craigslist.org/que/sop/d/cambria-heights-seagate-barracuda-7200/7938957634.html) |
+| $15 | Seagate Barracuda ATA ST320414A - IDE Hard Drive - 20Gb | sop | Cambria Heights | [link](https://newyork.craigslist.org/que/sop/d/cambria-heights-seagate-barracuda-ata/7938960074.html) |
+| $60 | Sharp LL-172G-B 17" LCD Monitor | sop | Sunnyside | [link](https://newyork.craigslist.org/que/sop/d/sunnyside-sharp-ll-172g-17-lcd-monitor/7908474529.html) |
+| $100 | SSD and Hard Drives for sale | sop | astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-ssd-and-hard-drives-for-sale/7926782675.html) |
+| $10 | Svarog Aluminum Laptop Stand / Desktop Notebook Riser – Silver | sop | Bayside | [link](https://newyork.craigslist.org/que/sop/d/oakland-gardens-svarog-aluminum-laptop/7932741295.html) |
+| $5 | Targus DEFCON Security Anchor Base Plate (PA400P) - Unused | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-targus-defcon-security/7928743286.html) |
+| $250 | Tobi Eye Tracker 5 | sop | Roosevelt Island | [link](https://newyork.craigslist.org/que/sop/d/new-york-tobi-eye-tracker/7943862567.html) |
+| $15 | Toshiba Qosmio fan, brand new. | sop | Briarwood | [link](https://newyork.craigslist.org/que/sop/d/jamaica-toshiba-qosmio-fan-brand-new/7918141957.html) |
+| $15 | TP-LINK TC-7610 DOCSIS 3.0 Cable Modem | sop | Woodside | [link](https://newyork.craigslist.org/que/sop/d/woodside-tp-link-tc-7610-docsis-30/7906641784.html) |
+| $15 | USB Cables Set | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-usb-cables-set/7913653397.html) |
+| $5 | USB Hub Ethernet Adapter | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/far-rockaway-usb-hub-ethernet-adapter/7931532625.html) |
+| $19 | Waterproof Protective Case iBdry | sop | Forest Hills | [link](https://newyork.craigslist.org/que/sop/d/forest-hills-waterproof-protective-case/7918534896.html) |
+| $300 | WD 8TB Elements External HDD | sop | Flushing | [link](https://newyork.craigslist.org/que/sop/d/flushing-wd-8tb-elements-external-hdd/7943985808.html) |
+| $40 | Western Digital WD Caviar IDE Hard Drive - 250Gb | sop | Cambria Heights | [link](https://newyork.craigslist.org/que/sop/d/cambria-heights-western-digital-wd/7938961104.html) |
+| $15 | Western Digital WD200 Caviar IDE Hard Drive - 20Gb | sop | Cambria Heights | [link](https://newyork.craigslist.org/que/sop/d/cambria-heights-western-digital-wd200/7938960687.html) |
+| $25 | Wireless Keyboard and Track pad | sop | Long Island City | [link](https://newyork.craigslist.org/que/sop/d/long-island-city-wireless-keyboard-and/7917103372.html) |
+| $40 | Xcellon 7 Port Powered USB 3.0 Aluminum Hub (Black) | sop | Astoria | [link](https://newyork.craigslist.org/que/sop/d/astoria-xcellon-port-powered-usb-30/7910313415.html) |
+| $35 | ZTNY B41N1341 Replacement Battery | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/flushing-ztny-b41n1341-replacement/7936707934.html) |
+| $30 | ZTNY B41N1341 Replacement Battery | sop | queens | [link](https://newyork.craigslist.org/que/sop/d/flushing-ztny-b41n1341-replacement/7937306409.html) |
+| $800 | Burton Snowboard Bundle | spo | Flushing | [link](https://newyork.craigslist.org/que/spo/d/flushing-burton-snowboard-bundle/7908678211.html) |
+| $20 | Gerber multi tools 🧰 compact small with many tools | spo | Queens | [link](https://newyork.craigslist.org/que/spo/d/kew-gardens-gerber-multi-tools-compact/7943209049.html) |
+| $100 | Hi-Lift UTV Model UTV-364 | spo | Bayside | [link](https://newyork.craigslist.org/que/spo/d/oakland-gardens-hi-lift-utv-model-utv/7928806425.html) |
+| $500 | Peloton Bike (2020) - Ground Floor Pickup - 2Pairs Shoes, Weights, Mat | spo | Ridgewood | [link](https://newyork.craigslist.org/que/spo/d/brooklyn-peloton-bike-ground-floor/7933414815.html) |
+| $85 | Pre-owned Motu 828 Firewire Audio Interface | spo | Rego Park, Queens | [link](https://newyork.craigslist.org/que/spo/d/rego-park-pre-owned-motu-828-firewire/7940027745.html) |
+| $125 | Sunny Health & Fitness SF-B2715 Zephyr Air Bike - Full Body Fan Bike | spo | Kensington, Brooklyn, NY | [link](https://newyork.craigslist.org/que/spo/d/brooklyn-sunny-health-fitness-sf-b2715/7937940131.html) |
+| $50 | Victoria's Secret Pink Collegiate Large Backpack Green Camo New | spo | Howard Beach | [link](https://newyork.craigslist.org/que/spo/d/howard-beach-victorias-secret-pink/7906458527.html) |
+| $80 | 15 Dell Optiplex 380 and 755 desktop computer systems | sys | Jamaica | [link](https://newyork.craigslist.org/que/sys/d/jamaica-15-dell-optiplex-380-and-755/7923170182.html) |
+| $0 | 27" LENOVO ALL IN ONE COMPUTER (TOUCH SCREEN) | sys | Long Island / Queens Area | [link](https://newyork.craigslist.org/que/sys/d/garden-city-27-lenovo-all-in-one/7930037549.html) |
+| $0 | ACER 12" LAPTOP COMPUTER AS-IS!! MODEL V5 | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7928839818.html) |
+| $0 | ACER 12" LAPTOP COMPUTER AS-IS!! MODEL V5 | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7930754760.html) |
+| $0 | ACER 12" LAPTOP COMPUTER AS-IS!! MODEL V5 | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-acer-12-laptop-computer/7925393160.html) |
+| $995 | Amiga 500, 1084 monitor, 1084S, A590 plus,25 orig/200 dsk, 3 PS, more | sys | Woodside | [link](https://newyork.craigslist.org/que/sys/d/woodside-amiga-monitor-1084s-a590/7913946024.html) |
+| $600 | Apple imac all in one computer great condrion | sys | Jamaica | [link](https://newyork.craigslist.org/que/sys/d/jamaica-apple-imac-all-in-one-computer/7941321200.html) |
+| $80 | Cisco UCS C240 M3 Server 12 Core Vmware ESX Similar Dell R720 R720xd | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-cisco-ucs-c240-m3-server-12/7942619614.html) |
+| $20 | Computer | sys | queens | [link](https://newyork.craigslist.org/que/sys/d/east-elmhurst-computer/7941327918.html) |
+| $40 | Computer | sys | queens | [link](https://newyork.craigslist.org/que/sys/d/east-elmhurst-computer/7938802394.html) |
+| $20 | COMPUTER CONTROL CENTER | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-control-center/7923218958.html) |
+| $0 | COMPUTER MONITORS: 15" 17" & 19" & DELL, HP | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-monitors-dell/7918563370.html) |
+| $0 | COMPUTER MONITORS: 15" 17" & 19" & DELL, HP | sys | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/sys/d/oakland-gardens-computer-monitors-dell/7923222173.html) |
+| $10 | Computer stand \| Laptop screen heightener | sys | Richmond Hill | [link](https://newyork.craigslist.org/que/sys/d/richmond-hill-computer-stand-laptop/7944148982.html) |
+| $50 | custom computer build for business or gaming | sys | queens | [link](https://newyork.craigslist.org/que/sys/d/ridgewood-custom-computer-build-for/7939436213.html) |
+| $699 | Custom Gaming PC – Ready to Crush Any Game! 💻✨ | sys | Kew Gardens | [link](https://newyork.craigslist.org/que/sys/d/kew-gardens-custom-gaming-pc-ready-to/7919877316.html) |
+| $980 | Dell 7920 Video Editing PC Computer 48 Core 96 Threads Adobe CAD Maya | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-7920-video-editing-pc/7942447933.html) |
+| $380 | DELL Computer 8 Core 32GB RAM SSD NVIDIA Quadro | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-computer-core-32gb-ram/7941004747.html) |
+| $540 | Dell Gaming PC Computer 10 Core i9 32GB RAM GTX Titan X 12GB 512NVMe | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-gaming-pc-computer-10/7937827335.html) |
+| $340 | Dell Gaming PC i7 NVIDIA GTX 1650 16GB RAM 512GB NVMe Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-gaming-pc-i7-nvidia-gtx/7930304368.html) |
+| $135 | Dell Inspiron One 2320 AIO PC Windows 10 Computer | sys | Forest Hills | [link](https://newyork.craigslist.org/que/sys/d/forest-hills-dell-inspiron-one-2320-aio/7940430591.html) |
+| $120 | Dell Latitude E6410 14" Laptop,Intel i5,500GB HDD,Windows 11,MS Office | sys | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-dell-latitude/7918444824.html) |
+| $280 | DELL Office PC Computer Intel Xeon 5820 16GB NVIDIA P620 Windows 11 | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-office-pc-computer/7942619017.html) |
+| $300 | DELL PC Computer Editing 5820 6 Core 16GB Adobe CAD | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-pc-computer-editing/7942619297.html) |
+| $180 | Dell PC Computer i7-7700k 32GB Memory SSD | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-pc-computer-i7-7700k/7941004471.html) |
+| $200 | Dell Precision Tower 7810 24 Cores PC Computer Home Lab VMware ProxMox | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-precision-tower-cores/7915382669.html) |
+| $200 | Dell Precision Workstation 5820 Xeon W2125 NVIDIA Quadro PC Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-precision-workstation/7910026728.html) |
+| $180 | Dell T3620 Gaming PC Computer i7 16GB RAM SSD | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-dell-t3620-gaming-pc/7942618762.html) |
+| $150 | Fractal Design Define R5 Mid-Tower Case and 850w PSU | sys | Rego Park | [link](https://newyork.craigslist.org/que/sys/d/rego-park-fractal-design-define-r5-mid/7930345500.html) |
+| $120 | Gaming computer, Intel i5-4690K, GTX 560 Ti,500GB SSD,Win 11+MS Office | sys | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-gaming-computer-intel/7918445010.html) |
+| $580 | Gaming Laptop Sager NVIDIA RTX 3060 i7 1270H 32GB RAM 1TB Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-gaming-laptop-sager-nvidia/7941006648.html) |
+| $20 | GENUINE LOGITECH *PRO* USB RECEIVER MOUSE Dongle Adapter FAST SHIP | sys | New York | [link](https://newyork.craigslist.org/que/sys/d/new-york-genuine-logitech-pro-usb/7941306714.html) |
+| $99 | HP 280 G1 Desktop Computer, Intel i5, Windows 11,MS Office | sys | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-hp-280-g1-desktop/7915446572.html) |
+| $20 | HP Computer Monitor - $20 | sys | Woodside, Queens, NY 11377 | [link](https://newyork.craigslist.org/que/sys/d/woodside-hp-computer-monitor-20/7939958001.html) |
+| $100 | HP desktop all-in-one with 1TB of storage | sys | Astoria | [link](https://newyork.craigslist.org/que/sys/d/astoria-hp-desktop-all-in-one-with-1tb/7927328610.html) |
+| $300 | HP Gaming Z4 G4 Computer 6 Core 3.7GHz SSD NVIDIA GTX 970 1TB | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-hp-gaming-z4-g4-computer/7937827425.html) |
+| $140 | HP Touchsmart 310 PC - Touchscreen All-in-ONE computer | sys | queens | [link](https://newyork.craigslist.org/que/sys/d/maspeth-hp-touchsmart-310-pc/7942584293.html) |
+| $290 | HP Z2 G4 Computer i5 16GB 1TB NVMe AMD FirePro Win 11 Pro | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-hp-z2-g4-computer-i5-16gb/7941004270.html) |
+| $30 | HP Z240 Tower Workstation Desktop Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-hp-z240-tower-workstation/7937827151.html) |
+| $280 | HP Z4 G4 PC Computer Xeon CPU w-2125 4.00Ghz NVIDIA K420 500GB SSD | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-hp-z4-g4-pc-computer-xeon/7942619105.html) |
+| $280 | HP Z640 18 Core Computer Tower Workstation 16GB 1TB AMD Radeon Pro WX | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-hp-core-computer-tower/7927339532.html) |
+| $280 | Lenovo Computer Professional Workstation Intel Xeon | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-computer-professional/7941004220.html) |
+| $280 | Lenovo Computer Proffesional Workstation Intel Xeon w2125 16GB RAM 512 | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-computer-proffesional/7942619237.html) |
+| $180 | Lenovo P320 Desktop PC Computer I7-7700K 16GB | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-p320-desktop-pc/7941004910.html) |
+| $69 | Lenovo ThinkCentre Desktop Computer– Compact Powerhouse! 💻 | sys | Jackson Heights | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-lenovo-thinkcentre/7917072841.html) |
+| $90 | Lenovo ThinkCentre M900 Tiny Computer, Intel i5-6500T,8GB RAM, WiFi | sys | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-lenovo-thinkcentre-m900/7921052224.html) |
+| $280 | Lenovo ThinkStation P330 i5-9600KF 32GB 4TB Workstation PC Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-lenovo-thinkstation-p330-i5/7937880403.html) |
+| $250 | LIKE NEW Apple iMac 21.5", 500 GB HD, i5, 2.5 GHz, 4 GB (Mid 2011) | sys | Richmond Hill, Queens | [link](https://newyork.craigslist.org/que/sys/d/jamaica-like-new-apple-imac-gb-hd-i5-25/7916080928.html) |
+| $490 | Like New HP All-in-One 24-cb1257c Touchscreen Computer | sys | Queens | [link](https://newyork.craigslist.org/que/sys/d/forest-hills-like-new-hp-all-in-one-24/7938753776.html) |
+| $450 | MSI GT62VR Dominator PRO Extreme Gaming Laptop:i7-6700/GeForce GTX1070 | sys | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/sys/d/jackson-heights-msi-gt62vr-dominator/7921052431.html) |
+| $0 | New HP COMPUTER 24 INCH (Touch Screen )All In One Model -K0024 | sys | Long Island / Queens Area | [link](https://newyork.craigslist.org/que/sys/d/west-hempstead-new-hp-computer-24-inch/7930037764.html) |
+| $250 | OWC / Akitio Thunder3 Dock Pro - Thunderbolt 3 Docking Station | sys | astoria | [link](https://newyork.craigslist.org/que/sys/d/astoria-owc-akitio-thunder3-dock-pro/7910313274.html) |
+| $288 | Surface computer ipod | sys | New York | [link](https://newyork.craigslist.org/que/sys/d/new-york-surface-computer-ipod/7931803596.html) |
+| $40 | ThinkStation P320 Tower Workstation Desktop Computer | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-thinkstation-p320-tower/7937826738.html) |
+| $50 | TOSHIBA Satellite C55t-C5300. Can't connect to Internet! | sys | Astoria | [link](https://newyork.craigslist.org/que/sys/d/astoria-toshiba-satellite-c55t-c5300/7925782889.html) |
+| $175 | VariDesk Pro - Standing, adjustable Desk Converter | sys | queens | [link](https://newyork.craigslist.org/que/sys/d/woodside-varidesk-pro-standing/7938335477.html) |
+| $440 | Video CAD Adobe Maya Computer 10 Core i9 32GB RAM 500GB SSD NVMe | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-video-cad-adobe-maya/7937827291.html) |
+| $340 | Video Editing PC Computer Gaming 10 Core Adobe CAD Maya 3D | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-video-editing-pc-computer/7942620011.html) |
+| $640 | Video Editing PC Computer Gaming 14 Core 32GB Adobe CAD Maya 3D | sys | Great Neck | [link](https://newyork.craigslist.org/que/sys/d/great-neck-video-editing-pc-computer/7942618587.html) |
+| $20 | View Sonic VA2342-LED Computer Monitor 23" | sys | Ridgewood | [link](https://newyork.craigslist.org/que/sys/d/ridgewood-view-sonic-va2342-led/7906918978.html) |
+| $1 | WANTED MACBOOK /PC LOCKED NOT WORKING WITH SOFTWARE/HARDWARE ISSUE | sys | ASTORIA | [link](https://newyork.craigslist.org/que/sys/d/astoria-wanted-macbook-pc-locked-not/7940319466.html) |
+| $50 | Learning Resources Botley 2.0 Coding Robot – Great STEM Toy for Kids! | tag | Jackson Heights | [link](https://newyork.craigslist.org/que/tag/d/jackson-heights-learning-resources/7937808432.html) |
+| $30 | Meccano STEM Engineering Sets (#20105 and #18202) with Pull-Back Motor | tag | Jackson Heights | [link](https://newyork.craigslist.org/que/tag/d/jackson-heights-meccano-stem/7937808975.html) |
+| $80 | Ultimate Screen-Free STEM Bundle: Botley 2.0 & Meccano Engineering Set | tag | Jackson Heights | [link](https://newyork.craigslist.org/que/tag/d/jackson-heights-ultimate-screen-free/7937809262.html) |
+| $175 | (2) TWO NEW Milwaukee 5AH Batteries + Charger | tls | Rego Park, Queens | [link](https://newyork.craigslist.org/que/tls/d/rego-park-two-new-milwaukee-5ah/7914997730.html) |
+| $150 | ***** RIDGID 300 - REPAIR SERVICE  141/258/918/200 | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/cambria-heights-ridgid-repair-service/7943075499.html) |
+| $250 | ***** RIDGID 450 TRIPOD CHAIN VISE 5” CAPACITY ***** | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/hollis-ridgid-450-tripod-chain-vise/7943459181.html) |
+| $2,000 | ***** RIDGID RP251 PROPRESS KIT ***** | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/hollis-ridgid-rp251-propress-kit/7931942352.html) |
+| $1,600 | ******* NEAR NEW RIDGID 141 DIE HEAD / GEARED THREADER ******* | tls | QUEENS | [link](https://newyork.craigslist.org/que/tls/d/hollis-near-new-ridgid-141-die-head/7943075824.html) |
+| $10 | 1/2 inch Drive Handle | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-2-inch-drive-handle/7943558956.html) |
+| $12 | 1/2" Drive Ratchets | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-2-drive-ratchets/7943559023.html) |
+| $150 | 10 AWG WIRE | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-10-awg-wire/7913854007.html) |
+| $50 | 116 PEACE SCREWDRIVER BIT & HEX KEY SET BRAND NEW | tls | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-116-peace-screwdriver/7923217615.html) |
+| $50 | 116 PEACE SCREWDRIVER, BIT AND HEX KEY SET, BRAND NEW | tls | BAYSIDE/QUEENS | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-116-peace-screwdriver/7924503784.html) |
+| $10 | 18 in. Magnetic Tool Holder Brand New Sealed in the Original Packaging | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-18-in-magnetic-tool/7909246851.html) |
+| $10 | 19" Tool Box 5 piece door hinge adjustment tool GB wire Stripper more | tls | Glendale, Queens | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-19-tool-box-piece-door-hinge/7935494967.html) |
+| $15 | 2 hand saws | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-hand-saws/7929375633.html) |
+| $20 | 3-Way Shower Arm Diverter with Handshower Mount Delta Faucet U4920-PK | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-way-shower-arm-diverter/7921220311.html) |
+| $12 | 3/8" Drive Ratchet | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-8-drive-ratchet/7943559115.html) |
+| $1 | 4 1/2 in metal cutting dics | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-in-metal-cutting-dics/7939337880.html) |
+| $17 | 4 Dies | tls | Ozone Park, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dies/7943558894.html) |
+| $45 | 4 Wrenches - Stanley / Armstrong / Pronto / S&K | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-wrenches-stanley-armstrong/7943557601.html) |
+| $175 | 4' Uboat All Metal Heavy Duty | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-uboat-all-metal-heavy-duty/7930103628.html) |
+| $150 | 4' wide Wire Rack, Bakers Rack Walk-in Freezer, Food Service | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-wide-wire-rack-bakers-rack-walk/7930117533.html) |
+| $40 | 5 Piece Air Compressor Tool Kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-piece-air-compressor-tool-kit/7943557289.html) |
+| $385 | 5 SEKTION Wall cabinet horizontal, white/Nickebo | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/long-island-city-sektion-wall-cabinet/7907718781.html) |
+| $300 | 5' Pallet Rack Beige for Basement, Shipping Containers, Warehouse | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-pallet-rack-beige-for-basement/7930102992.html) |
+| $1,998 | 6 Pallet Trucks Delivered As A Group Anywhere in Queens-Pick Your Size | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-pallet-trucks-delivered-as/7916398432.html) |
+| $30 | 64'' Fiberglass Long Handle Carbon Steel Square Point Shovel | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-64-fiberglass-long/7912145865.html) |
+| $30 | 64'' Fiberglass Long Handle Carbon Steel Square Point Shovel | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-64-fiberglass-long/7916397642.html) |
+| $10 | 8 IN 1 Magnetic Screwdriver Set | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-in-magnetic-screwdriver-set/7943557363.html) |
+| $170 | A/C & Refrigeration Manifold Imperial | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-c-refrigeration-manifold/7913845042.html) |
+| $0 | A/C Charging unit /Guages | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/middle-village-c-charging-unit-guages/7927225504.html) |
+| $19 | Adjustable Round Split Dies - High Speed Steel | tls | Ozone Park, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-adjustable-round-split-dies/7943558641.html) |
+| $15 | Adjustable Wrench Stanley 12In/300MM 87-472 Chrome | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-adjustable-wrench-stanley/7932455603.html) |
+| $20 | American Lock | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-american-lock/7918561938.html) |
+| $120 | American Locks Series 2000 (4) for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-american-locks-series-for/7912981635.html) |
+| $199 | Ametek Battery Mate 80 Model 750M1 Forklift Battery Charger | tls | College Point | [link](https://newyork.craigslist.org/que/tls/d/college-point-ametek-battery-mate-80/7933772681.html) |
+| $89 | Amprobe Clamp Meter | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-amprobe-clamp-meter/7913435445.html) |
+| $130 | Argon empty tank with regulator | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-argon-empty-tank-with-regulator/7940785652.html) |
+| $20 | Armstrong Tool Stud Removers | tls | Ozone Park, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-armstrong-tool-stud-removers/7943558511.html) |
+| $25 | Arrow electric nail gun - Great condition | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/corona-arrow-electric-nail-gun-great/7937608392.html) |
+| $75 | ASPL saw blade 300x30x3,2 z=72 GS | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-aspl-saw-blade-300x30x32/7942632558.html) |
+| $60 | Assortment of extension cords | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-assortment-of-extension-cords/7939556757.html) |
+| $70 | Automotive Tools | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-automotive-tools/7943558394.html) |
+| $65 | Automotive Tools / Wrenches | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-automotive-tools-wrenches/7943558450.html) |
+| $600 | BG CT2 Coolant Transfusion System - Professional Coolant Exchange | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-bg-ct2-coolant-transfusion/7942657948.html) |
+| $40 | Biohacking & wellness peptidess test janoshik | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-biohacking-wellness-peptidess/7910696771.html) |
+| $15 | Black & Decker Saw Blade Hedge Trimmer Corded | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/queens-village-black-decker-saw-blade/7942855635.html) |
+| $15 | Blades Sabre Saw-JIG SAW (18) for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-blades-sabre-saw-jig-saw-18-for/7913845396.html) |
+| $20 | Blades Saw All - Lenox 12" long (5) for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-blades-saw-all-lenox-12-long/7912982139.html) |
+| $20 | BLUE POINT 3/8 INPACT GUN | tls | OZONE PARK | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-blue-point-8-inpact-gun/7913932472.html) |
+| $25 | Bolt cutters | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-bolt-cutters/7924682589.html) |
+| $340 | Bosch 11316evs | tls | Ridgewood  glendale queens | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-bosch-11316evs/7944221058.html) |
+| $100 | Bosch 125ft 3point leveling laser | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-bosch-125ft-3point-leveling/7916382217.html) |
+| $65 | Bosch Jigsaw | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-bosch-jigsaw/7938557300.html) |
+| $25 | Braun series 3 | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/queens-village-braun-series/7922293621.html) |
+| $75 | Cable and web hoists/pullers | tls | Fresh meadows | [link](https://newyork.craigslist.org/que/tls/d/floral-park-cable-and-web-hoists-pullers/7938558654.html) |
+| $325 | Cart Flat Bed | tls | Farmingdale | [link](https://newyork.craigslist.org/que/tls/d/farmingdale-cart-flat-bed/7913205028.html) |
+| $59 | Charger, Two 18V M18 Batteries & Tool Bag for Milwaukee Drill Drivers | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-charger-two-18v-m18/7912428689.html) |
+| $10 | Chisels | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-chisels/7943588237.html) |
+| $50 | Cleaning out my workbench, all kinds of miscellaneous tools | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-cleaning-out-my-workbench-all/7918861407.html) |
+| $20 | Contour Gauge Set 10"& 5'' Profile Duplicator Ruler W/Lock (BRAND NEW) | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-contour-gauge-set-10/7916398871.html) |
+| $20 | Contour Gauge Set 10"&5'' Profile Duplicator Ruler W/Lock (BRAND NEW) | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-contour-gauge-set-105/7909246600.html) |
+| $150 | Corbin Russwin CL3351 NZD 626 Lockset | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-cl3351-nzd-626/7917047742.html) |
+| $150 | Corbin Russwin CL3351 NZD 626 Lockset | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-cl3351-nzd-626/7935670595.html) |
+| $150 | Corbin Russwin ML2003-LWA-630 Lockset | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-corbin-russwin-ml2003-lwa-630/7915100125.html) |
+| $50 | Core Removal Tool "C and D" | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-core-removal-tool-and/7912982566.html) |
+| $450 | CRAFTSMAN 20V tool set | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-craftsman-20v-tool-set/7916211431.html) |
+| $40 | Craftsman 47046 12 pc. SAE Combination Wrench Set w/ organizer, USA | tls | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/tls/d/jackson-heights-craftsman-pc-sae/7921363770.html) |
+| $55 | CRAFTSMAN 6500 TOOL BOX | tls | GLENDALE | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-craftsman-6500-tool-box/7925651084.html) |
+| $400 | Craftsman 9.0 HP 28" Snow Blower | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-craftsman-90-hp-28-snow-blower/7929124693.html) |
+| $30 | Craftsman metal toolbox / drawers | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-craftsman-metal-toolbox-drawers/7932005204.html) |
+| $10 | Craftsman Oil Filter Wrench | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-craftsman-oil-filter-wrench/7943558283.html) |
+| $150 | Craftsman Pro Series Router | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-craftsman-pro-series-router/7916209589.html) |
+| $500 | Crown Narrow Fork Pallet Jack | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-crown-narrow-fork-pallet-jack/7930104555.html) |
+| $400 | Cub Cadet 524 Snow Blower | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-cub-cadet-524-snow-blower/7929124225.html) |
+| $20 | Curtain rod | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/maspeth-curtain-rod/7942817319.html) |
+| $175 | Dewalt 1 3/4 pnuematic coil roofing nailgun | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-pnuematic-coil/7934640722.html) |
+| $130 | Dewalt 1.7ah twin pack powerstack batteries | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-17ah-twin-pack/7942852646.html) |
+| $400 | DEWALT 10" Heavy Duty Wet Tile Saw | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-dewalt-10-heavy-duty-wet-tile/7943222698.html) |
+| $175 | DEWALT 20-Volt MAX XR Cordless Brushless Compact Router | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-dewalt-20-volt-max-xr/7915879966.html) |
+| $500 | DeWalt 20v Cordless Pro Tools | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-dewalt-20v-cordless-pro-tools/7943185358.html) |
+| $450 | Dewalt 3 pc Combo Router kit, 3100 PSI pressure washer, BBQ Grill. | tls | Ozone park , Queens, NYC | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-pc-combo-router-kit/7940487318.html) |
+| $100 | DEWALT 9 Gallon Wet/Dry VAC, Heavy-Duty Shop Vacuum with Attachments | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-dewalt-gallon-wet-dry-vac-heavy/7943154595.html) |
+| $200 | Dewalt battery pack kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-battery-pack-kit/7923819015.html) |
+| $200 | Dewalt battery pack kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-battery-pack-kit/7942340260.html) |
+| $199 | DeWALT DCD998B Max XR 1/2" 20V Brushless Hammer Drill | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-dcd998b-max-xr/7937278351.html) |
+| $15 | Dewalt impact bit sets | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dewalt-impact-bit-sets/7927720490.html) |
+| $80 | DeWalt Metal Chop Saw 14" | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-dewalt-metal-chop-saw-14/7943222438.html) |
+| $20 | Dies - Set of 5 | tls | Ozone Park, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-dies-set-of/7943558807.html) |
+| $20 | DIY toolkit | tls | New York | [link](https://newyork.craigslist.org/que/tls/d/new-york-diy-toolkit/7943800625.html) |
+| $50 | Door lock hole opener | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-door-lock-hole-opener/7943894641.html) |
+| $40 | DORMA Door Closer Model 7601 PA Sn1 Al | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-dorma-door-closer-model-7601/7921094398.html) |
+| $15 | Drill Bit Organizer Rotatable in Blue | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-drill-bit-organizer/7909246743.html) |
+| $10 | Drill Bits - 705C-19/64 | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-drill-bits-705c-19-64/7932454763.html) |
+| $15 | Drill Bits and Milling Cutter Tools Organizer (Orange) | tls | Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-and-milling/7916399279.html) |
+| $15 | Drill Bits Milling Cutter Tools Organizer (Orange) | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-milling/7909246697.html) |
+| $15 | Drill Bits Organizer Rotatable (Blue) | tls | Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-drill-bits-organizer/7916399347.html) |
+| $0 | Drill kit | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-drill-kit/7927227737.html) |
+| $5 | Dust Collector system 4'' Y | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-dust-collector-system-y/7943588154.html) |
+| $200 | Edwards RV3  Two Stage Rotary Vane Vacuum Pump | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-edwards-rv3-two-stage-rotary/7931773305.html) |
+| $80 | Edward’s GS shop wall clock | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-edwards-gs-shop-wall-clock/7924929438.html) |
+| $450 | Ego snowbliwer | tls | Maspeth ny | [link](https://newyork.craigslist.org/que/tls/d/maspeth-ego-snowbliwer/7943947990.html) |
+| $50 | Electric snowblower (Toro 1500 Power Curve) | tls | Kew Gardens | [link](https://newyork.craigslist.org/que/tls/d/kew-gardens-electric-snowblower-toro/7932726359.html) |
+| $30 | Electric Steel Fish Tape 50ft. (Ideal) | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-electric-steel-fish-tape-50ft/7912983008.html) |
+| $400 | Engraving Machine, Vigor EN-775 | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-engraving-machine-vigor-en-775/7940785708.html) |
+| $2,599 | Esab Rebel 215 welder | tls | New York | [link](https://newyork.craigslist.org/que/tls/d/new-york-esab-rebel-215-welder/7943613265.html) |
+| $55 | Evolution R355TCT 14" Multi-Material Cutting Blade | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-evolution-r355tct-14/7937107332.html) |
+| $320 | Festool LR32 Guide Rail System Package (Excellent Condition) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-festool-lr32-guide-rail/7937979758.html) |
+| $525 | Festool TS 55 FEQ-F-Plus Plunge-Cut Track Saw | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-festool-ts-55-feq-plus/7937980202.html) |
+| $10 | Fiskars 18" Machete with Sheath | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-fiskars-18-machete-with/7928769753.html) |
+| $100 | Freud 4 inch joiner machine | tls | south ozone park | [link](https://newyork.craigslist.org/que/tls/d/south-ozone-park-freud-inch-joiner/7925970644.html) |
+| $1,900 | gain box & jobox | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-gain-box-jobox/7943323590.html) |
+| $125 | Gas Pressure Regulator | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-gas-pressure-regulator/7913435844.html) |
+| $4 | Gator Grip Universal Socket Wrench | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-gator-grip-universal-socket/7915088285.html) |
+| $79 | Gauges TIF for A/C & Refrigeration (3) for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-gauges-tif-for-c-refrigeration/7912983425.html) |
+| $20 | General Tools No. 825 Drill Grinding Attachment (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-general-tools-no-825/7937104635.html) |
+| $2,500 | Gibson Les Paul Kirk Hammett Greeny 2025 | tls | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/tls/d/queens-village-gibson-les-paul-kirk/7943841027.html) |
+| $325 | Graco TrueCoat 360 DSP Airless Paint Sprayer | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-graco-truecoat-360-dsp/7915606951.html) |
+| $89 | Graftsman circulating saw | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-graftsman-circulating-saw/7918366313.html) |
+| $89 | Graftsman circulating saw | tls | FLUSHING | [link](https://newyork.craigslist.org/que/tls/d/flushing-graftsman-circulating-saw/7918366060.html) |
+| $100 | Greenlee knockout sets | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-greenlee-knockout-sets/7943504107.html) |
+| $110 | Halogen Leak Detector TIF | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-halogen-leak-detector-tif/7913436294.html) |
+| $5 | Hand Tools | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-hand-tools/7943588321.html) |
+| $165 | hand truck | tls | east elmhurst | [link](https://newyork.craigslist.org/que/tls/d/east-elmhurst-hand-truck/7937849448.html) |
+| $165 | Hand truck | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/east-elmhurst-hand-truck/7936700470.html) |
+| $15 | Hand Truck | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/queens-village-hand-truck/7943844377.html) |
+| $85 | Hand Truck Aluminum | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-hand-truck-aluminum/7943420277.html) |
+| $165 | handtruck | tls | Jackson Heights | [link](https://newyork.craigslist.org/que/tls/d/east-elmhurst-handtruck/7937005815.html) |
+| $300 | Heat Welding Kit | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-heat-welding-kit/7916139319.html) |
+| $149 | Helium Regulator for Latex & Foil Balloons | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-helium-regulator-for-latex/7914022673.html) |
+| $59 | Helium Regulator for Latex Balloons | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-helium-regulator-for-latex/7914022039.html) |
+| $1,500 | HILTI #3514171 SDS-MAX TE 70-ATC-AVR Corded Rotary Hammer Drill 120-Vo | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-hilti-sds-max-te-70-atc/7941508455.html) |
+| $200 | Hilti DX2 Powder Actuated Fastening Tool | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-hilti-dx2-powder-actuated/7943222523.html) |
+| $40 | HK Porter 2790 heavy-duty slotted angle iron shears | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/flushing-hk-porter-2790-heavy-duty/7936966927.html) |
+| $2,500 | Hoists 2000 LBS & 1000LBS | tls | Astoria, NY Queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-hoists-2000-lbs-1000lbs/7943327068.html) |
+| $90 | Homelite 16 in electric chainsaw | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-homelite-16-in-electric/7934937810.html) |
+| $40 | Homelite Mighty Lite 26bp Backpack Blower | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/east-elmhurst-homelite-mighty-lite-26bp/7939590092.html) |
+| $800 | Hunter DSP400 Alignment Machine (Parts Only) | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-hunter-dsp400-alignment/7915269355.html) |
+| $23 | Husky and Armstrong 1/2" Drive Sockets | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-husky-and-armstrong-2-drive/7943558200.html) |
+| $150 | Husky BS1004W 4 gal. 135 psi compressor w/ hose | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/rego-park-husky-bs1004w-gal-135-psi/7907004293.html) |
+| $15 | IRWIN Record 1/2" Heavy Duty Pipe Clamp (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-irwin-record-2-heavy/7937101451.html) |
+| $35 | IRWIN VISE-GRIP 2078612/2078610 12/10" ProPliers Adjustable Wrench Set | tls | Jackson Heights, Queens | [link](https://newyork.craigslist.org/que/tls/d/jackson-heights-irwin-vise-grip/7918478857.html) |
+| $2 | JigSaw blades | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-jigsaw-blades/7916272954.html) |
+| $2,500 | JMR Electric Hydraulic Tubing Bender & Tooling | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-jmr-electric-hydraulic-tubing/7942744631.html) |
+| $5,500 | John Bean Prism Alignment Machine Toolbox Style | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-john-bean-prism-alignment/7925210200.html) |
+| $10 | Kreg Bench Dogs 3/4" Hole Diameter (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-kreg-bench-dogs-4-hole/7937106614.html) |
+| $65 | Kreg KHC6 Automaxx 6" Wood Project Clamp | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-kreg-khc6-automaxx-wood/7937102741.html) |
+| $15 | Leather Work Apron With 6 Pockets Tool Heavy Duty | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-leather-work-apron-with/7909246645.html) |
+| $15 | Leather Work Apron With 6 Pockets Tool Heavy Duty | tls | Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-leather-work-apron-with/7916399207.html) |
+| $14 | Lineman Pliers and wire stripper | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-lineman-pliers-and-wire/7943558104.html) |
+| $8 | Long Sleeve Navy Blue Size XLarge Shirt With Front Pocket – 4 Pc | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-long-sleeve-navy-blue-size/7935581952.html) |
+| $0 | Lots of Tools | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-lots-of-tools/7943143066.html) |
+| $75 | Louisville 8 ft ladder / fiberglass | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-louisville-ft-ladder-fiberglass/7931966072.html) |
+| $6 | Lufkin 16ft Mezurlok Power Tape & Folding Ruler | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-lufkin-16ft-mezurlok-power/7915088393.html) |
+| $10 | Magnetic Tool Holder 18'' (Brand New) | tls | Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-magnetic-tool-holder-18/7916401825.html) |
+| $45 | MagSwitch Magnetic Featherboard for Table Saw/Router Table/Band Saw | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-magswitch-magnetic/7937216593.html) |
+| $75 | Makita 18 volt charger | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7936755349.html) |
+| $75 | Makita 18 volt charger | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7939337950.html) |
+| $125 | Makita 18 volt sawzall and hammer drill | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-makita-18-volt/7939918367.html) |
+| $30 | Makita Circular Saw 7-1/4" | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-makita-circular-saw-1/7943222213.html) |
+| $880 | Makita EK6101 Cut-Off Saw | tls | New York | [link](https://newyork.craigslist.org/que/tls/d/new-york-makita-ek6101-cut-off-saw/7941916980.html) |
+| $150 | Makita Plate (Biscuit) Joiner PJ7000 | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-makita-plate-biscuit-joiner/7943222283.html) |
+| $200 | Makita SDS-Max Rotary Hammer | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-makita-sds-max-rotary-hammer/7943222352.html) |
+| $140 | Makita XMU04ZX Grass Shear with Hedge Trimmer Blade | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-makita-xmu04zx-grass/7921156221.html) |
+| $140 | Makita XMU04ZX Grass Shear with Hedge Trimmer Blade | tls | Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-makita-xmu04zx-grass/7916392002.html) |
+| $40 | Malco HVAC tin knockers duct hammer | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-malco-hvac-tin-knockers-duct/7919407628.html) |
+| $35 | Map/Pro tanks gas (TurboTorch) 2 for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-map-pro-tanks-gas-turbotorch/7942358196.html) |
+| $1 | Massive Tool and Hardware Sale | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-massive-tool-and-hardware/7938264863.html) |
+| $10 | Mechanix Wear SMP-91-010 - M-Pact Resistant Gloves Size: X Large | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-mechanix-wear-smp-pact/7918537286.html) |
+| $20 | Merit 180 Grit 25,000 RPM 1/4" Sanding Flap Wheels For Drill | tls | Woodside | [link](https://newyork.craigslist.org/que/tls/d/woodside-merit-180-grit-rpm-4-sanding/7923133329.html) |
+| $55 | Metabo 4 1/2 in angle grinder | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-metabo-in-angle-grinder/7909419800.html) |
+| $45 | Metal Counter Sinks | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-metal-counter-sinks/7929237569.html) |
+| $25 | Metal Machine Cutting Bit | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-metal-machine-cutting-bit/7938564488.html) |
+| $150 | MetalTech Baker Rolling Scaffold | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-metaltech-baker-rolling/7943222040.html) |
+| $2,500 | micro lath | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/corona-micro-lath/7914185988.html) |
+| $20 | MicroJig MATCHFIT Dado Stop DS-333 (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-microjig-matchfit-dado/7937978460.html) |
+| $40 | MILLERS FALLS NO 120 B HAND DRILL HEAVY DUTY ½" CHUCK TWO SPEED BREAST USA VTG | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-millers-falls-no-120-hand/7921094115.html) |
+| $140 | Milwaukee 18 volt 1/4 in impact kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-18-volt-4-in/7918941615.html) |
+| $145 | Milwaukee 18 volt compact 1/2 in drill kit | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-milwaukee-18-volt/7941370450.html) |
+| $99 | Milwaukee 18V Tool Kit w/ 2 Drill Drivers, Charger, 2 Batteries & Bag | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-milwaukee-18v-tool-kit-2-drill/7911640901.html) |
+| $200 | MILWAUKEE 2551-22 M12 FUEL™ 1/4" HEX HYDRAULIC DRIVER KIT – NEW IN BOX | tls | OZONE PARK | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-m12-fuel-4-hex/7910753856.html) |
+| $30 | Milwaukee electric chainsaw | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-milwaukee-electric-chainsaw/7929933284.html) |
+| $31 | Milwaukee Maximum Leverage Durable Grip and Hammer | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-milwaukee-maximum-leverage/7943557929.html) |
+| $1,800 | Milwaukee MX FUEL Lithium-Ion Cordless 1-1/8 in. Breaker with Battery | tls | College Point | [link](https://newyork.craigslist.org/que/tls/d/college-point-milwaukee-mx-fuel-lithium/7924053470.html) |
+| $99 | Milwaukee rotary hammer drill | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913020724.html) |
+| $99 | Milwaukee rotary hammer drill | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-rotary-hammer-drill/7918365910.html) |
+| $99 | Milwaukee rotary hammer drill | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913414278.html) |
+| $99 | Milwaukee rotary hammer drill | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-milwaukee-rotary-hammer-drill/7913414356.html) |
+| $100 | Milwaukee saw zall | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-milwaukee-saw-zall/7943893135.html) |
+| $40 | Milwaukee Sawzall 12AMP Corded | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-sawzall-12amp-corded/7943222118.html) |
+| $150 | Milwaukee Super Sawzall 15A Brand New | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-milwaukee-super-sawzall-15a/7943222778.html) |
+| $5 | Milwaukee utility knife | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-milwaukee-utility-knife/7919407261.html) |
+| $20 | Motor | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-motor/7942932523.html) |
+| $20 | Motor | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-motor/7942936080.html) |
+| $1,500 | MotorVac TransTech III Transmission Service System – MTT1000IIIP | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-motorvac-transtech-iii/7939137557.html) |
+| $75 | Multimeter Fluke | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-multimeter-fluke/7912983886.html) |
+| $13 | Naphtha - 32oz unopened container | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-naphtha-32oz-unopened-container/7924539504.html) |
+| $12 | Nespresso | tls | ridgewood | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-nespresso/7937841277.html) |
+| $300 | New 2 sets plus extra SK Professional 86124 Combination Wrench Sets | tls | south ozone park | [link](https://newyork.craigslist.org/que/tls/d/south-ozone-park-new-sets-plus-extra-sk/7918371487.html) |
+| $200 | New Dewalt 1/2 inch impact wrench | tls | south ozone park | [link](https://newyork.craigslist.org/que/tls/d/south-ozone-park-new-dewalt-2-inch/7925975934.html) |
+| $200 | NEW PELICAN VAULT 370 TACTICAL RIFLE CASE + PADDING \| CAMPING STORAGE | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-new-pelican-vault-370-tactical/7939893978.html) |
+| $40 | New Safety Helmet New in box | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-new-safety-helmet-new-in-box/7926374867.html) |
+| $50 | Norton 1601BF-DA-689 Door Closer Delayed Action, | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-norton-1601bf-da-689-door/7932652505.html) |
+| $50 | Norton Door Closer 9303BCX9318A Regular Arm w/ Soffit Plate & Backcheck | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-norton-door-closer/7932651947.html) |
+| $260 | Pfanner Protos Integral Arborist / Forestry Helmet (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-pfanner-protos-integral/7936138133.html) |
+| $120 | Phototacometer TIF | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-phototacometer-tif/7913436749.html) |
+| $150 | Pioneerworks Sewar & Drain Cleaner | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-pioneerworks-sewar-drain/7942779851.html) |
+| $15 | plane | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-plane/7943588291.html) |
+| $15 | Power Strip and Timer | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-power-strip-and-timer/7943558030.html) |
+| $1,050 | Powermatic 45 Wood Lathe | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-powermatic-45-wood-lathe/7943586064.html) |
+| $750 | Powermatic Tilt Table Mortiser, 1" Chisel, 10-3/4" Stroke, 115/230V 1Ph (719T) | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-powermatic-tilt-table-mortiser/7942744484.html) |
+| $160 | Powersmart Snowblower - 26 inch wide | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-powersmart-snowblower-26-inch/7930168891.html) |
+| $2,500 | Pro-Cut PFM 9.2 On-Car Brake Lathe | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-pro-cut-pfm-92-on-car-brake/7929819404.html) |
+| $25 | Refrigerant Charging Cylinder | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-refrigerant-charging-cylinder/7913437207.html) |
+| $40 | Ride1up ebike - salvage | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/east-elmhurst-ride1up-ebike-salvage/7939591254.html) |
+| $500 | Ridgid 100-B pro press tool and jaw set | tls | New York | [link](https://newyork.craigslist.org/que/tls/d/new-york-ridgid-100-pro-press-tool-and/7942203537.html) |
+| $1,800 | RIDGID 300 PIPE THREADING MACHINE w/ STAND *****6-Month Warranty****** | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/queens-village-ridgid-300-pipe/7943076051.html) |
+| $250 | RIDGID 9-Amp 7 in. Blade Corded Wet Tile Saw with Stand | tls | South Richmond Hill | [link](https://newyork.craigslist.org/que/tls/d/south-richmond-hill-ridgid-amp-in-blade/7942243695.html) |
+| $120 | RIDGID CA-25 Micro Visual Inspection | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-ridgid-ca-25-micro-visual/7919635753.html) |
+| $80 | Ridgid Foldable Mobile Miter Saw Stand | tls | fresh meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-ridgid-foldable-mobile/7942980473.html) |
+| $150 | Ridgid tile saw | tls | Howard beach | [link](https://newyork.craigslist.org/que/tls/d/kew-gardens-ridgid-tile-saw/7943214337.html) |
+| $25 | Ridgid U 36 bolt cutters | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-ridgid-36-bolt-cutters/7935263150.html) |
+| $80 | RIDGID Wet/Dry Vac Pump Accessory VP2000 (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-ridgid-wet-dry-vac-pump/7936139052.html) |
+| $59 | Ridgit cooper pipe cutter | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-ridgit-cooper-pipe-cutter/7914174162.html) |
+| $59 | Ridgit cooper pipe cutter | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-ridgit-cooper-pipe-cutter/7914463399.html) |
+| $10 | Right Snips Stanley FatMax  FMHT73557 | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-right-snips-stanley-fatmax/7932456059.html) |
+| $85 | Rigid 5/8 in electric hammer drill | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-8-in-electric-hammer/7934395791.html) |
+| $125 | Rigid dual 18 volt charger & 2 18 volt 4.0ah batteries | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-dual-18-volt-charger/7929437165.html) |
+| $65 | Rigid gen 5 brushless belt sander | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-rigid-gen-brushless-belt/7909419849.html) |
+| $250 | Rigid Jobsite Portable 10' Table Saw with Integrated Stand with wheels | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-rigid-jobsite-portable-10/7943221881.html) |
+| $60 | Rigid NXT HD Shop Vac 6HP, 14gal capacity | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/rego-park-rigid-nxt-hd-shop-vac-6hp/7943222611.html) |
+| $20 | Rockler Woodworking Glue Applicator Kit (Brand New) | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-rockler-woodworking/7937105716.html) |
+| $450 | Router.. complete with case. Dewalt DW618 Three Piece Combo Router kit | tls | Ozone park , Queens, NYC | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-router-complete-with-case/7940930082.html) |
+| $95 | Ryobi 1/2 in drill kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-2-in-drill-kit/7941825811.html) |
+| $50 | Ryobi 10 in electric buffer/polisher | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-10-in-electric-buffer/7919065452.html) |
+| $35 | Ryobi 18 volt charger | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-charger/7937742213.html) |
+| $40 | Ryobi 18 volt corner cat sander | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-corner-cat/7918941703.html) |
+| $80 | Ryobi 18 volt grass shear and shrubber trimmer | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-grass-shear/7934395991.html) |
+| $85 | Ryobi 18 volt sawzall kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18-volt-sawzall-kit/7937741249.html) |
+| $35 | Ryobi 18volt Electrostatic Sprayer | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-18volt-electrostatic/7937741930.html) |
+| $50 | Ryobi 4 1/2 in 18 volt grinder | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-18-volt-grinder/7927719812.html) |
+| $50 | Ryobi 4 1/2 in 18 volt grinder | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-18-volt-grinder/7920983790.html) |
+| $100 | Ryobi 4.0 ah 40 volt battery | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-ah-40-volt-battery/7934396748.html) |
+| $140 | Ryobi 40 volt 4.0 battery and rapid charger kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-volt-40-battery-and/7934396580.html) |
+| $85 | Ryobi 40 volt Rapid charger | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-40-volt-rapid-charger/7934396276.html) |
+| $75 | Ryobi 6 amp electric belt sander | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-amp-electric-belt/7927719479.html) |
+| $75 | Ryobi 6 amp electric belt sander | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-amp-electric-belt/7925812415.html) |
+| $45 | Ryobi 6in electric buffer | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-6in-electric-buffer/7923818955.html) |
+| $8 | Ryobi 7 1/4 in carbide 24 teeth thin kerf saw blades | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-in-carbide-24-teeth/7934937930.html) |
+| $150 | Ryobi brushless hammer drill kit | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-brushless-hammer-drill/7934397050.html) |
+| $75 | Ryobi Brushless jigsaw | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-ryobi-brushless/7941818085.html) |
+| $35 | RYOBI CIRCULAR SAW | tls | GLENDALE | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-ryobi-circular-saw/7936074434.html) |
+| $30 | Ryobi CSB142LZ Corded Electric Circular Saw w free drill | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-ryobi-csb142lz-corded-electric/7943940115.html) |
+| $50 | Ryobi electric corner cat sander | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-electric-corner-cat/7918941729.html) |
+| $85 | Ryobi electric router | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-ryobi-electric-router/7937180755.html) |
+| $35 | RYOBI JIG SAW | tls | GLENDALE | [link](https://newyork.craigslist.org/que/tls/d/ridgewood-ryobi-jig-saw/7935003296.html) |
+| $60 | Safety Tape Applicator | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-safety-tape-applicator/7919361189.html) |
+| $100 | Sand blaster | tls | Whitestone | [link](https://newyork.craigslist.org/que/tls/d/whitestone-sand-blaster/7943504619.html) |
+| $10 | Scotch-Brite Hand Pads (4) for | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-scotch-brite-hand-pads-for/7913437736.html) |
+| $40 | SEALED NEW TRAVEL LOCKS TSA COMBI LOCK LUGGAGE BIKE KEYS STORAGE | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-sealed-new-travel-locks-tsa/7939900790.html) |
+| $150 | Shear Electric (Bosch) | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-shear-electric-bosch/7912984347.html) |
+| $35 | Sheet Metal Snip Tools Set | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-sheet-metal-snip-tools-set/7913438321.html) |
+| $10 | Short Hatchet | tls | Ridgewood | [link](https://newyork.craigslist.org/que/tls/d/middle-village-short-hatchet/7919163368.html) |
+| $2,500 | Signs | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/astoria-signs/7943321443.html) |
+| $30 | Simpson 467 Digital Multi Meter | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-simpson-467-digital-multi/7943557689.html) |
+| $60 | SK Wayne ratchet set | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-sk-wayne-ratchet-set/7934805578.html) |
+| $40 | Skil circular saw | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-skil-circular-saw/7943895964.html) |
+| $40 | SKIL Corded Multi-Function Detail Sander with Micro-Filter Dust Box | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-skil-corded-multi-function/7943154786.html) |
+| $100 | Skil router table with router | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/astoria-skil-router-table-with-router/7943892368.html) |
+| $45 | Snap on charger | tls | Ozone park | [link](https://newyork.craigslist.org/que/tls/d/springfield-gardens-snap-on-charger/7939746045.html) |
+| $10,500 | Snap On John Bean V2400 Visualiner 3D/3D2 Alignment Machine | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-john-bean-v2400/7907130214.html) |
+| $60 | Snap On Torque Wrench -Inch Pounds- Needs Repair | tls | Glendale | [link](https://newyork.craigslist.org/que/tls/d/middle-village-snap-on-torque-wrench/7940103612.html) |
+| $3,350 | Snap-On 304D Wheel Balancer Used Excellent Working Condition | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-304d-wheel-balancer/7943998377.html) |
+| $1,500 | Snap-on MM250SL MIG Welder | tls | Astoria | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-snap-on-mm250sl-mig-welder/7942658030.html) |
+| $7,500 | Snap-On Polartek Plus Model EEAC331B R134a A/C Machine | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-snap-on-polartek-plus-model/7935755840.html) |
+| $750 | Snap-On Wrenchs : Industrial GOEX Combination Wrench Set 11 pieces 2" to 1 5/16" | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/flushing-snap-on-wrenchs-industrial/7916528096.html) |
+| $220 | SNOW JOE ION18SB-HYB-RM 40-VOLT IONMAX HYBRID SINGLE STAGE SNOW BLOWER | tls | OZONE PARK | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-snow-joe-ion18sb-hyb-rm-40/7908785083.html) |
+| $40 | Solder Wire: Kester SN63PB37 #66/44, 0.80mm/0.031” | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-solder-wire-kester-sn63pb/7936589694.html) |
+| $59 | Soldering Gun (Weller) | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-soldering-gun-weller/7913846922.html) |
+| $2,000 | Spartan 1065 Sewer Machine w/Autofeed | tls | Queens Village | [link](https://newyork.craigslist.org/que/tls/d/hollis-spartan-1065-sewer-machine/7943075316.html) |
+| $89 | Spectroline Lamp | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-spectroline-lamp/7913652543.html) |
+| $10 | SPRING COMPRESSER TOOL | tls | OZONE PARK | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-spring-compresser-tool/7913934014.html) |
+| $49 | Stay Brite #8 Soft Soldering 1 Lb. | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-stay-brite-soft-soldering-lb/7913438970.html) |
+| $50 | Stihl FSB-KM Curved Shaft Trimmer | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-stihl-fsb-km-curved/7937045585.html) |
+| $6 | Strainer | tls | ridgewood | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-strainer/7942816180.html) |
+| $1,500 | Sun Motorvac Carbon Clean System EEFS100A Fuel System Cleaning Machine | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/asbury-park-sun-motorvac-carbon-clean/7939137530.html) |
+| $2,550 | Super Nice Miller Tig Welder Synchrowave 200 / CJ Flex Torch | tls | New York | [link](https://newyork.craigslist.org/que/tls/d/new-york-super-nice-miller-tig-welder/7943910398.html) |
+| $4 | T-Shirts Size XL,2X,2XL 100% Cotton, with Front Pocket Color – BLUE | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-shirts-size-xl2x2xl-100/7935572836.html) |
+| $4 | T-Shirts Size XXL, 100% Cotton, with Front Pocket, Color – White 4Pc. | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-shirts-size-xxl-100-cotton/7935574317.html) |
+| $8 | Tacktical Flashlight | tls | Kew gardens queens | [link](https://newyork.craigslist.org/que/tls/d/kew-gardens-tacktical-flashlight/7925675881.html) |
+| $8 | Tacktical Flashlight | tls | Kew gardens queens | [link](https://newyork.craigslist.org/que/tls/d/kew-gardens-tacktical-flashlight/7936217129.html) |
+| $20 | Temperature Chart Recorder (Dickson) | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-temperature-chart-recorder/7913439950.html) |
+| $130 | Thermometer by Cooper Instrument | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-thermometer-by-cooper/7913652985.html) |
+| $70 | TICONN 13'' Rivet Gun Kit with Metric & SAE 7 Mandrels and Rivet Nuts | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-ticonn-13-rivet-gun-kit/7933165380.html) |
+| $70 | TICONN 13'' Rivet Gun Kit with Metric & SAE 7 Mandrels and Rivet Nuts | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-ticonn-13-rivet-gun-kit/7916393523.html) |
+| $50 | Toro Leaf Blower | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-toro-leaf-blower/7909246254.html) |
+| $250 | Transport Moving Rolling Flat Cart | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-transport-moving-rolling-flat/7930521875.html) |
+| $12 | Tray | tls | ridgewood | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-tray/7937682719.html) |
+| $35 | Trimmer Head Dual Line Bump & Feed VP33 Rotary 10231 | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-trimmer-head-dual-line/7931857612.html) |
+| $70 | Turbo Torch (Hand) | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-turbo-torch-hand/7912984829.html) |
+| $75 | TurboTorch  A-5 Tip | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-turbotorch-5-tip/7912985286.html) |
+| $69 | Two (2) DeWalt Drill Driver and Hammer Drill Tools + Hard Case and Tool Bag | tls | Brooklyn | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-two-dewalt-drill-driver-and/7921052785.html) |
+| $59 | Two (2) Milwaukee 18V Hammer Drill Drivers M18 Tool Only | tls | Ozone Park | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-two-milwaukee-18v-hammer/7915808856.html) |
+| $15 | Two 4 way Screwdrivers | tls | Queens, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-two-way-screwdrivers/7943557496.html) |
+| $80 | Two used Werner Portable Rolling Scaffold 500 lb. Load | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-two-used-werner-portable/7937348980.html) |
+| $250 | Uboat Transport Cart Merchandise Utility Stock Rolling Cart | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/bayside-uboat-transport-cart/7930098348.html) |
+| $40 | Universal Hardware 4013 Heavy-Duty Ivory Residential Door Closer | tls | Sunnyside | [link](https://newyork.craigslist.org/que/tls/d/sunnyside-universal-hardware-4013-heavy/7932652082.html) |
+| $1 | USED HONDA EU2000 4SALE | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/flushing-used-honda-eu2000-4sale/7923631712.html) |
+| $110 | Vacuum Pump | tls | Flushing | [link](https://newyork.craigslist.org/que/tls/d/flushing-vacuum-pump/7913847750.html) |
+| $10 | VACUUM Pump oil | tls | ridgewood | [link](https://newyork.craigslist.org/que/tls/d/maspeth-vacuum-pump-oil/7942817114.html) |
+| $25 | Vermont American Tap Set & Cutting Tools | tls | Ozone Park, NY | [link](https://newyork.craigslist.org/que/tls/d/ozone-park-vermont-american-tap-set/7943558736.html) |
+| $60 | VICE --- Medium size Vintage Bench VICE | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/queens-village-vice-medium-size-vintage/7927465666.html) |
+| $20 | Vintage Bear Hunter Pocket Knife | tls | Forest Hills | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-vintage-bear-hunter-pocket/7906875704.html) |
+| $45 | Vintage Craftsman Orbital Sander | tls | Fresh meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-craftsman-orbital/7938556468.html) |
+| $25 | Vintage Craftsman Pipe Tubing Cutter | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-craftsman-pipe/7938557996.html) |
+| $65 | Vintage General Electric Jig Saw | tls | Fresh Meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-vintage-general-electric/7938557691.html) |
+| $40 | Vintage mini/rachet snap-on Gm-70m with 8mm socket | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/richmond-hill-vintage-mini-rachet-snap/7916358232.html) |
+| $20 | Visegrip | tls | ridgewood | [link](https://newyork.craigslist.org/que/tls/d/brooklyn-visegrip/7937690612.html) |
+| $65 | Wagner FLEXiO 590 Paint Sprayer Kit – Indoor & Outdoor HVLP Sprayer | tls | Bayside | [link](https://newyork.craigslist.org/que/tls/d/oakland-gardens-wagner-flexio-590-paint/7936077265.html) |
+| $15 | Wall Switch WSX WH PIR Occupancy Sensor, 1-Pole, 120/277 Volt, White | tls | queens | [link](https://newyork.craigslist.org/que/tls/d/forest-hills-wall-switch-wsx-wh-pir/7921274659.html) |
+| $120 | Wavetek BDM-40 Benchtop Meter | tls | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/tls/d/queens-village-wavetek-bdm-40-benchtop/7940446303.html) |
+| $120 | Wavetek BDM-40 Benchtop Meter | tls | BELLEROSE MANOR | [link](https://newyork.craigslist.org/que/tls/d/queens-village-wavetek-bdm-40-benchtop/7941282269.html) |
+| $90 | WEN 2.3-Amp 8-inch 5-speed cast iron benchtop drill press | tls | Maspeth | [link](https://newyork.craigslist.org/que/tls/d/maspeth-wen-23-amp-inch-speed-cast-iron/7943113601.html) |
+| $250 | Werner 22 ft. Aluminum Telescoping Multi-Position Ladder with 300 lbs. | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-werner-22-ft-aluminum/7936215381.html) |
+| $250 | Werner 22 ft. Aluminum Telescoping Multi-Position Ladder with 300 lbs. | tls | Queens, Middle Village | [link](https://newyork.craigslist.org/que/tls/d/middle-village-werner-22-ft-aluminum/7916390311.html) |
+| $35 | Woods Powr Grip | tls | Fresh meadows | [link](https://newyork.craigslist.org/que/tls/d/fresh-meadows-woods-powr-grip/7929237730.html) |
+| $125 | Zipwall SLP2 | tls | Queens | [link](https://newyork.craigslist.org/que/tls/d/flushing-zipwall-slp2/7924053635.html) |
+| $15 | Element Lux Dark Amber Blue Light Blocking Glasses | vgm | Long Island City | [link](https://newyork.craigslist.org/que/vgm/d/long-island-city-element-lux-dark-amber/7943727152.html) |
+| — | WTB: COMPUTER LAPTOP, PC & SERVER MEMORY/RAM + INTEL XEON CPUs/PROCESS | wad | WE BUY INTEL, MICRON, SK/HYNIX, SAMSUNG, DELL, CISCO, HP/HPE | [link](https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-computer-laptop-pc/7940103604.html) |
+| — | WTB: DATA CENTER, NETWORKING, COMPUTER SERVERS, GPUs, RAM/MEMORY-MORE! | wad | WE BUY CISCO, NVIDIA, JUNIPER, INTEL, DELL, HP, HPE & MORE $ | [link](https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-data-center/7941248108.html) |
+| — | WTB: DATA CENTER, NETWORKING, COMPUTER SERVERS, GPUs, RAM/MEMORY-MORE! | wad | WE BUY CISCO, NVIDIA, JUNIPER, INTEL, DELL, HP, HPE & MORE $ | [link](https://newyork.craigslist.org/que/wad/d/jamaica-wtb-data-center-networking/7941239873.html) |
+| — | WTB: MICRON, SK/HYNIX, SAMSUNG, INTEL, CISCO, RAM, MEMORY, CPUs & MORE | wad | WE BUY COMPUTER PROCESSORS/CPU’S, SERVER/PC/LAPTOP MEMORY | [link](https://newyork.craigslist.org/que/wad/d/long-island-city-wtb-micron-sk-hynix/7942916508.html) |
+| — | WTB: MICRON, SK/HYNIX, SAMSUNG, INTEL, CISCO, RAM, MEMORY, CPUs & MORE | wad | WE BUY COMPUTER PROCESSORS/CPU’S, SERVER/PC/LAPTOP MEMORY | [link](https://newyork.craigslist.org/que/wad/d/jamaica-wtb-micron-sk-hynix-samsung/7942709388.html) |
+| — | CASH FOR GIFT CARDS STORE CREDITS + ELECTRONICS + HAND TOOLS WANTED | wan | JAMAICA QUEENS, NY | [link](https://newyork.craigslist.org/que/wan/d/wyandanch-cash-for-gift-cards-store/7911490949.html) |
+| $0 | FREE Scrap Electronics for Recycling in Rego Park | zip | Rego Park, Queens | [link](https://newyork.craigslist.org/que/zip/d/rego-park-free-scrap-electronics-for/7918103730.html) |
+| $0 | FREE – Hospital/Adjustable Bed with Mattress – You Haul | zip | New York | [link](https://newyork.craigslist.org/que/zip/d/astoria-free-hospital-adjustable-bed/7938169744.html) |
+| $0 | Two-way (6-part) computer mailers | zip | Fresh Meadows/Jamaica | [link](https://newyork.craigslist.org/que/zip/d/fresh-meadows-two-way-part-computer/7936290839.html) |
+| $0 | UPLIFT Ergonomic Adjustable Keyboard Tray | zip | Astoria | [link](https://newyork.craigslist.org/que/zip/d/astoria-uplift-ergonomic-adjustable/7937925940.html) |
+| $0 | Work or dining tables 72 x 18 Metal Legs - 35 available | zip | woodside | [link](https://newyork.craigslist.org/que/zip/d/woodside-work-or-dining-tables-72-18/7938324717.html) |


### PR DESCRIPTION
## What

Adds `scripts/craigslist_crawl.py` — a crawler for craigslist's Queens subarea (`que`, which covers Flushing), plus an initial snapshot of listings.

It pulls the **server-rendered** static search pages (no JS/API decoding) across a set of for-sale terms, dedupes by posting id, and writes both JSON and a browsable markdown table.

## Default queries ("hardware and other etc")

`hardware`, `tools`, `electronics`, `computer`, `appliances`

## Initial snapshot

**1,421 unique listings** committed to:
- `scripts/craigslist_flushing_listings.json` — full structured data (pid, title, price, location, category, url, matched_query)
- `scripts/craigslist_flushing_listings.md` — sorted markdown table

## Re-run

```bash
python scripts/craigslist_crawl.py                       # default queries
python scripts/craigslist_crawl.py --queries hardware tools
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)