### PR TITLE
auth-service: MCP relay endpoint + HTTPS exposure via Caddy

### DIFF
--- a/auth-service/Caddyfile
+++ b/auth-service/Caddyfile
@@ -1,0 +1,18 @@
+# Caddy reverse proxy: terminates HTTPS and forwards to the local auth-service.
+# Hostname uses sslip.io (free wildcard DNS) so Let's Encrypt can issue a cert
+# for the VM's static IP without owning a domain:
+#   34-30-182-125.sslip.io  ->  34.30.182.125
+#
+# Caddy auto-obtains/renews the Let's Encrypt cert (HTTP-01 on port 80, which
+# must be open to the internet — it only serves the ACME challenge + HTTPS
+# redirect). The actual API on :443 is restricted to Render egress IPs by the
+# GCP firewall, not by Caddy.
+#
+# Deploy:
+#   sudo apt-get install -y caddy         # or the official Caddy repo
+#   sudo cp Caddyfile /etc/caddy/Caddyfile
+#   sudo systemctl restart caddy
+
+34-30-182-125.sslip.io {
+	reverse_proxy localhost:8080
+}

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -124,13 +124,41 @@ All POSTs and order reads require `Authorization: Bearer <exec-token>`.
 | GET    | `/orders/trailing_stop`            | active percentage trailing-stop orders    |
 | POST   | `/orders/trailing_stop`            | relay a place payload (`dry_run` default) |
 | POST   | `/orders/trailing_stop/replace`    | relay a replace payload (`dry_run` default)|
-| POST   | `/exec`                            | run an external command                   |
+| POST   | `/exec`                            | run an external command (shell)           |
+| POST   | `/exec/mcp`                        | relay a JSON-RPC call to the Robinhood MCP |
+
+`/exec/mcp` forwards a JSON-RPC payload to the **official Robinhood MCP**
+(`https://agent.robinhood.com/mcp/trading`, HTTP transport) and relays the status
++ codes. It attaches the MCP OAuth token from `[mcp] token` (or `MCP_TOKEN_SECRET`)
+— provisioned via the agentic-account OAuth flow, separate from the password
+session. Body: `{"payload": <json-rpc object>, "session_id": "<optional>"}`.
 
 ```bash
 curl -s localhost:8080/auth/status -H "Authorization: Bearer <exec-token>"
 ```
 
 ---
+
+## Making changes (preferred workflow)
+
+**SSH in and check first.** The VM is the source of truth for what's deployed —
+before changing anything, SSH in and inspect the current state (running service,
+config, what's already on disk). Don't assume; check.
+
+Change code with minimal disruption:
+
+1. **SSH first, check:** `systemctl status auth-service`, read the files, confirm
+   what's actually running.
+2. **Stage the change:** edit on the VM (or edit locally and `scp` up). Editing
+   files does **not** affect the running process — the server keeps serving the
+   old code until it's restarted, so changes land safely without disturbing it.
+3. **Test standalone:** `./venv/bin/python -c '...'` (or run `dryrun.py` /
+   `reauth_verify.py`) to exercise the new code path without touching the live
+   server.
+4. **Activate when ready:** `sudo systemctl restart auth-service`.
+
+Commit to git afterward, treating the VM's files as the source of truth (pull
+them down and diff before committing).
 
 ## Operations
 

--- a/auth-service/config.py
+++ b/auth-service/config.py
@@ -51,6 +51,13 @@ EXEC_REQUIRE_AUTH = os.getenv(
     "EXEC_REQUIRE_AUTH", _get("exec", "require_auth", "true")
 ).lower() == "true"
 
+# --- Robinhood MCP (official hosted agentic-trading server) ---
+# HTTP-transport MCP endpoint; OAuth Bearer required. Token is provisioned via
+# the agentic-account OAuth flow (separate from our password session).
+MCP_URL = os.getenv("MCP_URL", _get("mcp", "url", "https://agent.robinhood.com/mcp/trading"))
+MCP_TOKEN = os.getenv("MCP_TOKEN", _get("mcp", "token"))
+MCP_TOKEN_SECRET = os.getenv("MCP_TOKEN_SECRET", _get("mcp", "token_secret"))
+
 # --- Server ---
 PORT = int(os.getenv("PORT", _get("server", "port", "8080")))
 DEBUG = os.getenv("FLASK_DEBUG", _get("server", "debug", "false")).lower() == "true"

--- a/auth-service/env.prod.example
+++ b/auth-service/env.prod.example
@@ -22,7 +22,13 @@ url =               ; form-login endpoint for the default provider
 token = change-me
 token_secret =
 timeout_seconds = 60
-require_auth = true  ; /exec only runs after a successful /login
+require_auth = true
+
+[mcp]
+# Official Robinhood MCP (HTTP transport). Relayed by POST /exec/mcp.
+url = https://agent.robinhood.com/mcp/trading
+token =              ; OAuth bearer from the agentic-account flow (or set token_secret)
+token_secret =       ; Secret Manager name holding the MCP OAuth token  ; /exec only runs after a successful /login
 
 [server]
 port = 8080

--- a/auth-service/mcp_client.py
+++ b/auth-service/mcp_client.py
@@ -1,0 +1,53 @@
+"""Relay calls to the official Robinhood MCP server (HTTP transport).
+
+The MCP endpoint (https://agent.robinhood.com/mcp/trading) speaks JSON-RPC 2.0
+over streamable HTTP and requires an OAuth Bearer token. This module forwards a
+caller-supplied JSON-RPC payload and relays the response + status code, so other
+services can drive the MCP through our box.
+
+The OAuth token is provisioned separately (agentic-account OAuth flow) and lives
+in [mcp] token / MCP_TOKEN (or a Secret Manager name via MCP_TOKEN_SECRET).
+Without it the MCP returns 401, which we relay unchanged.
+"""
+
+import logging
+
+import requests
+
+import config
+
+log = logging.getLogger("mcp")
+
+
+def relay(payload: dict, token: str | None = None,
+          session_id: str | None = None, timeout: int = 30) -> dict:
+    """Forward one JSON-RPC payload to the MCP and relay the outcome + codes."""
+    if not config.MCP_URL:
+        return {"ok": False, "error_code": "MCP_URL_UNSET"}
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+
+    try:
+        r = requests.post(config.MCP_URL, json=payload, headers=headers, timeout=timeout)
+    except requests.RequestException as e:
+        return {"ok": False, "error_code": "MCP_HTTP_ERROR", "detail": str(e)}
+
+    out = {
+        "ok": r.ok,
+        "status": r.status_code,
+        "session_id": r.headers.get("Mcp-Session-Id"),
+    }
+    # MCP may answer as JSON or as an SSE stream — capture whichever we get.
+    try:
+        out["result"] = r.json()
+    except ValueError:
+        out["body"] = (r.text or "")[:2000]
+    if not r.ok:
+        out["error_code"] = f"MCP_HTTP_{r.status_code}"
+    return out

--- a/auth-service/server.py
+++ b/auth-service/server.py
@@ -22,6 +22,7 @@ import logging
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import config
+import mcp_client
 import robinhood
 import session as session_mgr
 from gcp_secrets import get_secret
@@ -47,6 +48,12 @@ def _exec_token() -> str:
     if config.EXEC_TOKEN_SECRET:
         return get_secret(config.EXEC_TOKEN_SECRET, config.GCP_PROJECT_ID)
     return config.EXEC_TOKEN
+
+
+def _mcp_token() -> str:
+    if config.MCP_TOKEN_SECRET:
+        return get_secret(config.MCP_TOKEN_SECRET, config.GCP_PROJECT_ID)
+    return config.MCP_TOKEN
 
 
 def _ensure_session(profile_id: str):
@@ -122,6 +129,8 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_replace()
         elif route == "/command":
             self._handle_command()
+        elif route == "/exec/mcp":
+            self._handle_mcp()
         elif route == "/exec":
             self._handle_exec()
         else:
@@ -235,6 +244,29 @@ class Handler(BaseHTTPRequestHandler):
             "authenticated": True,
             "account_number": sess.account_number,
         })
+
+    def _handle_mcp(self):
+        # Relay a JSON-RPC call to the official Robinhood MCP — the "mcp exec"
+        # option alongside the normal shell /exec. Caller authenticates with our
+        # bearer token; the MCP's OAuth token is attached server-side. Does not
+        # need our RH password session (the MCP has its own OAuth).
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        try:
+            body = self._read_json()
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON body"})
+            return
+        payload = body.get("payload")
+        if payload is None and body.get("method"):
+            payload = body  # caller sent the JSON-RPC object directly
+        if not isinstance(payload, dict):
+            self._send(400, {"error": "missing JSON-RPC 'payload'"})
+            return
+        result = mcp_client.relay(payload, token=_mcp_token(),
+                                  session_id=body.get("session_id"))
+        self._send(200, result)
 
     def _handle_exec(self):
         if not self._authorized():


### PR DESCRIPTION
Builds on #93.

## Adds
- **`/exec/mcp`** — relays JSON-RPC to the **official Robinhood MCP** (`https://agent.robinhood.com/mcp/trading`, HTTP transport) via `mcp_client.py`. Caller auths with our bearer token; MCP OAuth token attached server-side.
- **`[mcp]` config** (url / token / token_secret)
- **`Caddyfile`** — TLS front-end (sslip.io hostname + Let's Encrypt) giving `AUTH_SERVICE_URL = https://34-30-182-125.sslip.io`, reverse-proxying `:443 → localhost:8080`. No service code change.
- **README** — SSH-first change workflow + MCP endpoint docs

## Deployed + verified
On `allocation-engine-auth-service-prod`: MCP reachable (401 stub, needs OAuth token), HTTPS live with valid LE cert, 443 allowlisted to Render Ohio (non-allowlisted IPs blocked).

Secrets (`env.prod`, `state/`) gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)