### PR TITLE
Add auth-service: GCP-secrets Robinhood auth + command relay

### DIFF
--- a/auth-service/.gitignore
+++ b/auth-service/.gitignore
@@ -1,0 +1,5 @@
+venv/
+env.prod
+state/
+__pycache__/
+*.pyc

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,142 @@
+# auth-service
+
+A tiny standalone service that authenticates to Robinhood (credentials from GCP
+Secret Manager) and exposes an HTTP surface other services call to run commands
+inside the authenticated session and relay status/error codes.
+
+Lightweight by design (targets an **e2-micro**, 1 GB RAM):
+- Web layer is the Python **stdlib `http.server`** — no Flask/gunicorn.
+- Secrets via the **Secret Manager REST API** + the GCE metadata token — no
+  `google-cloud-secret-manager` gRPC stack.
+- Config is stdlib **`configparser`** — no `python-dotenv`.
+- Two pip deps total: `requests`, `pyotp`.
+
+---
+
+## GCP prerequisites
+
+These must exist **before** deploying. We hit each of these the hard way, so
+they are called out explicitly.
+
+1. **Secret Manager secrets** holding the Robinhood credentials, e.g.
+   `rh-prod-user` (username) and `rh-prod-pass` (password):
+   ```bash
+   printf 'you@example.com' | gcloud secrets create rh-prod-user --data-file=- --project PROJECT
+   printf 'yourpassword'    | gcloud secrets create rh-prod-pass --data-file=- --project PROJECT
+   ```
+   (Optional `rh-prod-totp` if the login uses a TOTP secret.)
+
+2. **Secret Manager API enabled**:
+   ```bash
+   gcloud services enable secretmanager.googleapis.com --project PROJECT
+   ```
+
+3. **VM access scope must include `cloud-platform`.** The legacy default scopes
+   do **not** allow Secret Manager, and the metadata token is scope-limited
+   regardless of IAM — this shows up as a `403` on secret access. Fix (VM must
+   be stopped to change scopes):
+   ```bash
+   gcloud compute instances stop VM --zone ZONE --project PROJECT
+   gcloud compute instances set-service-account VM --zone ZONE --project PROJECT \
+     --service-account SA_EMAIL --scopes cloud-platform
+   gcloud compute instances start VM --zone ZONE --project PROJECT
+   ```
+
+4. **IAM: `secretmanager.secretAccessor` on the VM's service account.** Basic
+   `roles/editor` does **not** grant access to secret payloads. Grant per-secret
+   (least privilege):
+   ```bash
+   for S in rh-prod-user rh-prod-pass; do
+     gcloud secrets add-iam-policy-binding $S --project PROJECT \
+       --member serviceAccount:SA_EMAIL --role roles/secretmanager.secretAccessor
+   done
+   ```
+
+5. **Static external IP.** A changing source IP re-trips Robinhood's device
+   challenge on every login. Pin the VM's IP:
+   ```bash
+   gcloud compute addresses create VM-ip --project PROJECT --region REGION \
+     --addresses $(gcloud compute instances describe VM --zone ZONE --project PROJECT \
+       --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
+   ```
+
+6. **Firewall: keep port 8080 internal.** The server binds `0.0.0.0:8080` and
+   `/exec` runs arbitrary commands — do not expose it to the internet. Reach it
+   over the VPC/SSH only, and set a real `[exec] token` (see below).
+
+---
+
+## Deploy
+
+SSH to the VM, then:
+
+```bash
+# 1. get the code
+git clone https://github.com/IamJasonBian/allocation-engine-2.0.git
+cd allocation-engine-2.0/auth-service      # or curl install.sh (see below)
+
+# 2. venv + deps  (installs python3-venv if missing)
+./install.sh
+
+# 3. configure
+cp env.prod.example env.prod && chmod 600 env.prod
+#   edit env.prod:
+#     [gcp] project_id      = PROJECT   (blank = auto-detect on GCE)
+#     [rh.auth] user/pass   = secret NAMES (rh-prod-user / rh-prod-pass)
+#     [rh.auth] device      = a fixed UUID (pin it once approved, keeps device stable)
+#     [exec] token          = a strong bearer token for privileged endpoints
+
+# 4. install + start the systemd service
+sed "s#__INSTALL_DIR__#$PWD#g; s#__USER__#$USER#g" auth-service.service \
+  | sudo tee /etc/systemd/system/auth-service.service >/dev/null
+sudo systemctl daemon-reload && sudo systemctl enable --now auth-service
+
+# 5. first login — fires a device-approval push; approve it on your phone
+curl -s -X POST localhost:8080/login -H "Authorization: Bearer <exec-token>"
+```
+
+Curl-style install (fetches sources, makes venv, drops an `env.prod`):
+```bash
+curl -fsSL https://raw.githubusercontent.com/IamJasonBian/allocation-engine-2.0/main/auth-service/install.sh | bash
+```
+
+### First-login / device approval
+
+`/login` drives Robinhood's device-approval workflow and **blocks up to ~3 min**
+waiting for you to tap **Approve** in the Robinhood app. Once it succeeds, the
+access + refresh tokens are cached (`state/`, mode 600) and reused; the service
+silently refreshes before expiry, so you should not be prompted again unless the
+whole token chain is invalidated. Keeping the IP and `[rh.auth] device` stable is
+what prevents repeat challenges.
+
+---
+
+## Endpoints
+
+All POSTs and order reads require `Authorization: Bearer <exec-token>`.
+
+| Method | Path                               | Purpose                                   |
+|--------|------------------------------------|-------------------------------------------|
+| GET    | `/health`                          | liveness                                  |
+| GET    | `/auth/status`                     | auth state + error codes (for alerting)   |
+| POST   | `/login`                           | force a real (re)authentication           |
+| POST   | `/command`                         | generic authenticated intake for callers  |
+| GET    | `/orders/trailing_stop`            | active percentage trailing-stop orders    |
+| POST   | `/orders/trailing_stop`            | relay a place payload (`dry_run` default) |
+| POST   | `/orders/trailing_stop/replace`    | relay a replace payload (`dry_run` default)|
+| POST   | `/exec`                            | run an external command                   |
+
+```bash
+curl -s localhost:8080/auth/status -H "Authorization: Bearer <exec-token>"
+```
+
+---
+
+## Operations
+
+- **Logs:** `journalctl -u auth-service -f`
+- **Restart:** `sudo systemctl restart auth-service`
+- **Re-auth after full token loss:** `POST /login` (device push) or
+  `./venv/bin/python reauth_verify.py`
+- **Config path override:** `AUTH_SERVICE_ENV=/path/to/file`; any INI key can be
+  overridden by the matching env var (`GCP_PROJECT_ID`, `EXEC_TOKEN`, …).

--- a/auth-service/auth-service.service
+++ b/auth-service/auth-service.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=auth-service (authenticated command runner)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__USER__
+WorkingDirectory=__INSTALL_DIR__
+ExecStart=__INSTALL_DIR__/venv/bin/python server.py
+Restart=on-failure
+RestartSec=5
+# Light footprint for e2-micro: cap memory so a runaway command can't OOM the box.
+MemoryMax=256M
+
+[Install]
+WantedBy=multi-user.target

--- a/auth-service/config.py
+++ b/auth-service/config.py
@@ -1,0 +1,63 @@
+"""Configuration for the auth-service.
+
+Loaded from an INI file — `env.prod` by default (override with AUTH_SERVICE_ENV).
+Credentials themselves live in GCP Secret Manager; this file holds only the
+project id and the *names* of the secrets. Any value may be overridden by an
+environment variable of the same name as the module attribute below.
+
+Uses stdlib configparser (no python-dotenv) to keep the footprint tiny.
+"""
+
+import configparser
+import os
+from pathlib import Path
+
+_ENV_FILE = os.getenv("AUTH_SERVICE_ENV", "env.prod")
+
+# interpolation=None so '%' in tokens/passwords isn't treated specially.
+_parser = configparser.ConfigParser(interpolation=None)
+_candidate = Path(_ENV_FILE)
+if not _candidate.is_absolute():
+    _candidate = Path(__file__).resolve().parent / _ENV_FILE
+if _candidate.exists():
+    _parser.read(_candidate)
+
+
+def _get(section: str, key: str, default: str = "") -> str:
+    return _parser.get(section, key, fallback=default)
+
+
+# --- GCP ---
+GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID", _get("gcp", "project_id"))
+
+# --- [rh.auth] Robinhood login — values are GCP Secret Manager secret names ---
+SECRET_USERNAME = os.getenv("SECRET_USERNAME", _get("rh.auth", "user"))
+SECRET_PASSWORD = os.getenv("SECRET_PASSWORD", _get("rh.auth", "pass"))
+SECRET_TOTP = os.getenv("SECRET_TOTP", _get("rh.auth", "totp"))
+
+# Stable device identity. Pinning the approved device token keeps Robinhood from
+# treating us as a new device (which re-triggers approval) even if the session
+# cache is wiped. If unset, a token is minted on first login and cached.
+RH_DEVICE_TOKEN = os.getenv("RH_DEVICE_TOKEN", _get("rh.auth", "device"))
+
+# --- Login flow ---
+LOGIN_URL = os.getenv("LOGIN_URL", _get("login", "url"))
+
+# --- /exec endpoint ---
+EXEC_TOKEN = os.getenv("EXEC_TOKEN", _get("exec", "token"))
+EXEC_TOKEN_SECRET = os.getenv("EXEC_TOKEN_SECRET", _get("exec", "token_secret"))
+EXEC_TIMEOUT_SECONDS = int(os.getenv("EXEC_TIMEOUT_SECONDS", _get("exec", "timeout_seconds", "60")))
+EXEC_REQUIRE_AUTH = os.getenv(
+    "EXEC_REQUIRE_AUTH", _get("exec", "require_auth", "true")
+).lower() == "true"
+
+# --- Server ---
+PORT = int(os.getenv("PORT", _get("server", "port", "8080")))
+DEBUG = os.getenv("FLASK_DEBUG", _get("server", "debug", "false")).lower() == "true"
+
+# --- Session state (token cache on disk) ---
+DEFAULT_PROFILE = os.getenv("DEFAULT_PROFILE", _get("rh.auth", "profile", "rh.auth"))
+STATE_DIR = os.getenv(
+    "STATE_DIR",
+    _get("server", "state_dir", str(Path(__file__).resolve().parent / "state")),
+)

--- a/auth-service/dryrun.py
+++ b/auth-service/dryrun.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""End-to-end dry run — confirms the whole flow against LIVE Robinhood.
+
+Steps:
+  1. Secret Manager -> frozen Credentials (never printed)
+  2. authenticate() -> Session  (you approve the push on your device)
+  3. read active percentage trailing-stop orders (READ-ONLY)
+  4. build a place + replace payload in DRY-RUN mode (NOTHING is submitted)
+
+No order is ever POSTed. Run on the box:  ./venv/bin/python dryrun.py
+"""
+
+import json
+import logging
+
+import os
+
+import config
+import robinhood
+import session as session_mgr
+
+# INFO by default so raw API bodies (which include the access token on the
+# successful oauth2/token response) are NOT dumped. DRYRUN_DEBUG=1 for verbose
+# diagnosis — safe to use while auth is still failing (no token issued yet).
+_level = logging.DEBUG if os.getenv("DRYRUN_DEBUG") else logging.INFO
+logging.basicConfig(level=_level,
+                    format="%(asctime)s %(levelname)-7s %(name)s  %(message)s",
+                    datefmt="%H:%M:%S")
+log = logging.getLogger("dryrun")
+
+
+def main():
+    profile = config.DEFAULT_PROFILE
+    print(f"\n=== 1. credentials from Secret Manager (project={config.GCP_PROJECT_ID}) ===")
+    creds = session_mgr.load_credentials(profile)
+    print(f"  loaded: {creds!r}")          # __repr__ masks the secrets
+    print(f"  device_token: {creds.device_token}")
+
+    print("\n=== 2. authenticate (approve the push on your device) ===")
+    deadline = int(os.getenv("DEADLINE", "150"))
+    result = robinhood.authenticate(creds, approval_deadline=deadline)
+    print(f"  status={result.status} error_code={result.error_code} detail={result.detail}")
+    if result.status != "OK" or result.session is None:
+        print("  >>> auth did not complete; stopping.")
+        return
+    session = result.session
+    session_mgr.save(profile, session)
+    print(f"  session: {session!r}")
+    print(f"  account_url: {session.account_url}")
+
+    print("\n=== 3. active percentage trailing-stop orders (read-only) ===")
+    orders = robinhood.get_trailing_stop_orders(session)
+    print(f"  found {len(orders)} active percentage trailing-stop order(s)")
+    for o in orders:
+        print(json.dumps({
+            "id": o.get("id"),
+            "state": o.get("state"),
+            "side": o.get("side"),
+            "trigger": o.get("trigger"),
+            "trailing_peg": o.get("trailing_peg"),
+            "stop_price": o.get("stop_price"),
+            "instrument": o.get("instrument"),
+        }, indent=2))
+
+    print("\n=== 4. place/replace payload (DRY RUN — nothing submitted) ===")
+    sample = orders[0] if orders else None
+    instrument = sample["instrument"] if sample else "https://api.robinhood.com/instruments/<UUID>/"
+    symbol = sample.get("symbol", "<SYMBOL>") if sample else "<SYMBOL>"
+    place = robinhood.place_trailing_stop(
+        session,
+        robinhood.build_trailing_stop_payload(
+            account_url=session.account_url, instrument_url=instrument,
+            symbol=symbol, side="sell", quantity="1", trail_percent="5.00"),
+        dry_run=True)
+    print("  PLACE:")
+    print(json.dumps(place, indent=2))
+    if sample:
+        replace = robinhood.replace_trailing_stop(
+            session, sample["id"],
+            robinhood.build_trailing_stop_payload(
+                account_url=session.account_url, instrument_url=instrument,
+                symbol=symbol, side=sample.get("side", "sell"),
+                quantity=sample.get("quantity", "1"), trail_percent="6.00"),
+            dry_run=True)
+        print("  REPLACE:")
+        print(json.dumps(replace, indent=2))
+
+    print("\n=== done — auth + read confirmed live; place/replace shown as dry-run ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/auth-service/env.prod.example
+++ b/auth-service/env.prod.example
@@ -1,0 +1,29 @@
+# auth-service config (INI). Copy to env.prod and fill in.
+# Credentials live in GCP Secret Manager — this file holds only the project id
+# and the *names* of the secrets.
+
+[gcp]
+# Blank on GCE = auto-detect from the metadata server.
+project_id = route-manager-prod
+
+# [rh.auth] — Robinhood login. Values are Secret Manager secret NAMES, not the
+# credentials themselves.
+[rh.auth]
+user = rh-prod-user
+pass = rh-prod-pass
+totp =              ; optional: name of a base32 TOTP secret (2FA logins)
+device =            ; stable device-token UUID (pin the approved one so it never changes)
+
+[login]
+url =               ; form-login endpoint for the default provider
+
+[exec]
+# Provide EITHER a literal token OR a Secret Manager name to resolve it from.
+token = change-me
+token_secret =
+timeout_seconds = 60
+require_auth = true  ; /exec only runs after a successful /login
+
+[server]
+port = 8080
+debug = false

--- a/auth-service/gcp_secrets.py
+++ b/auth-service/gcp_secrets.py
@@ -1,0 +1,66 @@
+"""GCP Secret Manager access over the REST API.
+
+We avoid the google-cloud-secret-manager client library on purpose: it pulls in
+grpc + protobuf (100 MB+ resident), which is wasteful on an e2-micro. Instead we
+grab an OAuth token from the GCE metadata server and call the Secret Manager
+REST endpoint directly with `requests`.
+
+Locally (off-GCE), set GOOGLE_ACCESS_TOKEN (e.g. `gcloud auth print-access-token`)
+and the metadata path is skipped.
+"""
+
+import base64
+import os
+
+import requests
+
+_METADATA_TOKEN_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/"
+    "instance/service-accounts/default/token"
+)
+_METADATA_PROJECT_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/project/project-id"
+)
+_METADATA_HEADERS = {"Metadata-Flavor": "Google"}
+
+
+def _access_token() -> str:
+    """OAuth access token: env override first, else the metadata server."""
+    override = os.getenv("GOOGLE_ACCESS_TOKEN")
+    if override:
+        return override
+    resp = requests.get(_METADATA_TOKEN_URL, headers=_METADATA_HEADERS, timeout=5)
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def _project_id(explicit: str = "") -> str:
+    """Project id from config, else discovered from the metadata server."""
+    if explicit:
+        return explicit
+    resp = requests.get(_METADATA_PROJECT_URL, headers=_METADATA_HEADERS, timeout=5)
+    resp.raise_for_status()
+    return resp.text
+
+
+def get_secret(name: str, project_id: str = "", version: str = "latest") -> str:
+    """Return the decoded payload of a Secret Manager secret.
+
+    `name` may be a bare secret id ("auth-service-password") or a full resource
+    name ("projects/123/secrets/foo/versions/latest").
+    """
+    if name.startswith("projects/"):
+        resource = name if "/versions/" in name else f"{name}/versions/{version}"
+    else:
+        project = _project_id(project_id)
+        resource = f"projects/{project}/secrets/{name}/versions/{version}"
+
+    url = f"https://secretmanager.googleapis.com/v1/{resource}:access"
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {_access_token()}"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    payload = resp.json()["payload"]["data"]
+    return base64.b64decode(payload).decode("utf-8")

--- a/auth-service/gen_token.py
+++ b/auth-service/gen_token.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Generate a request token for authenticating inbound calls.
+
+Prints one cryptographically-strong bearer token. Set it as `[exec] token` in
+env.prod; callers then send `Authorization: Bearer <token>` on privileged
+endpoints (/login, /command, /orders/*, /exec). Rarely run — only to provision
+or rotate the inbound auth token.
+
+    ./venv/bin/python gen_token.py
+"""
+
+import secrets
+
+if __name__ == "__main__":
+    print(secrets.token_urlsafe(32))

--- a/auth-service/install.sh
+++ b/auth-service/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Standalone installer for auth-service. Designed for a fresh e2-micro.
+#
+#   curl -fsSL https://raw.githubusercontent.com/IamJasonBian/allocation-engine-2.0/main/auth-service/install.sh | bash
+#
+# What it does (all idempotent):
+#   1. Ensures python3 + venv are present.
+#   2. Fetches the auth-service sources (skipped if run from inside the folder).
+#   3. Creates a venv and installs the tiny requirements set.
+#   4. Writes a .env from the template if one does not exist.
+#   5. Prints how to run it (foreground) or install the systemd unit.
+#
+# Env knobs:
+#   INSTALL_DIR   where to install (default: ~/auth-service)
+#   REPO_RAW_BASE raw base URL to fetch sources from when piped via curl
+#
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/auth-service}"
+REPO_RAW_BASE="${REPO_RAW_BASE:-https://raw.githubusercontent.com/IamJasonBian/allocation-engine-2.0/main/auth-service}"
+FILES="config.py gcp_secrets.py auth.py runner.py server.py requirements.txt env.prod.example auth-service.service"
+
+log() { printf '\033[1;32m[install]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[install]\033[0m %s\n' "$*" >&2; }
+
+# --- 1. python3 ---
+if ! command -v python3 >/dev/null 2>&1; then
+  err "python3 not found. On Debian/Ubuntu: sudo apt-get install -y python3 python3-venv"
+  exit 1
+fi
+
+# --- 2. sources ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/server.py" ]; then
+  # Running from inside a checked-out copy — install in place.
+  INSTALL_DIR="$SCRIPT_DIR"
+  log "Using sources in $INSTALL_DIR"
+else
+  log "Fetching sources into $INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR"
+  for f in $FILES; do
+    curl -fsSL "$REPO_RAW_BASE/$f" -o "$INSTALL_DIR/$f"
+  done
+fi
+
+cd "$INSTALL_DIR"
+
+# --- 3. venv + deps ---
+if [ ! -d venv ]; then
+  log "Creating virtualenv"
+  python3 -m venv venv
+fi
+log "Installing requirements"
+./venv/bin/pip install --quiet --upgrade pip
+./venv/bin/pip install --quiet -r requirements.txt
+
+# --- 4. .env ---
+if [ ! -f env.prod ]; then
+  cp env.prod.example env.prod
+  log "Wrote env.prod (edit it: set [gcp] project_id, [login] url, [exec] token, secret names)"
+else
+  log "env.prod already exists — leaving it untouched"
+fi
+
+# --- 5. next steps ---
+cat <<EOF
+
+$(log "Done.")
+Run in the foreground:
+    cd $INSTALL_DIR && ./venv/bin/python server.py
+
+Install as a systemd service (auto-restart on boot):
+    sed "s#__INSTALL_DIR__#$INSTALL_DIR#g; s#__USER__#$USER#g" $INSTALL_DIR/auth-service.service \\
+      | sudo tee /etc/systemd/system/auth-service.service >/dev/null
+    sudo systemctl daemon-reload && sudo systemctl enable --now auth-service
+
+EOF

--- a/auth-service/models.py
+++ b/auth-service/models.py
@@ -1,0 +1,65 @@
+"""Immutable value objects for the auth-service.
+
+Everything the login flow produces is a frozen dataclass — credentials pulled
+from Secret Manager and the resulting Robinhood session are both immutable once
+constructed, so nothing downstream can mutate a token or password in place.
+"""
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True, slots=True)
+class Credentials:
+    """Secrets fetched from GCP Secret Manager (never logged)."""
+
+    username: str
+    password: str
+    totp_secret: str | None = None   # base32; optional
+    device_token: str | None = None  # stable per-device UUID
+
+    def __repr__(self) -> str:  # keep secrets out of logs/tracebacks
+        return f"Credentials(username={self.username!r}, password=***, totp=***)"
+
+
+@dataclass(frozen=True, slots=True)
+class Session:
+    """An authenticated Robinhood session."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str          # "Bearer"
+    expires_at: float        # epoch seconds
+    device_token: str
+    account_url: str = ""
+    account_number: str = ""
+
+    def headers(self) -> dict:
+        """Headers to pass to https://api.robinhood.com/."""
+        return {
+            "Authorization": f"{self.token_type} {self.access_token}",
+            "Accept": "application/json",
+        }
+
+    def with_account(self, account_url: str, account_number: str) -> "Session":
+        return replace(self, account_url=account_url, account_number=account_number)
+
+    def __repr__(self) -> str:
+        return (
+            f"Session(token_type={self.token_type!r}, access_token=***, "
+            f"expires_at={self.expires_at}, account_number={self.account_number!r})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AuthResult:
+    """Outcome of an auth attempt — relayed to callers for alerting.
+
+    status is one of: OK, NEEDS_APPROVAL, MFA_REQUIRED, TIMEOUT, ERROR.
+    error_code is a stable machine string; detail is human-readable.
+    """
+
+    status: str
+    session: Session | None = None
+    approval_id: str | None = None
+    error_code: str | None = None
+    detail: str = ""

--- a/auth-service/reauth_verify.py
+++ b/auth-service/reauth_verify.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Clean re-login + prove the production token-reuse loop end-to-end.
+
+  1. full login (device push — approve on your phone)  -> save
+  2. refresh (spend refresh token, save the ROTATED one)
+  3. refresh AGAIN using the rotated token (proves the save-on-rotate loop)
+  4. live /accounts/ call with the final token (proves it actually works)
+
+Leaves a valid, reusable session on disk. INFO level (no token dumps).
+"""
+
+import logging
+import time
+
+import config
+import robinhood
+import session as sm
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(levelname)-7s %(name)s  %(message)s",
+                    datefmt="%H:%M:%S")
+
+
+def main():
+    profile = config.DEFAULT_PROFILE
+    creds = sm.load_credentials(profile)
+
+    print("\n=== 1. full login (approve the push on your phone) ===")
+    r = robinhood.authenticate(creds, approval_deadline=150)
+    print(f"  login: {r.status} {r.error_code or ''}")
+    if r.status != "OK":
+        print("  >>> login failed; stopping.")
+        return
+    sm.save(profile, r.session)
+    a0 = r.session.access_token
+
+    print("\n=== 2. refresh -> save rotated token ===")
+    r1 = robinhood.refresh(sm.load(profile))
+    print(f"  refresh#1: {r1.status} {r1.error_code or ''}; new access differs: "
+          f"{r1.session.access_token != a0 if r1.session else 'n/a'}")
+    if r1.status != "OK":
+        print("  >>> refresh#1 failed; stopping."); return
+    sm.save(profile, r1.session)
+
+    print("\n=== 3. refresh AGAIN with the rotated token (the real reuse loop) ===")
+    r2 = robinhood.refresh(sm.load(profile))
+    print(f"  refresh#2: {r2.status} {r2.error_code or ''}; new access differs: "
+          f"{r2.session.access_token != r1.session.access_token if r2.session else 'n/a'}")
+    if r2.status != "OK":
+        print("  >>> refresh#2 failed; stopping."); return
+    sm.save(profile, r2.session)
+
+    print("\n=== 4. live /accounts/ with the final token ===")
+    acct = robinhood.get_account(sm.load(profile))
+    print(f"  live account: {acct.get('account_number')}")
+
+    print("\n=== token-reuse loop verified; clean session saved ===")
+    print(f"  status(): {sm.status(profile)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/auth-service/requirements.txt
+++ b/auth-service/requirements.txt
@@ -1,0 +1,6 @@
+# Deliberately tiny — targets an e2-micro (1 GB RAM).
+# Web layer is Python stdlib (http.server); no Flask/gunicorn.
+# Secrets use the Secret Manager REST API; no google-cloud gRPC client.
+# Config is stdlib configparser; no python-dotenv.
+requests>=2.31.0        # login flow + Secret Manager REST calls
+pyotp>=2.9.0            # optional TOTP for 2FA logins

--- a/auth-service/robinhood.py
+++ b/auth-service/robinhood.py
@@ -1,0 +1,363 @@
+"""Robinhood API client — auth flow + percentage trailing-stop orders.
+
+Scope is deliberately narrow (per the service's mandate):
+  * authenticate (password grant + device-approval / MFA)
+  * read active percentage trailing-stop orders
+  * place / replace percentage trailing-stop orders
+
+The exact request/response shapes are modelled on robin_stocks, which may be
+stale — so every network step logs its raw JSON (truncated) at DEBUG so we can
+confirm against the live API and adjust. Nothing here mutates account state
+unless dry_run=False is passed explicitly.
+"""
+
+import json
+import logging
+import time
+import uuid
+
+import pyotp
+import requests
+
+from models import AuthResult, Credentials, Session
+
+log = logging.getLogger("robinhood")
+
+BASE = "https://api.robinhood.com"
+# Robinhood's long-standing public OAuth client id (same one robin_stocks uses).
+CLIENT_ID = "c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS"
+
+_BASE_HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "User-Agent": "auth-service/1.0 (+robinhood)",
+    "X-Robinhood-API-Version": "1.431.4",
+}
+
+ACTIVE_STATES = {"queued", "confirmed", "unconfirmed", "partially_filled"}
+
+
+_SENSITIVE = {
+    "access_token", "refresh_token", "password", "mfa_code", "backup_code",
+    "read_only_secondary_access_token", "device_token", "bearer_token",
+}
+
+
+def _redact(obj):
+    if isinstance(obj, dict):
+        return {k: ("***" if k in _SENSITIVE else _redact(v)) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact(x) for x in obj]
+    return obj
+
+
+def _dump(label: str, resp: requests.Response) -> dict:
+    """Log a truncated, token-redacted raw response and return parsed JSON."""
+    try:
+        data = resp.json()
+    except ValueError:
+        log.debug("%s -> HTTP %s: %s", label, resp.status_code, (resp.text or "")[:800])
+        return {}
+    log.debug("%s -> HTTP %s: %s", label, resp.status_code,
+              json.dumps(_redact(data))[:1000])
+    return data
+
+
+def _new_session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update(_BASE_HEADERS)
+    return s
+
+
+# --------------------------------------------------------------------------- #
+# token validity
+# --------------------------------------------------------------------------- #
+
+def check_token_valid(session: Session | None, skew: int = 60, verify: bool = False) -> bool:
+    """True if `session` looks usable.
+
+    Local expiry check by default (fast). With verify=True, also confirms the
+    token against the live API (GET /user/), which is the real "is the token on
+    the device still good" test.
+    """
+    if session is None or not session.access_token:
+        return False
+    if session.expires_at and session.expires_at - skew <= time.time():
+        return False
+    if not verify:
+        return True
+    try:
+        s = _new_session()
+        s.headers.update(session.headers())
+        r = s.get(f"{BASE}/user/", timeout=10)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# auth flow
+# --------------------------------------------------------------------------- #
+
+def authenticate(creds: Credentials, http_timeout: int = 10,
+                 approval_deadline: int = 90) -> AuthResult:
+    """Full password-grant flow, handling device-approval + MFA.
+
+    Returns an AuthResult; on success .session is a frozen Session. Errors carry
+    a stable error_code so callers can alert a human.
+    """
+    device_token = creds.device_token or str(uuid.uuid4())
+    http = _new_session()
+    payload = {
+        "client_id": CLIENT_ID,
+        "expires_in": 86400,
+        "grant_type": "password",
+        "password": creds.password,
+        "scope": "internal",
+        "username": creds.username,
+        "device_token": device_token,
+        "try_passkeys": False,
+        "token_request_path": "/login",
+        "create_read_only_secondary_token": True,
+    }
+    if creds.totp_secret:
+        payload["mfa_code"] = pyotp.TOTP(creds.totp_secret).now()
+
+    try:
+        resp = http.post(f"{BASE}/oauth2/token/", json=payload, timeout=http_timeout)
+    except requests.Timeout:
+        return AuthResult("TIMEOUT", error_code="LOGIN_HTTP_TIMEOUT",
+                          detail=f"oauth2/token timed out after {http_timeout}s")
+    except requests.RequestException as e:
+        return AuthResult("ERROR", error_code="LOGIN_HTTP_ERROR", detail=str(e))
+
+    data = _dump("oauth2/token", resp)
+
+    # Device-approval workflow (the "approve on your phone" path).
+    if data.get("verification_workflow"):
+        workflow_id = data["verification_workflow"]["id"]
+        approved = mfa_flow(http, device_token, workflow_id, deadline=approval_deadline)
+        if not approved.ok:
+            return AuthResult(approved.status, error_code=approved.error_code,
+                              detail=approved.detail, approval_id=workflow_id)
+        # Retry the token request now that the challenge is satisfied.
+        try:
+            resp = http.post(f"{BASE}/oauth2/token/", json=payload, timeout=http_timeout)
+        except requests.RequestException as e:
+            return AuthResult("ERROR", error_code="LOGIN_RETRY_ERROR", detail=str(e))
+        data = _dump("oauth2/token (retry)", resp)
+
+    # Classic TOTP/SMS MFA (only if no TOTP secret was configured).
+    if data.get("mfa_required"):
+        return AuthResult("MFA_REQUIRED", error_code="MFA_CODE_REQUIRED",
+                          detail=f"mfa_type={data.get('mfa_type')}")
+
+    access = data.get("access_token")
+    if not access:
+        return AuthResult("ERROR", error_code="LOGIN_NO_TOKEN",
+                          detail=json.dumps(data)[:300])
+
+    session = Session(
+        access_token=access,
+        refresh_token=data.get("refresh_token", ""),
+        token_type=data.get("token_type", "Bearer"),
+        expires_at=time.time() + int(data.get("expires_in", 86400)),
+        device_token=device_token,
+    )
+    # Attach the account (needed for order placement).
+    try:
+        acct = get_account(session)
+        session = session.with_account(acct.get("url", ""), acct.get("account_number", ""))
+    except Exception as e:  # noqa: BLE001 — non-fatal, auth still succeeded
+        log.warning("account lookup failed post-login: %s", e)
+
+    return AuthResult("OK", session=session)
+
+
+def refresh(session: Session, http_timeout: int = 10) -> AuthResult:
+    """Renew the access token using the refresh token — no device push.
+
+    This is the token-reuse path: when the cached access token expires we spend
+    the refresh token instead of re-running the full login (which would prompt
+    the human again). Account info carries over unchanged.
+    """
+    if not session.refresh_token:
+        return AuthResult("ERROR", error_code="NO_REFRESH_TOKEN")
+    http = _new_session()
+    payload = {
+        "client_id": CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": session.refresh_token,
+        "scope": "internal",
+        "expires_in": 86400,
+        "device_token": session.device_token,
+    }
+    try:
+        resp = http.post(f"{BASE}/oauth2/token/", json=payload, timeout=http_timeout)
+    except requests.RequestException as e:
+        return AuthResult("ERROR", error_code="REFRESH_HTTP_ERROR", detail=str(e))
+    data = _dump("oauth2/token (refresh)", resp)
+    access = data.get("access_token")
+    if not access:
+        return AuthResult("ERROR", error_code="REFRESH_FAILED",
+                          detail=json.dumps(_redact(data))[:200])
+    new = Session(
+        access_token=access,
+        refresh_token=data.get("refresh_token", session.refresh_token),
+        token_type=data.get("token_type", "Bearer"),
+        expires_at=time.time() + int(data.get("expires_in", 86400)),
+        device_token=session.device_token,
+        account_url=session.account_url,
+        account_number=session.account_number,
+    )
+    return AuthResult("OK", session=new)
+
+
+class _ApprovalOutcome:
+    def __init__(self, ok, status="OK", error_code=None, detail=""):
+        self.ok = ok
+        self.status = status
+        self.error_code = error_code
+        self.detail = detail
+
+
+def mfa_flow(http: requests.Session, device_token: str, workflow_id: str,
+             deadline: int = 90, poll_interval: float = 3.0) -> _ApprovalOutcome:
+    """Drive the pathfinder device-approval challenge to completion.
+
+    Unlike robin_stocks' unbounded `while True`, this honours `deadline` so a
+    never-approved push can't wedge the service (see CLAUDE.md 429 storm note).
+    """
+    try:
+        r = http.post(f"{BASE}/pathfinder/user_machine/", json={
+            "device_id": device_token, "flow": "suv",
+            "input": {"workflow_id": workflow_id},
+        }, timeout=10)
+        machine = _dump("pathfinder/user_machine", r)
+        machine_id = machine.get("id")
+        if not machine_id:
+            return _ApprovalOutcome(False, "ERROR", "APPROVAL_NO_MACHINE_ID",
+                                    json.dumps(machine)[:200])
+
+        view_url = f"{BASE}/pathfinder/inquiries/{machine_id}/user_view/"
+        deadline_ts = time.time() + deadline
+        while time.time() < deadline_ts:
+            v = _dump("inquiries/user_view", http.get(view_url, timeout=10))
+            challenge = (v.get("type_context", {}) or {}).get("context", {}) \
+                         .get("sheriff_challenge", {})
+            ctype = challenge.get("type")
+            status = challenge.get("status")
+
+            if status == "validated":
+                return _ApprovalOutcome(True)
+
+            if ctype == "prompt":
+                # Poll the push-approval status until the user taps Approve.
+                cid = challenge.get("id")
+                status_url = f"{BASE}/push/{cid}/get_prompts_status/"
+                while time.time() < deadline_ts:
+                    ps = _dump("push/get_prompts_status",
+                               http.get(status_url, timeout=10))
+                    if ps.get("challenge_status") == "validated":
+                        # Tell pathfinder the challenge is satisfied.
+                        http.post(view_url, json={"sequence": 0, "user_input": {"status": "continue"}}, timeout=10)
+                        return _ApprovalOutcome(True)
+                    log.info("waiting for device approval… (tap Approve on your phone)")
+                    time.sleep(poll_interval)
+                return _ApprovalOutcome(False, "TIMEOUT", "APPROVAL_TIMEOUT",
+                                        "device push not approved before deadline")
+
+            if ctype in ("sms", "email"):
+                return _ApprovalOutcome(False, "MFA_REQUIRED", "MFA_CODE_REQUIRED",
+                                        f"challenge type {ctype} requires a code")
+            time.sleep(poll_interval)
+
+        return _ApprovalOutcome(False, "TIMEOUT", "APPROVAL_TIMEOUT",
+                                "no challenge resolution before deadline")
+    except requests.RequestException as e:
+        return _ApprovalOutcome(False, "ERROR", "APPROVAL_HTTP_ERROR", str(e))
+
+
+# --------------------------------------------------------------------------- #
+# account + orders
+# --------------------------------------------------------------------------- #
+
+def get_account(session: Session) -> dict:
+    http = _new_session()
+    http.headers.update(session.headers())
+    r = http.get(f"{BASE}/accounts/", timeout=10)
+    data = _dump("accounts", r)
+    results = data.get("results", [])
+    if not results:
+        raise RuntimeError("no accounts returned")
+    return results[0]
+
+
+def get_trailing_stop_orders(session: Session, only_percentage: bool = True) -> list[dict]:
+    """Return active trailing-stop orders (percentage type by default)."""
+    http = _new_session()
+    http.headers.update(session.headers())
+    orders, url = [], f"{BASE}/orders/"
+    while url:
+        data = _dump("orders", http.get(url, timeout=15))
+        orders.extend(data.get("results", []))
+        url = data.get("next")
+
+    out = []
+    for o in orders:
+        if o.get("state") not in ACTIVE_STATES:
+            continue
+        if o.get("trigger") != "stop":
+            continue
+        peg = o.get("trailing_peg") or {}
+        # Read is tolerant: if the live shape differs we still surface the order.
+        if only_percentage and peg.get("type") not in (None, "percentage"):
+            continue
+        out.append(o)
+    return out
+
+
+def build_trailing_stop_payload(*, account_url: str, instrument_url: str, symbol: str,
+                                side: str, quantity, trail_percent, stop_price=None,
+                                time_in_force: str = "gtc") -> dict:
+    """Construct a percentage trailing-stop order payload.
+
+    Uses the `trailing_peg` shape (robin_stocks). We confirm this against a live
+    read before ever POSTing — see get_trailing_stop_orders.
+    """
+    payload = {
+        "account": account_url,
+        "instrument": instrument_url,
+        "symbol": symbol,
+        "type": "market",
+        "time_in_force": time_in_force,
+        "trigger": "stop",
+        "side": side,
+        "quantity": str(quantity),
+        "trailing_peg": {"type": "percentage", "percentage": str(trail_percent)},
+        "ref_id": str(uuid.uuid4()),
+    }
+    if stop_price is not None:
+        payload["stop_price"] = str(stop_price)
+    return payload
+
+
+def place_trailing_stop(session: Session, payload: dict, dry_run: bool = True) -> dict:
+    if dry_run:
+        log.info("[dry_run] would POST %s/orders/ %s", BASE, json.dumps(payload))
+        return {"dry_run": True, "method": "POST", "url": f"{BASE}/orders/", "payload": payload}
+    http = _new_session()
+    http.headers.update(session.headers())
+    return _dump("orders (place)", http.post(f"{BASE}/orders/", json=payload, timeout=15))
+
+
+def replace_trailing_stop(session: Session, order_id: str, payload: dict,
+                          dry_run: bool = True) -> dict:
+    """Replace an existing order via Robinhood's replace endpoint."""
+    url = f"{BASE}/orders/{order_id}/replace/"
+    if dry_run:
+        log.info("[dry_run] would POST %s %s", url, json.dumps(payload))
+        return {"dry_run": True, "method": "POST", "url": url, "payload": payload}
+    http = _new_session()
+    http.headers.update(session.headers())
+    return _dump("orders (replace)", http.post(url, json=payload, timeout=15))

--- a/auth-service/runner.py
+++ b/auth-service/runner.py
@@ -1,0 +1,54 @@
+"""Run external commands and capture their results.
+
+Commands run as the service user, in the authenticated context of the process
+(the login session is already established when EXEC_REQUIRE_AUTH is on). Output
+is captured and returned structurally so the caller can inspect it.
+"""
+
+import logging
+import shlex
+import subprocess
+
+import config
+
+log = logging.getLogger("runner")
+
+
+def run_command(command, cwd: str | None = None) -> dict:
+    """Execute `command` and return {exit_code, stdout, stderr, timed_out}.
+
+    `command` may be a string (parsed with shlex) or an argv list. A list is
+    passed straight to subprocess (no shell), which is the safer form.
+    """
+    if isinstance(command, str):
+        argv = shlex.split(command)
+    elif isinstance(command, list):
+        argv = command
+    else:
+        raise ValueError("command must be a string or a list of strings")
+
+    if not argv:
+        raise ValueError("command is empty")
+
+    log.info("exec: %s", argv)
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=config.EXEC_TIMEOUT_SECONDS,
+        )
+        return {
+            "exit_code": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "timed_out": False,
+        }
+    except subprocess.TimeoutExpired as e:
+        return {
+            "exit_code": None,
+            "stdout": e.stdout or "",
+            "stderr": (e.stderr or "") + "\n[timed out]",
+            "timed_out": True,
+        }

--- a/auth-service/server.py
+++ b/auth-service/server.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Lightweight auth-service HTTP server (stdlib only, no Flask).
+
+Other services call this box to (a) confirm we're authenticated and (b) act on
+percentage trailing-stop orders inside the authenticated Robinhood session.
+
+Endpoints (all POSTs and order reads require Bearer EXEC_TOKEN):
+  GET  /health                        — liveness
+  GET  /auth/status                   — auth state + error codes (for alerting)
+  POST /login                         — trigger the login flow (device approval)
+  GET  /orders/trailing_stop          — active percentage trailing-stop orders
+  POST /orders/trailing_stop          — place one (dry_run defaults to true)
+  POST /orders/trailing_stop/replace  — replace one (dry_run defaults to true)
+  POST /exec                          — run an external command
+
+Threaded server; single process; tiny footprint (e2-micro friendly).
+"""
+
+import hmac
+import json
+import logging
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import config
+import robinhood
+import session as session_mgr
+from gcp_secrets import get_secret
+from runner import run_command
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("server")
+
+
+def _notify_approval(profile_id: str):
+    log.warning("*** DEVICE APPROVAL NEEDED for %s — approve the push on your phone ***",
+                profile_id)
+
+
+session_mgr.on_approval_needed = _notify_approval
+
+
+def _exec_token() -> str:
+    if config.EXEC_TOKEN_SECRET:
+        return get_secret(config.EXEC_TOKEN_SECRET, config.GCP_PROJECT_ID)
+    return config.EXEC_TOKEN
+
+
+def _ensure_session(profile_id: str):
+    """Return (session, error_response|None). Relays error codes to the caller."""
+    result = session_mgr.get_session(profile_id)
+    if result.status == "OK" and result.session is not None:
+        return result.session, None
+    return None, {
+        "authenticated": False,
+        "status": result.status,
+        "error_code": result.error_code,
+        "detail": result.detail,
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "auth-service/1.0"
+
+    # -- helpers --
+
+    def _send(self, code: int, body: dict):
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _read_json(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        if not length:
+            return {}
+        return json.loads(self.rfile.read(length) or b"{}")
+
+    def _authorized(self) -> bool:
+        expected = _exec_token()
+        if not expected:
+            log.warning("EXEC_TOKEN not configured — refusing privileged call")
+            return False
+        header = self.headers.get("Authorization", "")
+        prefix = "Bearer "
+        if not header.startswith(prefix):
+            return False
+        return hmac.compare_digest(header[len(prefix):], expected)
+
+    def _profile(self, body: dict | None = None) -> str:
+        if body and body.get("profile"):
+            return body["profile"]
+        return config.DEFAULT_PROFILE
+
+    def log_message(self, fmt, *args):
+        log.info("%s - %s", self.address_string(), fmt % args)
+
+    # -- routing --
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._send(200, {"status": "ok", "service": "auth-service"})
+        elif self.path == "/auth/status":
+            self._send(200, session_mgr.status(config.DEFAULT_PROFILE))
+        elif self.path.rstrip("/") == "/orders/trailing_stop":
+            self._handle_read_orders()
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        route = self.path.rstrip("/")
+        if route == "/login":
+            self._handle_login()
+        elif route == "/orders/trailing_stop":
+            self._handle_place()
+        elif route == "/orders/trailing_stop/replace":
+            self._handle_replace()
+        elif route == "/command":
+            self._handle_command()
+        elif route == "/exec":
+            self._handle_exec()
+        else:
+            self._send(404, {"error": "not found"})
+
+    # -- handlers --
+
+    def _handle_login(self):
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        result = session_mgr.get_session(config.DEFAULT_PROFILE, force=True)
+        code = 200 if result.status == "OK" else 502
+        self._send(code, {
+            "status": result.status,
+            "error_code": result.error_code,
+            "detail": result.detail,
+            **session_mgr.status(config.DEFAULT_PROFILE),
+        })
+
+    def _handle_read_orders(self):
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        sess, err = _ensure_session(config.DEFAULT_PROFILE)
+        if err:
+            self._send(409, err)
+            return
+        try:
+            orders = robinhood.get_trailing_stop_orders(sess)
+            self._send(200, {"count": len(orders), "orders": orders})
+        except Exception as e:  # noqa: BLE001
+            log.exception("read orders failed")
+            self._send(502, {"error_code": "READ_ORDERS_FAILED", "detail": str(e)})
+
+    def _handle_place(self):
+        # The order payload is built elsewhere; we authenticate, relay it to
+        # Robinhood, and return the resulting status/codes. dry_run defaults true.
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        try:
+            body = self._read_json()
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON body"})
+            return
+        payload = body.get("payload")
+        if not isinstance(payload, dict):
+            self._send(400, {"error": "missing 'payload' object"})
+            return
+        sess, err = _ensure_session(self._profile(body))
+        if err:
+            self._send(409, err)
+            return
+        try:
+            result = robinhood.place_trailing_stop(
+                sess, payload, dry_run=body.get("dry_run", True))
+            self._send(200, result)
+        except Exception as e:  # noqa: BLE001
+            log.exception("place failed")
+            self._send(502, {"error_code": "PLACE_FAILED", "detail": str(e)})
+
+    def _handle_replace(self):
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        try:
+            body = self._read_json()
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON body"})
+            return
+        payload = body.get("payload")
+        if not isinstance(payload, dict) or not body.get("order_id"):
+            self._send(400, {"error": "need 'order_id' and 'payload' object"})
+            return
+        sess, err = _ensure_session(self._profile(body))
+        if err:
+            self._send(409, err)
+            return
+        try:
+            result = robinhood.replace_trailing_stop(
+                sess, body["order_id"], payload, dry_run=body.get("dry_run", True))
+            self._send(200, result)
+        except Exception as e:  # noqa: BLE001
+            log.exception("replace failed")
+            self._send(502, {"error_code": "REPLACE_FAILED", "detail": str(e)})
+
+    def _handle_command(self):
+        # Generic authenticated intake for other services. For now we validate
+        # the caller + confirm an authenticated session and relay the result
+        # codes; real per-action dispatch is added later.
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        try:
+            body = self._read_json()
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON body"})
+            return
+        action = body.get("action")
+        if not action:
+            self._send(400, {"error": "missing 'action'"})
+            return
+        sess, err = _ensure_session(self._profile(body))
+        if err:
+            self._send(409, err)
+            return
+        self._send(200, {
+            "accepted": True,
+            "action": action,
+            "authenticated": True,
+            "account_number": sess.account_number,
+        })
+
+    def _handle_exec(self):
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        if config.EXEC_REQUIRE_AUTH:
+            _, err = _ensure_session(config.DEFAULT_PROFILE)
+            if err:
+                self._send(409, err)
+                return
+        try:
+            body = self._read_json()
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON body"})
+            return
+        command = body.get("command")
+        if not command:
+            self._send(400, {"error": "missing 'command'"})
+            return
+        try:
+            self._send(200, run_command(command, cwd=body.get("cwd")))
+        except ValueError as e:
+            self._send(400, {"error": str(e)})
+        except Exception as e:  # noqa: BLE001
+            log.exception("exec failed")
+            self._send(500, {"error": str(e)})
+
+
+def main():
+    server = ThreadingHTTPServer(("0.0.0.0", config.PORT), Handler)
+    log.info("auth-service listening on :%d", config.PORT)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("shutting down")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/auth-service/session.py
+++ b/auth-service/session.py
@@ -1,0 +1,199 @@
+"""Session manager — the concurrency-safe front door other services hit.
+
+Implements the semantics from the design sketch, with threads instead of
+asyncio (the server is a stdlib threaded http.server, so a Future-based
+in-flight map is lighter than bolting on an event loop):
+
+    get_session(profile_id):
+        1. load persisted state; if the token is still valid, return it
+        2. otherwise start (or join) a single in-flight auth for that profile
+        3. caller-side timeout protects the whole wait
+
+Three timeouts, mirroring the sketch:
+    * caller-side       — CALLER_TIMEOUT (100s), on the whole get_session wait
+    * login HTTP        — LOGIN_HTTP_TIMEOUT (10s), on each oauth2/token POST
+    * approval deadline — APPROVAL_DEADLINE (90s), on the device-push wait
+"""
+
+import json
+import logging
+import threading
+import time
+import uuid
+from concurrent.futures import Future, TimeoutError as FutureTimeout
+from dataclasses import asdict
+from pathlib import Path
+
+import config
+import robinhood
+from gcp_secrets import get_secret
+from models import AuthResult, Credentials, Session
+
+log = logging.getLogger("session")
+
+CALLER_TIMEOUT = 200
+LOGIN_HTTP_TIMEOUT = 10
+APPROVAL_DEADLINE = 180
+
+_STATE_DIR = Path(config.STATE_DIR)
+_lock = threading.Lock()
+_inflight: dict[str, Future] = {}
+
+# Optional hook: called with (profile_id) right before we block on a device
+# push, so the server can ping a human. Set by server.py.
+on_approval_needed = None
+
+
+# --------------------------------------------------------------------------- #
+# state persistence (token cache)  — frozen Session <-> JSON on disk
+# --------------------------------------------------------------------------- #
+
+def _state_path(profile_id: str) -> Path:
+    safe = profile_id.replace("/", "_")
+    return _STATE_DIR / f"{safe}.json"
+
+
+def load(profile_id: str) -> Session | None:
+    path = _state_path(profile_id)
+    if not path.exists():
+        return None
+    try:
+        d = json.loads(path.read_text())
+        return Session(**d)
+    except Exception as e:  # noqa: BLE001 — corrupt cache shouldn't crash auth
+        log.warning("failed to load state for %s: %s", profile_id, e)
+        return None
+
+
+def save(profile_id: str, session: Session) -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _state_path(profile_id)
+    path.write_text(json.dumps(asdict(session)))
+    path.chmod(0o600)
+
+
+def _device_token(profile_id: str) -> str:
+    """Resolve the device token, most-stable source first.
+
+    1. pinned config value (RH_DEVICE_TOKEN / [rh.auth] device) — never changes
+    2. the token cached from a prior login
+    3. a freshly minted UUID (first ever login)
+    """
+    if config.RH_DEVICE_TOKEN:
+        return config.RH_DEVICE_TOKEN
+    existing = load(profile_id)
+    if existing and existing.device_token:
+        return existing.device_token
+    return str(uuid.uuid4())
+
+
+# --------------------------------------------------------------------------- #
+# credentials from Secret Manager -> frozen dataclass
+# --------------------------------------------------------------------------- #
+
+def load_credentials(profile_id: str) -> Credentials:
+    username = get_secret(config.SECRET_USERNAME, config.GCP_PROJECT_ID)
+    password = get_secret(config.SECRET_PASSWORD, config.GCP_PROJECT_ID)
+    totp = None
+    if config.SECRET_TOTP:
+        totp = get_secret(config.SECRET_TOTP, config.GCP_PROJECT_ID)
+    return Credentials(
+        username=username,
+        password=password,
+        totp_secret=totp,
+        device_token=_device_token(profile_id),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# auth
+# --------------------------------------------------------------------------- #
+
+def _do_auth(profile_id: str) -> AuthResult:
+    # Token reuse: if we have a cached refresh token, spend it first — that
+    # renews the access token silently, with no device push. Only fall back to
+    # a full login (which prompts the human) if refresh fails or is absent.
+    cached = load(profile_id)
+    if cached and cached.refresh_token:
+        refreshed = robinhood.refresh(cached)
+        if refreshed.status == "OK" and refreshed.session is not None:
+            save(profile_id, refreshed.session)
+            log.info("token refreshed for %s (no push)", profile_id)
+            return refreshed
+        log.warning("refresh failed for %s (%s) — falling back to full login",
+                    profile_id, refreshed.error_code)
+
+    creds = load_credentials(profile_id)
+    if callable(on_approval_needed):
+        # We can't know for sure a push is coming until the server responds, but
+        # the common prod path (trusted device, no TOTP) always prompts — so we
+        # notify up front and the human ignores it if not needed.
+        try:
+            on_approval_needed(profile_id)
+        except Exception:  # noqa: BLE001
+            pass
+    result = robinhood.authenticate(
+        creds, http_timeout=LOGIN_HTTP_TIMEOUT, approval_deadline=APPROVAL_DEADLINE,
+    )
+    if result.status == "OK" and result.session is not None:
+        save(profile_id, result.session)
+    else:
+        log.error("auth failed for %s: %s / %s", profile_id,
+                  result.error_code, result.detail)
+    return result
+
+
+def get_session(profile_id: str = "rh.auth", force: bool = False) -> AuthResult:
+    """Return an authenticated session for `profile_id`.
+
+    Fast path returns the cached token. `force=True` skips the cache and drives a
+    real (re)authentication — used by the manual /login trigger so it can't be
+    fooled by a locally-unexpired-but-server-revoked token. Otherwise a single
+    auth runs per profile (concurrent callers join the same Future) under a
+    caller-side timeout.
+    """
+    if not force:
+        cached = load(profile_id)
+        if robinhood.check_token_valid(cached):
+            return AuthResult("OK", session=cached)
+
+    with _lock:
+        task = _inflight.get(profile_id)
+        if task is None:
+            task = Future()
+            _inflight[profile_id] = task
+            starter = task
+        else:
+            starter = None
+
+    if starter is not None:
+        # This caller owns the auth; run it and fulfil the Future.
+        def _run():
+            try:
+                starter.set_result(_do_auth(profile_id))
+            except Exception as e:  # noqa: BLE001
+                starter.set_exception(e)
+            finally:
+                with _lock:
+                    _inflight.pop(profile_id, None)
+        threading.Thread(target=_run, name=f"auth-{profile_id}", daemon=True).start()
+
+    try:
+        return task.result(timeout=CALLER_TIMEOUT)
+    except FutureTimeout:
+        return AuthResult("TIMEOUT", error_code="CALLER_TIMEOUT",
+                          detail=f"auth did not complete within {CALLER_TIMEOUT}s")
+    except Exception as e:  # noqa: BLE001
+        return AuthResult("ERROR", error_code="AUTH_EXCEPTION", detail=str(e))
+
+
+def status(profile_id: str = "rh.auth") -> dict:
+    """Auth status for callers / alerting — never triggers a login."""
+    session = load(profile_id)
+    valid = robinhood.check_token_valid(session)
+    return {
+        "profile": profile_id,
+        "authenticated": valid,
+        "expires_at": session.expires_at if session else None,
+        "account_number": session.account_number if session else None,
+    }


### PR DESCRIPTION
Standalone lightweight auth-service (stdlib `http.server`, targets e2-micro).

## What it does
- Pulls Robinhood credentials from **GCP Secret Manager** (REST + metadata token) into frozen dataclasses
- Device-approval auth flow with **token reuse** + silent refresh-token renewal
- Session manager: in-flight dedup + caller/login/approval timeouts
- Endpoints for other services: `/auth/status`, `/login` (forces real re-auth), `/command`, `/orders/trailing_stop` (read + dry-run place/replace relay), `/exec`
- `gen_token.py` mints the inbound bearer token; `install.sh` + systemd unit
- README is a deploy guide with GCP prerequisites (scope, IAM, static IP, pinned device token)

Deployed and verified live on `allocation-engine-auth-service-prod`. Secrets (`env.prod`, `state/`) are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)