### PR TITLE
auth-service: guardrails + test suite; local robinhood-mcp box (pre-emptive reference)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,20 @@
 - Both deploy from `main` branch of `IamJasonBian/allocation-engine-2.0`
 - Auto-deploy is **off** on the worker; deploys are triggered via API
 
+## Service boundaries
+
+**When working on the core-logic (allocation-engine loop, `app/`, `main.py`),
+touch only core-logic code. When working on the auth-service, touch only
+`auth-service/`.** The two services must not touch each other outside of
+**read** interactions:
+
+- Core-logic may **call** the auth-service's read endpoints (`/auth/status`,
+  `/token`, `GET /orders/trailing_stop`) — it must not modify `auth-service/`
+  code, its VM, or its config.
+- The auth-service never calls into core-logic.
+- Changes to the running auth-service VM (deploy/restart/config) are their own
+  task — never a side effect of core-logic work.
+
 ## Render Deploy
 
 Deploys are **destructive to session state** — Render's ephemeral filesystem wipes the local Robinhood pickle on every deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,13 @@ touch only core-logic code. When working on the auth-service, touch only
 - Changes to the running auth-service VM (deploy/restart/config) are their own
   task — never a side effect of core-logic work.
 
+**Robinhood authentication runs ONLY in the auth-service box.** No other
+component ever runs `robinhood.authenticate` / `rh.login()` / password+TOTP
+flows. Consumers get a live bearer from the box's `GET /token` and treat an RH
+`401` as "re-vend once, retry" — the box owns login, refresh, and device
+identity. (Legacy exception, to be migrated: the Render services' pickle flow
+documented below still logs in directly; no new code may.)
+
 ## Render Deploy
 
 Deploys are **destructive to session state** — Render's ephemeral filesystem wipes the local Robinhood pickle on every deploy.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ may only interact through **reads** (core-logic calling the auth-service's
 read endpoints — `/auth/status`, `/token`, `GET /orders/trailing_stop`);
 neither modifies the other's code, config, or deployment.
 
+**Robinhood authentication runs only in the auth-service box.** Nothing else
+runs a Robinhood login/authenticate flow — consumers take a vended bearer from
+the box's `GET /token` and re-vend once on `401`. The box owns login, refresh,
+and device identity.
+
 ## Architecture
 
 ### System overview

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca` or `/robinhood` to
 | `ENGINE_BROKER` | Broker for engine reconciliation | `alpaca` |
 | `PORT` | Server port | `10000` |
 
+## Service boundaries
+
+This repo holds two independently-operated services plus a local tool:
+
+- **core-logic** — the allocation engine (`app/`, `main.py`): API + engine loop
+  on Render.
+- **auth-service/** — standalone Robinhood auth/session service on its own GCP
+  VM (see `auth-service/README.md`).
+- **robinhood-mcp/** — local MCP server exposing our Robinhood logic as tools
+  (see `robinhood-mcp/README.md`).
+
+**Rule: work on one service touches only that service.** Core-logic work stays
+in core-logic; auth-service work stays in `auth-service/`. At runtime the two
+may only interact through **reads** (core-logic calling the auth-service's
+read endpoints — `/auth/status`, `/token`, `GET /orders/trailing_stop`);
+neither modifies the other's code, config, or deployment.
+
 ## Architecture
 
 ### System overview

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -119,6 +119,7 @@ All POSTs and order reads require `Authorization: Bearer <exec-token>`.
 |--------|------------------------------------|-------------------------------------------|
 | GET    | `/health`                          | liveness                                  |
 | GET    | `/auth/status`                     | auth state + error codes (for alerting)   |
+| GET    | `/token`                           | vend the live RH access token (Bearer)    |
 | POST   | `/login`                           | force a real (re)authentication           |
 | POST   | `/command`                         | generic authenticated intake for callers  |
 | GET    | `/orders/trailing_stop`            | active percentage trailing-stop orders    |
@@ -129,9 +130,9 @@ All POSTs and order reads require `Authorization: Bearer <exec-token>`.
 
 `/exec/mcp` forwards a JSON-RPC payload to the **official Robinhood MCP**
 (`https://agent.robinhood.com/mcp/trading`, HTTP transport) and relays the status
-+ codes. It attaches the MCP OAuth token from `[mcp] token` (or `MCP_TOKEN_SECRET`)
-— provisioned via the agentic-account OAuth flow, separate from the password
-session. Body: `{"payload": <json-rpc object>, "session_id": "<optional>"}`.
++ codes. It attaches the MCP token from `[mcp] token` (or `MCP_TOKEN_SECRET`); if neither
+is set it **falls back to the live RH access token** vended by `/token`. Body:
+`{"payload": <json-rpc object>, "session_id": "<optional>"}`.
 
 ```bash
 curl -s localhost:8080/auth/status -H "Authorization: Bearer <exec-token>"

--- a/auth-service/config.py
+++ b/auth-service/config.py
@@ -57,6 +57,9 @@ EXEC_REQUIRE_AUTH = os.getenv(
 MCP_URL = os.getenv("MCP_URL", _get("mcp", "url", "https://agent.robinhood.com/mcp/trading"))
 MCP_TOKEN = os.getenv("MCP_TOKEN", _get("mcp", "token"))
 MCP_TOKEN_SECRET = os.getenv("MCP_TOKEN_SECRET", _get("mcp", "token_secret"))
+# Comma-separated tool names exempt from the destructive-verb guardrail
+# (see guardrails.py). Empty = only trailing-stop tools may mutate.
+MCP_ALLOWED_TOOLS = os.getenv("MCP_ALLOWED_TOOLS", _get("mcp", "allowed_tools"))
 
 # --- Server ---
 PORT = int(os.getenv("PORT", _get("server", "port", "8080")))

--- a/auth-service/guardrails.py
+++ b/auth-service/guardrails.py
@@ -1,0 +1,103 @@
+"""Trade-safety guardrails — block destructive actions outside trailing stops.
+
+The service's mandate is narrow: percentage trailing-stop orders are the only
+sanctioned account mutation. These checks make that structural instead of
+conventional, on all three surfaces that could otherwise move money:
+
+  * /orders/trailing_stop (+ /replace) — the payload must actually BE a
+    percentage trailing stop, so the allow-listed endpoint can't be used to
+    smuggle a plain market/limit order to Robinhood.
+  * /exec/mcp — tools/call with a destructive tool name (buy/sell/place/
+    cancel/…) is refused unless the tool is trailing-stop related or
+    explicitly allow-listed via [mcp] allowed_tools. Reads pass through.
+  * /exec — shell commands that reference Robinhood order/transfer surfaces
+    are refused (accident prevention; the bearer token + firewall remain the
+    real gate).
+
+Each check returns None when allowed, or a human-readable reason when blocked.
+Callers turn a reason into HTTP 403 GUARDRAIL_BLOCKED and log it.
+"""
+
+import re
+
+import config
+
+# Verbs that mutate account state. Matched against name tokens, so read tools
+# like get_orders / list_positions never trip on their nouns.
+DESTRUCTIVE_VERBS = {
+    "buy", "sell", "place", "submit", "create", "cancel", "replace", "modify",
+    "amend", "edit", "update", "close", "exercise", "liquidate", "transfer",
+    "withdraw", "deposit", "execute", "trade", "short", "delete", "set",
+}
+
+# Robinhood REST surfaces that place/mutate orders or move money — refused in
+# /exec commands regardless of HTTP verb (reads have dedicated endpoints).
+_EXEC_BLOCKED_RE = re.compile(
+    r"robinhood\.com[^\s]*(orders|transfers|ach|withdraw|deposit|payments)"
+    r"|agent\.robinhood\.com",
+    re.IGNORECASE,
+)
+
+
+def _tokens(name: str) -> set[str]:
+    return {t for t in re.split(r"[^a-z0-9]+", name.lower()) if t}
+
+
+def _allowed_tools() -> set[str]:
+    return {t.strip() for t in config.MCP_ALLOWED_TOOLS.split(",") if t.strip()}
+
+
+def check_trailing_stop_payload(payload: dict) -> str | None:
+    """The only order shape this box may relay: a percentage trailing stop."""
+    if payload.get("trigger") != "stop":
+        return "payload.trigger must be 'stop' (got %r)" % payload.get("trigger")
+    peg = payload.get("trailing_peg")
+    if not isinstance(peg, dict) or peg.get("type") != "percentage":
+        return "payload.trailing_peg.type must be 'percentage'"
+    try:
+        pct = float(peg.get("percentage", 0))
+    except (TypeError, ValueError):
+        pct = 0
+    if not 0 < pct <= 100:
+        return "trailing_peg.percentage must be in (0, 100]"
+    if payload.get("type") != "market":
+        return "payload.type must be 'market' (got %r)" % payload.get("type")
+    if "price" in payload:
+        return "limit 'price' not allowed on a trailing stop"
+    if payload.get("side") not in ("buy", "sell"):
+        return "payload.side must be 'buy' or 'sell'"
+    try:
+        qty = float(payload.get("quantity", 0))
+    except (TypeError, ValueError):
+        qty = 0
+    if qty <= 0:
+        return "payload.quantity must be > 0"
+    return None
+
+
+def check_mcp_payload(payload: dict) -> str | None:
+    """Gate the JSON-RPC relay: only tools/call can mutate, so gate its name."""
+    if payload.get("method") != "tools/call":
+        return None
+    name = str((payload.get("params") or {}).get("name") or "")
+    if not name:
+        return "tools/call without params.name"
+    tokens = _tokens(name)
+    if name in _allowed_tools():
+        return None
+    if "trailing" in tokens:  # trailing-stop tools are the sanctioned writes
+        return None
+    hits = tokens & DESTRUCTIVE_VERBS
+    if hits:
+        return "destructive tool %r blocked (matched: %s); add to [mcp] allowed_tools to permit" % (
+            name, ", ".join(sorted(hits)))
+    return None
+
+
+def check_exec_command(command) -> str | None:
+    """Refuse shell commands that touch Robinhood order/money-movement URLs."""
+    text = command if isinstance(command, str) else " ".join(str(a) for a in command)
+    m = _EXEC_BLOCKED_RE.search(text)
+    if m:
+        return "command references a Robinhood trading surface (%r); use the trailing-stop endpoints" % m.group(0)
+    return None

--- a/auth-service/server.py
+++ b/auth-service/server.py
@@ -22,6 +22,7 @@ import logging
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import config
+import guardrails
 import mcp_client
 import robinhood
 import session as session_mgr
@@ -53,7 +54,13 @@ def _exec_token() -> str:
 def _mcp_token() -> str:
     if config.MCP_TOKEN_SECRET:
         return get_secret(config.MCP_TOKEN_SECRET, config.GCP_PROJECT_ID)
-    return config.MCP_TOKEN
+    if config.MCP_TOKEN:
+        return config.MCP_TOKEN
+    # Fall back to the live RH bearer from our device-authenticated session.
+    result = session_mgr.get_session(config.DEFAULT_PROFILE)
+    if result.status == "OK" and result.session is not None:
+        return result.session.access_token
+    return ""
 
 
 def _ensure_session(profile_id: str):
@@ -104,6 +111,10 @@ class Handler(BaseHTTPRequestHandler):
             return body["profile"]
         return config.DEFAULT_PROFILE
 
+    def _guardrail_block(self, reason: str) -> None:
+        log.warning("GUARDRAIL BLOCKED %s %s: %s", self.command, self.path, reason)
+        self._send(403, {"error_code": "GUARDRAIL_BLOCKED", "detail": reason})
+
     def log_message(self, fmt, *args):
         log.info("%s - %s", self.address_string(), fmt % args)
 
@@ -116,6 +127,8 @@ class Handler(BaseHTTPRequestHandler):
             self._send(200, session_mgr.status(config.DEFAULT_PROFILE))
         elif self.path.rstrip("/") == "/orders/trailing_stop":
             self._handle_read_orders()
+        elif self.path.rstrip("/") == "/token":
+            self._handle_token()
         else:
             self._send(404, {"error": "not found"})
 
@@ -181,6 +194,10 @@ class Handler(BaseHTTPRequestHandler):
         if not isinstance(payload, dict):
             self._send(400, {"error": "missing 'payload' object"})
             return
+        reason = guardrails.check_trailing_stop_payload(payload)
+        if reason:
+            self._guardrail_block(reason)
+            return
         sess, err = _ensure_session(self._profile(body))
         if err:
             self._send(409, err)
@@ -205,6 +222,10 @@ class Handler(BaseHTTPRequestHandler):
         payload = body.get("payload")
         if not isinstance(payload, dict) or not body.get("order_id"):
             self._send(400, {"error": "need 'order_id' and 'payload' object"})
+            return
+        reason = guardrails.check_trailing_stop_payload(payload)
+        if reason:
+            self._guardrail_block(reason)
             return
         sess, err = _ensure_session(self._profile(body))
         if err:
@@ -245,6 +266,30 @@ class Handler(BaseHTTPRequestHandler):
             "account_number": sess.account_number,
         })
 
+    def _handle_token(self):
+        # Vend the live RH access token (Bearer) — for callers and for MCP_TOKEN.
+        # Behind our bearer since it hands out a live credential. get_session
+        # reuses the cached token / silently refreshes; never forces a push.
+        if not self._authorized():
+            self._send(401, {"error": "unauthorized"})
+            return
+        result = session_mgr.get_session(config.DEFAULT_PROFILE)
+        if result.status != "OK" or result.session is None:
+            self._send(409, {
+                "error": "not authenticated",
+                "status": result.status,
+                "error_code": result.error_code,
+            })
+            return
+        s = result.session
+        self._send(200, {
+            "token": s.access_token,
+            "token_type": s.token_type,
+            "expires_at": s.expires_at,
+            "device_token": s.device_token,
+            "account_number": s.account_number,
+        })
+
     def _handle_mcp(self):
         # Relay a JSON-RPC call to the official Robinhood MCP — the "mcp exec"
         # option alongside the normal shell /exec. Caller authenticates with our
@@ -263,6 +308,10 @@ class Handler(BaseHTTPRequestHandler):
             payload = body  # caller sent the JSON-RPC object directly
         if not isinstance(payload, dict):
             self._send(400, {"error": "missing JSON-RPC 'payload'"})
+            return
+        reason = guardrails.check_mcp_payload(payload)
+        if reason:
+            self._guardrail_block(reason)
             return
         result = mcp_client.relay(payload, token=_mcp_token(),
                                   session_id=body.get("session_id"))
@@ -285,6 +334,10 @@ class Handler(BaseHTTPRequestHandler):
         command = body.get("command")
         if not command:
             self._send(400, {"error": "missing 'command'"})
+            return
+        reason = guardrails.check_exec_command(command)
+        if reason:
+            self._guardrail_block(reason)
             return
         try:
             self._send(200, run_command(command, cwd=body.get("cwd")))

--- a/auth-service/tests/test_guardrails.py
+++ b/auth-service/tests/test_guardrails.py
@@ -1,0 +1,147 @@
+"""Unit tests for the trade-safety guardrails (no network, no server)."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("AUTH_SERVICE_ENV", "/nonexistent-env-for-tests")
+
+import config  # noqa: E402
+import guardrails  # noqa: E402
+import robinhood  # noqa: E402
+
+
+def _valid_trailing_payload(**overrides):
+    payload = robinhood.build_trailing_stop_payload(
+        account_url="https://api.robinhood.com/accounts/ACCT/",
+        instrument_url="https://api.robinhood.com/instruments/abc/",
+        symbol="TSLA",
+        side="sell",
+        quantity=10,
+        trail_percent=5,
+    )
+    payload.update(overrides)
+    return payload
+
+
+class TrailingStopPayloadTests(unittest.TestCase):
+    def test_canonical_builder_payload_passes(self):
+        self.assertIsNone(guardrails.check_trailing_stop_payload(_valid_trailing_payload()))
+
+    def test_buy_side_trailing_stop_passes(self):
+        self.assertIsNone(guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(side="buy")))
+
+    def test_plain_market_buy_blocked(self):
+        payload = {"account": "a", "instrument": "i", "symbol": "TSLA",
+                   "type": "market", "trigger": "immediate", "side": "buy",
+                   "quantity": "10", "time_in_force": "gfd"}
+        self.assertIn("trigger", guardrails.check_trailing_stop_payload(payload))
+
+    def test_limit_order_blocked(self):
+        self.assertIn("price", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(price="100.00")))
+
+    def test_missing_trailing_peg_blocked(self):
+        payload = _valid_trailing_payload()
+        del payload["trailing_peg"]
+        self.assertIn("trailing_peg", guardrails.check_trailing_stop_payload(payload))
+
+    def test_price_peg_blocked(self):
+        self.assertIn("percentage", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(trailing_peg={"type": "price", "price": "5.00"})))
+
+    def test_non_market_type_blocked(self):
+        self.assertIn("market", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(type="limit")))
+
+    def test_bad_side_blocked(self):
+        self.assertIn("side", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(side="hold")))
+
+    def test_zero_quantity_blocked(self):
+        self.assertIn("quantity", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(quantity="0")))
+
+    def test_negative_quantity_blocked(self):
+        self.assertIn("quantity", guardrails.check_trailing_stop_payload(
+            _valid_trailing_payload(quantity="-5")))
+
+    def test_out_of_range_percentage_blocked(self):
+        for pct in ("0", "150", "junk"):
+            self.assertIn("percentage", guardrails.check_trailing_stop_payload(
+                _valid_trailing_payload(
+                    trailing_peg={"type": "percentage", "percentage": pct})),
+                msg=f"pct={pct}")
+
+
+class McpPayloadTests(unittest.TestCase):
+    def _call(self, tool, arguments=None):
+        return {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments or {}}}
+
+    def test_non_tool_call_methods_pass(self):
+        for method in ("initialize", "tools/list", "ping", "resources/list",
+                       "prompts/list", "notifications/initialized"):
+            self.assertIsNone(guardrails.check_mcp_payload(
+                {"jsonrpc": "2.0", "id": 1, "method": method}), msg=method)
+
+    def test_read_tools_pass(self):
+        for tool in ("get_orders", "list_positions", "get_portfolio",
+                     "get_quote", "search_instruments", "order_history"):
+            self.assertIsNone(guardrails.check_mcp_payload(self._call(tool)), msg=tool)
+
+    def test_destructive_tools_blocked(self):
+        for tool in ("buy_stock", "sell_stock", "place_order", "submit_order",
+                     "create_order", "cancel_order", "modify_order",
+                     "close_position", "transfer_funds", "withdraw_cash",
+                     "execute_trade", "sell", "buy"):
+            reason = guardrails.check_mcp_payload(self._call(tool))
+            self.assertIsNotNone(reason, msg=tool)
+            self.assertIn("destructive", reason)
+
+    def test_trailing_stop_tools_exempt(self):
+        for tool in ("place_trailing_stop_order", "replace_trailing_stop",
+                     "cancel_trailing_stop_order", "update_trailing_stop"):
+            self.assertIsNone(guardrails.check_mcp_payload(self._call(tool)), msg=tool)
+
+    def test_allow_list_overrides_block(self):
+        original = config.MCP_ALLOWED_TOOLS
+        config.MCP_ALLOWED_TOOLS = "cancel_order, rebalance_portfolio"
+        try:
+            self.assertIsNone(guardrails.check_mcp_payload(self._call("cancel_order")))
+            self.assertIsNotNone(guardrails.check_mcp_payload(self._call("buy_stock")))
+        finally:
+            config.MCP_ALLOWED_TOOLS = original
+
+    def test_tool_call_without_name_blocked(self):
+        self.assertIsNotNone(guardrails.check_mcp_payload(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}}))
+
+
+class ExecCommandTests(unittest.TestCase):
+    def test_benign_commands_pass(self):
+        for cmd in ("echo hi", "uptime", ["ls", "-la", "/tmp"],
+                    "curl -s https://example.com/health"):
+            self.assertIsNone(guardrails.check_exec_command(cmd), msg=str(cmd))
+
+    def test_rh_order_urls_blocked_string_and_list(self):
+        self.assertIsNotNone(guardrails.check_exec_command(
+            "curl -X POST https://api.robinhood.com/orders/ -d '{}'"))
+        self.assertIsNotNone(guardrails.check_exec_command(
+            ["curl", "https://api.robinhood.com/options/orders/"]))
+
+    def test_money_movement_urls_blocked(self):
+        for url in ("https://api.robinhood.com/transfers/",
+                    "https://api.robinhood.com/ach/relationships/",
+                    "https://api.robinhood.com/payments/"):
+            self.assertIsNotNone(guardrails.check_exec_command(f"curl {url}"), msg=url)
+
+    def test_raw_mcp_url_blocked(self):
+        self.assertIsNotNone(guardrails.check_exec_command(
+            "curl https://agent.robinhood.com/mcp/trading"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auth-service/tests/test_server.py
+++ b/auth-service/tests/test_server.py
@@ -1,0 +1,293 @@
+"""HTTP-level tests: real server on an ephemeral port, mocked RH/MCP layers.
+
+Verifies the two properties callers depend on:
+  1. Auth interface — every privileged endpoint rejects missing/wrong/malformed
+     bearer tokens (401) and accepts the configured one; /health stays open.
+  2. Guardrails — destructive payloads are refused (403) before any relay,
+     while trailing-stop traffic and reads pass through.
+"""
+
+import http.client
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+from http.server import ThreadingHTTPServer
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("AUTH_SERVICE_ENV", "/nonexistent-env-for-tests")
+
+import config  # noqa: E402
+import robinhood  # noqa: E402
+import server  # noqa: E402
+from models import AuthResult, Session  # noqa: E402
+
+TOKEN = "test-exec-token"
+
+FAKE_SESSION = Session(
+    access_token="fake-access-token",
+    refresh_token="fake-refresh",
+    token_type="Bearer",
+    expires_at=time.time() + 3600,
+    device_token="fake-device",
+    account_url="https://api.robinhood.com/accounts/TESTACCT/",
+    account_number="TESTACCT",
+)
+
+PRIVILEGED = [
+    ("GET", "/orders/trailing_stop"),
+    ("GET", "/token"),
+    ("POST", "/login"),
+    ("POST", "/orders/trailing_stop"),
+    ("POST", "/orders/trailing_stop/replace"),
+    ("POST", "/command"),
+    ("POST", "/exec"),
+    ("POST", "/exec/mcp"),
+]
+
+
+def _valid_trailing_payload(**overrides):
+    payload = robinhood.build_trailing_stop_payload(
+        account_url="https://api.robinhood.com/accounts/TESTACCT/",
+        instrument_url="https://api.robinhood.com/instruments/abc/",
+        symbol="TSLA",
+        side="sell",
+        quantity=10,
+        trail_percent=5,
+    )
+    payload.update(overrides)
+    return payload
+
+
+class ServerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        config.EXEC_TOKEN = TOKEN
+        config.EXEC_TOKEN_SECRET = ""
+        config.MCP_TOKEN = ""
+        config.MCP_TOKEN_SECRET = ""
+        config.MCP_ALLOWED_TOOLS = ""
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.port = cls.httpd.server_address[1]
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
+    def setUp(self):
+        # Authenticated-session happy path by default; tests override as needed.
+        self.get_session = mock.patch.object(
+            server.session_mgr, "get_session",
+            return_value=AuthResult("OK", session=FAKE_SESSION)).start()
+        self.status = mock.patch.object(
+            server.session_mgr, "status",
+            return_value={"profile": "rh.auth", "authenticated": True,
+                          "expires_at": FAKE_SESSION.expires_at,
+                          "account_number": "TESTACCT"}).start()
+        self.relay = mock.patch.object(
+            server.mcp_client, "relay",
+            return_value={"ok": True, "status": 200, "result": {}}).start()
+        self.run_command = mock.patch.object(
+            server, "run_command",
+            return_value={"exit_code": 0, "stdout": "", "stderr": "",
+                          "timed_out": False}).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def request(self, method, path, body=None, token=TOKEN, raw_header=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        headers = {"Content-Type": "application/json"}
+        if raw_header is not None:
+            headers["Authorization"] = raw_header
+        elif token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        payload = None
+        if body is not None:
+            payload = body if isinstance(body, (bytes, str)) else json.dumps(body)
+        conn.request(method, path, body=payload, headers=headers)
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        try:
+            parsed = json.loads(data)
+        except ValueError:
+            parsed = {"_raw": data.decode("utf-8", "replace")}
+        return resp.status, parsed
+
+    # ---- auth interface ----
+
+    def test_health_needs_no_auth(self):
+        status, body = self.request("GET", "/health", token=None)
+        self.assertEqual(status, 200)
+        self.assertEqual(body["status"], "ok")
+
+    def test_auth_status_needs_no_auth(self):
+        status, body = self.request("GET", "/auth/status", token=None)
+        self.assertEqual(status, 200)
+        self.assertTrue(body["authenticated"])
+
+    def test_privileged_endpoints_reject_missing_token(self):
+        for method, path in PRIVILEGED:
+            status, _ = self.request(method, path, body={}, token=None)
+            self.assertEqual(status, 401, msg=f"{method} {path}")
+
+    def test_privileged_endpoints_reject_wrong_token(self):
+        for method, path in PRIVILEGED:
+            status, _ = self.request(method, path, body={}, token="wrong-token")
+            self.assertEqual(status, 401, msg=f"{method} {path}")
+
+    def test_privileged_endpoints_reject_malformed_headers(self):
+        for raw in (f"Token {TOKEN}", f"bearer {TOKEN}", "Bearer", "Bearer ", TOKEN):
+            status, _ = self.request("GET", "/token", raw_header=raw)
+            self.assertEqual(status, 401, msg=repr(raw))
+
+    def test_unconfigured_exec_token_refuses_all(self):
+        with mock.patch.object(config, "EXEC_TOKEN", ""):
+            status, _ = self.request("GET", "/token", token="")
+            self.assertEqual(status, 401)
+            status, _ = self.request("GET", "/token", token=TOKEN)
+            self.assertEqual(status, 401)
+
+    def test_correct_token_accepted_on_reads(self):
+        with mock.patch.object(server.robinhood, "get_trailing_stop_orders",
+                               return_value=[]):
+            status, body = self.request("GET", "/orders/trailing_stop")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, {"count": 0, "orders": []})
+
+    def test_token_vend_returns_session_token(self):
+        status, body = self.request("GET", "/token")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["token"], "fake-access-token")
+        self.assertEqual(body["account_number"], "TESTACCT")
+
+    def test_token_vend_conflict_when_unauthenticated(self):
+        self.get_session.return_value = AuthResult(
+            "ERROR", error_code="LOGIN_NO_TOKEN")
+        status, body = self.request("GET", "/token")
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error_code"], "LOGIN_NO_TOKEN")
+
+    def test_login_forces_reauth(self):
+        status, _ = self.request("POST", "/login", body={})
+        self.assertEqual(status, 200)
+        self.get_session.assert_called_with(config.DEFAULT_PROFILE, force=True)
+
+    def test_unknown_route_404(self):
+        status, _ = self.request("GET", "/nope")
+        self.assertEqual(status, 404)
+
+    def test_malformed_json_400(self):
+        status, _ = self.request("POST", "/orders/trailing_stop", body="{not json")
+        self.assertEqual(status, 400)
+
+    # ---- trailing-stop guardrails over HTTP ----
+
+    def test_place_valid_trailing_stop_dry_run_default(self):
+        status, body = self.request("POST", "/orders/trailing_stop",
+                                    body={"payload": _valid_trailing_payload()})
+        self.assertEqual(status, 200)
+        self.assertTrue(body["dry_run"])  # dry_run must default to true
+
+    def test_place_live_passes_dry_run_false_through(self):
+        with mock.patch.object(server.robinhood, "place_trailing_stop",
+                               return_value={"id": "ord-1"}) as place:
+            status, _ = self.request(
+                "POST", "/orders/trailing_stop",
+                body={"payload": _valid_trailing_payload(), "dry_run": False})
+        self.assertEqual(status, 200)
+        self.assertFalse(place.call_args.kwargs["dry_run"])
+
+    def test_place_plain_market_buy_blocked(self):
+        payload = {"account": "a", "instrument": "i", "symbol": "TSLA",
+                   "type": "market", "trigger": "immediate", "side": "buy",
+                   "quantity": "10"}
+        status, body = self.request("POST", "/orders/trailing_stop",
+                                    body={"payload": payload, "dry_run": False})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error_code"], "GUARDRAIL_BLOCKED")
+
+    def test_place_limit_order_blocked(self):
+        status, body = self.request(
+            "POST", "/orders/trailing_stop",
+            body={"payload": _valid_trailing_payload(price="1.00")})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error_code"], "GUARDRAIL_BLOCKED")
+
+    def test_replace_guarded_too(self):
+        payload = _valid_trailing_payload(trigger="immediate")
+        status, body = self.request(
+            "POST", "/orders/trailing_stop/replace",
+            body={"order_id": "ord-1", "payload": payload})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error_code"], "GUARDRAIL_BLOCKED")
+
+    def test_replace_valid_passes(self):
+        status, body = self.request(
+            "POST", "/orders/trailing_stop/replace",
+            body={"order_id": "ord-1", "payload": _valid_trailing_payload()})
+        self.assertEqual(status, 200)
+        self.assertTrue(body["dry_run"])
+
+    # ---- MCP guardrails over HTTP ----
+
+    def test_mcp_tools_list_relayed_with_session_fallback_token(self):
+        status, body = self.request(
+            "POST", "/exec/mcp",
+            body={"payload": {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}})
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        # MCP_TOKEN unset -> the live session bearer is attached instead.
+        self.assertEqual(self.relay.call_args.kwargs["token"], "fake-access-token")
+
+    def test_mcp_read_tool_call_relayed(self):
+        status, _ = self.request(
+            "POST", "/exec/mcp",
+            body={"method": "tools/call", "id": 2,
+                  "params": {"name": "get_portfolio", "arguments": {}}})
+        self.assertEqual(status, 200)
+        self.relay.assert_called_once()
+
+    def test_mcp_destructive_tool_blocked_before_relay(self):
+        for tool in ("buy_stock", "sell_stock", "place_order", "cancel_order"):
+            self.relay.reset_mock()
+            status, body = self.request(
+                "POST", "/exec/mcp",
+                body={"method": "tools/call", "id": 3,
+                      "params": {"name": tool, "arguments": {"symbol": "TSLA"}}})
+            self.assertEqual(status, 403, msg=tool)
+            self.assertEqual(body["error_code"], "GUARDRAIL_BLOCKED", msg=tool)
+            self.relay.assert_not_called()
+
+    def test_mcp_trailing_stop_tool_allowed(self):
+        status, _ = self.request(
+            "POST", "/exec/mcp",
+            body={"method": "tools/call", "id": 4,
+                  "params": {"name": "place_trailing_stop_order", "arguments": {}}})
+        self.assertEqual(status, 200)
+        self.relay.assert_called_once()
+
+    # ---- /exec guardrails over HTTP ----
+
+    def test_exec_benign_command_runs(self):
+        status, body = self.request("POST", "/exec", body={"command": "echo hi"})
+        self.assertEqual(status, 200)
+        self.assertEqual(body["exit_code"], 0)
+        self.run_command.assert_called_once()
+
+    def test_exec_rh_order_curl_blocked_before_run(self):
+        status, body = self.request(
+            "POST", "/exec",
+            body={"command": "curl -X POST https://api.robinhood.com/orders/"})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error_code"], "GUARDRAIL_BLOCKED")
+        self.run_command.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/robinhood-mcp/README.md
+++ b/robinhood-mcp/README.md
@@ -1,0 +1,57 @@
+# robinhood-mcp — local Robinhood MCP box
+
+A simple, standalone MCP server (stdlib-only, stdio transport) that exposes our
+Robinhood logic as MCP tools. It exists because the official Robinhood MCP
+(`agent.robinhood.com/mcp/trading`) requires an agentic-OAuth token that can't
+be minted headlessly — this box provides the same kind of tool surface backed
+by our own session token instead, and can be added to the full flow later
+(relay from the auth-service, or `claude mcp add` directly).
+
+## Trade safety (structural)
+
+- **No buy/sell/cancel tools exist.** The tool catalog is reads plus exactly
+  one write: percentage trailing stops.
+- The trailing-stop tools take scalar arguments (`symbol`, `side`, `quantity`,
+  `trail_percent`) and build the order payload internally — a caller can never
+  supply raw order JSON.
+- `dry_run` defaults to `true` on both write tools.
+
+## Tools
+
+| Tool | What |
+|------|------|
+| `get_stock_orders` | Stock orders (paginated, symbols resolved) |
+| `get_option_orders` | Option orders |
+| `get_positions` | Current stock positions |
+| `get_trailing_stop_orders` | Active percentage trailing stops |
+| `place_trailing_stop` | The sanctioned write; `dry_run` default true |
+| `replace_trailing_stop` | Replace by order id; `dry_run` default true |
+| `sync_trading_db` | Push RH order history → 5thstreetcapital Trading DB |
+
+## Auth
+
+First match wins:
+
+1. `RH_ACCESS_TOKEN` — a live RH bearer (e.g. vended by the auth-service
+   `GET /token`; from a laptop: `gcloud compute ssh` the box and curl
+   `localhost:8080/token` with the exec bearer).
+2. `AUTH_SERVICE_URL` + `AUTH_SERVICE_TOKEN` — the box fetches the token from
+   the auth-service itself (works from Render, whose IPs are allowlisted).
+
+This is a **read-only** consumer of the auth-service (`/token`), per the
+service-boundary rule in the repo README.
+
+## Run
+
+```bash
+# as an MCP server for Claude Code
+claude mcp add robinhood-local -- python3 /path/to/robinhood-mcp/server.py
+
+# tests (no network)
+cd robinhood-mcp && python3 -m unittest discover -s tests
+```
+
+The Trading DB target defaults to
+`https://5thstreetcapital.netlify.app/.netlify/functions` (override with
+`TRADING_DB_BASE`). Its write endpoints are deliberately open — see
+`/docs` on that site for the contract.

--- a/robinhood-mcp/README.md
+++ b/robinhood-mcp/README.md
@@ -28,18 +28,21 @@ by our own session token instead, and can be added to the full flow later
 | `replace_trailing_stop` | Replace by order id; `dry_run` default true |
 | `sync_trading_db` | Push RH order history → 5thstreetcapital Trading DB |
 
-## Auth
+## Auth — all of it goes through the auth-service box
 
-First match wins:
+Every RH token is vended from the auth-service `GET /token`; there is no
+local-token path. Set both:
 
-1. `RH_ACCESS_TOKEN` — a live RH bearer (e.g. vended by the auth-service
-   `GET /token`; from a laptop: `gcloud compute ssh` the box and curl
-   `localhost:8080/token` with the exec bearer).
-2. `AUTH_SERVICE_URL` + `AUTH_SERVICE_TOKEN` — the box fetches the token from
-   the auth-service itself (works from Render, whose IPs are allowlisted).
+- `AUTH_SERVICE_URL` — the box (`https://34-30-182-125.sslip.io` from Render,
+  whose IPs are allowlisted; from a laptop, port-forward:
+  `gcloud compute ssh allocation-engine-auth-service-prod --zone us-central1-c
+  --project route-manager-prod -- -N -L 8080:localhost:8080` then use
+  `http://127.0.0.1:8080`).
+- `AUTH_SERVICE_TOKEN` — the box's exec bearer.
 
-This is a **read-only** consumer of the auth-service (`/token`), per the
-service-boundary rule in the repo README.
+On an RH `401` the server re-vends once and retries — the box owns
+refresh/login entirely. This is a **read-only** consumer of the auth-service
+(`/token`), per the service-boundary rule in the repo README.
 
 ## Run
 

--- a/robinhood-mcp/server.py
+++ b/robinhood-mcp/server.py
@@ -12,9 +12,9 @@ Trade safety is structural: there are no buy/sell/cancel tools at all, and the
 one write tool (place/replace trailing stop) builds its payload internally
 from scalar arguments — a caller can never supply raw order JSON.
 
-Token source (first match wins):
-  RH_ACCESS_TOKEN          — a live RH bearer (e.g. vended by the box's /token)
-  AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN — fetch from the box's /token endpoint
+ALL Robinhood auth goes through the auth-service box: every token is vended
+from its GET /token endpoint (AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN), and an
+RH 401 triggers one re-vend + retry — the box owns refresh/login entirely.
 """
 
 import json
@@ -40,6 +40,12 @@ _account_cache: dict[str, str] = {}
 # HTTP plumbing (module-level so tests can stub it)
 # --------------------------------------------------------------------------- #
 
+class HttpError(RuntimeError):
+    def __init__(self, code: int, message: str):
+        super().__init__(message)
+        self.code = code
+
+
 def http_json(method: str, url: str, body: dict | None = None,
               headers: dict | None = None, timeout: int = 30) -> dict:
     req = urllib.request.Request(
@@ -52,32 +58,44 @@ def http_json(method: str, url: str, body: dict | None = None,
             return json.load(r)
     except urllib.error.HTTPError as e:
         detail = e.read().decode("utf-8", "replace")[:500]
-        raise RuntimeError(f"HTTP {e.code} from {url}: {detail}") from e
+        raise HttpError(e.code, f"HTTP {e.code} from {url}: {detail}") from e
 
 
-def rh_token() -> str:
-    if _token_cache["token"]:
+def rh_token(force: bool = False) -> str:
+    """Vend the live RH bearer from the auth-service box (the only auth path)."""
+    if _token_cache["token"] and not force:
         return _token_cache["token"]
-    token = os.getenv("RH_ACCESS_TOKEN")
-    if not token:
-        base, bearer = os.getenv("AUTH_SERVICE_URL"), os.getenv("AUTH_SERVICE_TOKEN")
-        if not (base and bearer):
-            raise RuntimeError(
-                "no token: set RH_ACCESS_TOKEN, or AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN")
-        token = http_json("GET", f"{base.rstrip('/')}/token",
-                          headers={"Authorization": f"Bearer {bearer}"})["token"]
-    _token_cache["token"] = token
-    return token
+    base, bearer = os.getenv("AUTH_SERVICE_URL"), os.getenv("AUTH_SERVICE_TOKEN")
+    if not (base and bearer):
+        raise RuntimeError(
+            "set AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN — all RH auth goes "
+            "through the auth-service box's GET /token")
+    _token_cache["token"] = http_json(
+        "GET", f"{base.rstrip('/')}/token",
+        headers={"Authorization": f"Bearer {bearer}"})["token"]
+    return _token_cache["token"]
+
+
+def _rh_request(method: str, url: str, body: dict | None = None) -> dict:
+    try:
+        return http_json(method, url, body,
+                         headers={"Authorization": f"Bearer {rh_token()}"})
+    except HttpError as e:
+        if e.code != 401:
+            raise
+        # Token expired/revoked mid-flight: the box re-vends (it owns
+        # refresh/login); retry exactly once with the fresh bearer.
+        return http_json(method, url, body,
+                         headers={"Authorization": f"Bearer {rh_token(force=True)}"})
 
 
 def rh_get(path_or_url: str) -> dict:
     url = path_or_url if path_or_url.startswith("http") else f"{RH_BASE}{path_or_url}"
-    return http_json("GET", url, headers={"Authorization": f"Bearer {rh_token()}"})
+    return _rh_request("GET", url)
 
 
 def rh_post(path: str, body: dict) -> dict:
-    return http_json("POST", f"{RH_BASE}{path}", body,
-                     headers={"Authorization": f"Bearer {rh_token()}"})
+    return _rh_request("POST", f"{RH_BASE}{path}", body)
 
 
 def _paginate(url: str, max_items: int) -> list[dict]:

--- a/robinhood-mcp/server.py
+++ b/robinhood-mcp/server.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Local Robinhood MCP — our logic in a simple box (stdlib only).
+
+The official Robinhood MCP (agent.robinhood.com) requires an agentic-OAuth
+token we can't mint headlessly, so this server exposes the same kind of tool
+surface backed by our own session token instead. Speaks MCP over stdio
+(newline-delimited JSON-RPC 2.0), so it plugs into Claude Code today
+(`claude mcp add robinhood-local -- python3 server.py`) and can be relayed
+from the auth-service box later.
+
+Trade safety is structural: there are no buy/sell/cancel tools at all, and the
+one write tool (place/replace trailing stop) builds its payload internally
+from scalar arguments — a caller can never supply raw order JSON.
+
+Token source (first match wins):
+  RH_ACCESS_TOKEN          — a live RH bearer (e.g. vended by the box's /token)
+  AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN — fetch from the box's /token endpoint
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+RH_BASE = "https://api.robinhood.com"
+TRADING_DB_BASE = os.getenv(
+    "TRADING_DB_BASE", "https://5thstreetcapital.netlify.app/.netlify/functions")
+
+ACTIVE_STATES = {"queued", "confirmed", "unconfirmed", "partially_filled"}
+
+_token_cache = {"token": None}
+_symbol_cache: dict[str, str] = {}
+_account_cache: dict[str, str] = {}
+
+
+# --------------------------------------------------------------------------- #
+# HTTP plumbing (module-level so tests can stub it)
+# --------------------------------------------------------------------------- #
+
+def http_json(method: str, url: str, body: dict | None = None,
+              headers: dict | None = None, timeout: int = 30) -> dict:
+    req = urllib.request.Request(
+        url, method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Content-Type": "application/json", "Accept": "application/json",
+                 **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:500]
+        raise RuntimeError(f"HTTP {e.code} from {url}: {detail}") from e
+
+
+def rh_token() -> str:
+    if _token_cache["token"]:
+        return _token_cache["token"]
+    token = os.getenv("RH_ACCESS_TOKEN")
+    if not token:
+        base, bearer = os.getenv("AUTH_SERVICE_URL"), os.getenv("AUTH_SERVICE_TOKEN")
+        if not (base and bearer):
+            raise RuntimeError(
+                "no token: set RH_ACCESS_TOKEN, or AUTH_SERVICE_URL + AUTH_SERVICE_TOKEN")
+        token = http_json("GET", f"{base.rstrip('/')}/token",
+                          headers={"Authorization": f"Bearer {bearer}"})["token"]
+    _token_cache["token"] = token
+    return token
+
+
+def rh_get(path_or_url: str) -> dict:
+    url = path_or_url if path_or_url.startswith("http") else f"{RH_BASE}{path_or_url}"
+    return http_json("GET", url, headers={"Authorization": f"Bearer {rh_token()}"})
+
+
+def rh_post(path: str, body: dict) -> dict:
+    return http_json("POST", f"{RH_BASE}{path}", body,
+                     headers={"Authorization": f"Bearer {rh_token()}"})
+
+
+def _paginate(url: str, max_items: int) -> list[dict]:
+    out: list[dict] = []
+    while url and len(out) < max_items:
+        page = rh_get(url)
+        out.extend(page.get("results", []))
+        url = page.get("next")
+    return out[:max_items]
+
+
+def _symbol_for(instrument_url: str) -> str | None:
+    if not instrument_url:
+        return None
+    if instrument_url not in _symbol_cache:
+        try:
+            _symbol_cache[instrument_url] = http_json("GET", instrument_url).get("symbol")
+        except RuntimeError:
+            return None
+    return _symbol_cache[instrument_url]
+
+
+def _account() -> dict:
+    if not _account_cache:
+        results = rh_get("/accounts/").get("results", [])
+        if not results:
+            raise RuntimeError("no accounts returned")
+        _account_cache.update(results[0])
+    return _account_cache
+
+
+# --------------------------------------------------------------------------- #
+# tools — reads + the one sanctioned write (trailing stop)
+# --------------------------------------------------------------------------- #
+
+def tool_get_stock_orders(limit: int = 100, state: str | None = None) -> dict:
+    orders = _paginate(f"{RH_BASE}/orders/?page_size=100", int(limit))
+    if state:
+        orders = [o for o in orders if o.get("state") == state]
+    for o in orders:
+        o["symbol"] = _symbol_for(o.get("instrument", ""))
+    return {"count": len(orders), "orders": orders}
+
+
+def tool_get_option_orders(limit: int = 100, state: str | None = None) -> dict:
+    orders = _paginate(f"{RH_BASE}/options/orders/?page_size=100", int(limit))
+    if state:
+        orders = [o for o in orders if o.get("state") == state]
+    return {"count": len(orders), "orders": orders}
+
+
+def tool_get_positions(nonzero: bool = True) -> dict:
+    qs = "?nonzero=true" if nonzero else ""
+    positions = _paginate(f"{RH_BASE}/positions/{qs}", 500)
+    for p in positions:
+        p["symbol"] = _symbol_for(p.get("instrument", ""))
+    return {"count": len(positions), "positions": positions}
+
+
+def tool_get_trailing_stop_orders() -> dict:
+    orders = _paginate(f"{RH_BASE}/orders/?page_size=100", 1000)
+    out = []
+    for o in orders:
+        if o.get("state") not in ACTIVE_STATES or o.get("trigger") != "stop":
+            continue
+        peg = o.get("trailing_peg") or {}
+        if peg.get("type") not in (None, "percentage"):
+            continue
+        o["symbol"] = _symbol_for(o.get("instrument", ""))
+        out.append(o)
+    return {"count": len(out), "orders": out}
+
+
+def _trailing_payload(symbol: str, side: str, quantity, trail_percent,
+                      time_in_force: str = "gtc") -> dict:
+    if side not in ("buy", "sell"):
+        raise ValueError("side must be 'buy' or 'sell'")
+    if not 0 < float(trail_percent) <= 100:
+        raise ValueError("trail_percent must be in (0, 100]")
+    if float(quantity) <= 0:
+        raise ValueError("quantity must be > 0")
+    found = http_json(
+        "GET", f"{RH_BASE}/instruments/?symbol={urllib.parse.quote(symbol)}"
+    ).get("results", [])
+    if not found:
+        raise ValueError(f"unknown symbol {symbol!r}")
+    acct = _account()
+    return {
+        "account": acct.get("url", ""),
+        "instrument": found[0]["url"],
+        "symbol": symbol,
+        "type": "market",
+        "time_in_force": time_in_force,
+        "trigger": "stop",
+        "side": side,
+        "quantity": str(quantity),
+        "trailing_peg": {"type": "percentage", "percentage": str(trail_percent)},
+        "ref_id": str(uuid.uuid4()),
+    }
+
+
+def tool_place_trailing_stop(symbol: str, side: str, quantity, trail_percent,
+                             time_in_force: str = "gtc", dry_run: bool = True) -> dict:
+    payload = _trailing_payload(symbol, side, quantity, trail_percent, time_in_force)
+    if dry_run:
+        return {"dry_run": True, "method": "POST", "url": f"{RH_BASE}/orders/",
+                "payload": payload}
+    return rh_post("/orders/", payload)
+
+
+def tool_replace_trailing_stop(order_id: str, symbol: str, side: str, quantity,
+                               trail_percent, time_in_force: str = "gtc",
+                               dry_run: bool = True) -> dict:
+    payload = _trailing_payload(symbol, side, quantity, trail_percent, time_in_force)
+    url = f"/orders/{order_id}/replace/"
+    if dry_run:
+        return {"dry_run": True, "method": "POST", "url": f"{RH_BASE}{url}",
+                "payload": payload}
+    return rh_post(url, payload)
+
+
+def tool_sync_trading_db(stock_limit: int = 700, option_limit: int = 300) -> dict:
+    """Push RH order history into the 5thstreetcapital Trading DB (open writes)."""
+    stock = tool_get_stock_orders(limit=stock_limit)["orders"]
+    option = tool_get_option_orders(limit=option_limit)["orders"]
+    upserted = {"stock": 0, "option": 0}
+    for i in range(0, len(stock), 100):
+        res = http_json("POST", f"{TRADING_DB_BASE}/db-orders",
+                        {"orders": stock[i:i + 100]})
+        upserted["stock"] += res["data"]["stock_upserted"]
+    for i in range(0, len(option), 100):
+        res = http_json("POST", f"{TRADING_DB_BASE}/db-orders",
+                        {"option_orders": option[i:i + 100]})
+        upserted["option"] += res["data"]["option_upserted"]
+    return {"pulled": {"stock": len(stock), "option": len(option)},
+            "upserted": upserted}
+
+
+TOOLS = {
+    "get_stock_orders": (tool_get_stock_orders, "Stock orders (newest first), symbols resolved.", {
+        "limit": {"type": "integer", "default": 100},
+        "state": {"type": "string", "description": "filter: filled/queued/cancelled/…"},
+    }),
+    "get_option_orders": (tool_get_option_orders, "Option orders (newest first).", {
+        "limit": {"type": "integer", "default": 100},
+        "state": {"type": "string"},
+    }),
+    "get_positions": (tool_get_positions, "Current stock positions.", {
+        "nonzero": {"type": "boolean", "default": True},
+    }),
+    "get_trailing_stop_orders": (tool_get_trailing_stop_orders,
+                                 "Active percentage trailing-stop orders.", {}),
+    "place_trailing_stop": (tool_place_trailing_stop,
+                            "Place a percentage trailing-stop order (the only sanctioned write). dry_run defaults true.", {
+        "symbol": {"type": "string"}, "side": {"type": "string", "enum": ["buy", "sell"]},
+        "quantity": {"type": "number"}, "trail_percent": {"type": "number"},
+        "time_in_force": {"type": "string", "default": "gtc"},
+        "dry_run": {"type": "boolean", "default": True},
+    }),
+    "replace_trailing_stop": (tool_replace_trailing_stop,
+                              "Replace a trailing-stop order by id. dry_run defaults true.", {
+        "order_id": {"type": "string"}, "symbol": {"type": "string"},
+        "side": {"type": "string", "enum": ["buy", "sell"]},
+        "quantity": {"type": "number"}, "trail_percent": {"type": "number"},
+        "time_in_force": {"type": "string", "default": "gtc"},
+        "dry_run": {"type": "boolean", "default": True},
+    }),
+    "sync_trading_db": (tool_sync_trading_db,
+                        "Pull RH order history and upsert it into the 5thstreetcapital Trading DB.", {
+        "stock_limit": {"type": "integer", "default": 700},
+        "option_limit": {"type": "integer", "default": 300},
+    }),
+}
+
+
+# --------------------------------------------------------------------------- #
+# MCP protocol (stdio, newline-delimited JSON-RPC 2.0)
+# --------------------------------------------------------------------------- #
+
+def _tool_list() -> list[dict]:
+    return [{
+        "name": name,
+        "description": desc,
+        "inputSchema": {"type": "object", "properties": props},
+    } for name, (_, desc, props) in TOOLS.items()]
+
+
+def handle_message(msg: dict) -> dict | None:
+    method, msg_id = msg.get("method"), msg.get("id")
+    if method and method.startswith("notifications/"):
+        return None
+
+    def ok(result):
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+    def err(code, message):
+        return {"jsonrpc": "2.0", "id": msg_id,
+                "error": {"code": code, "message": message}}
+
+    if method == "initialize":
+        return ok({
+            "protocolVersion": msg.get("params", {}).get("protocolVersion", "2024-11-05"),
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "robinhood-local", "version": "1.0.0"},
+        })
+    if method == "ping":
+        return ok({})
+    if method == "tools/list":
+        return ok({"tools": _tool_list()})
+    if method == "tools/call":
+        params = msg.get("params") or {}
+        name, args = params.get("name"), params.get("arguments") or {}
+        if name not in TOOLS:
+            return err(-32602, f"unknown tool {name!r}")
+        try:
+            result = TOOLS[name][0](**args)
+            return ok({"content": [{"type": "text", "text": json.dumps(result)}],
+                       "isError": False})
+        except (RuntimeError, ValueError, TypeError) as e:
+            return ok({"content": [{"type": "text", "text": str(e)}], "isError": True})
+    return err(-32601, f"method {method!r} not supported")
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue
+        resp = handle_message(msg)
+        if resp is not None:
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/robinhood-mcp/tests/test_server.py
+++ b/robinhood-mcp/tests/test_server.py
@@ -5,9 +5,9 @@ import os
 import subprocess
 import sys
 import unittest
+import unittest.mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-os.environ["RH_ACCESS_TOKEN"] = "test-token"
 
 import server  # noqa: E402
 
@@ -26,11 +26,12 @@ class FakeHttp:
         self.routes.append((method, url_part, response))
 
     def __call__(self, method, url, body=None, headers=None, timeout=30):
-        self.calls.append({"method": method, "url": url, "body": body,
-                           "headers": headers or {}})
+        call = {"method": method, "url": url, "body": body,
+                "headers": headers or {}}
+        self.calls.append(call)
         for m, part, resp in self.routes:
             if m == method and part in url:
-                return resp(body) if callable(resp) else resp
+                return resp(call) if callable(resp) else resp
         raise AssertionError(f"unexpected {method} {url}")
 
 
@@ -158,14 +159,79 @@ class ToolTests(unittest.TestCase):
         # substring of "/options/orders/"
         self.http.route("GET", "/options/orders/", {"results": [], "next": None})
         self.http.route("GET", "/orders/", {"results": stock, "next": None})
-        self.http.route("POST", "/db-orders", lambda body: {
-            "data": {"stock_upserted": len(body.get("orders", [])),
-                     "option_upserted": len(body.get("option_orders", []))}})
+        self.http.route("POST", "/db-orders", lambda call: {
+            "data": {"stock_upserted": len(call["body"].get("orders", [])),
+                     "option_upserted": len(call["body"].get("option_orders", []))}})
         out = server.tool_sync_trading_db()
         self.assertEqual(out["pulled"]["stock"], 150)
         self.assertEqual(out["upserted"]["stock"], 150)
         posts = [c for c in self.http.calls if "/db-orders" in c["url"]]
         self.assertEqual(len(posts), 2)  # 150 orders -> two batches of <=100
+
+
+class BoxAuthTests(unittest.TestCase):
+    """All RH auth must flow through the auth-service box's /token."""
+
+    def setUp(self):
+        self.http = FakeHttp()
+        self._orig = server.http_json
+        server.http_json = self.http
+        server._token_cache["token"] = None
+        self.env = unittest.mock.patch.dict(os.environ, {
+            "AUTH_SERVICE_URL": "https://box.test",
+            "AUTH_SERVICE_TOKEN": "exec-bearer"})
+        self.env.start()
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        server.http_json = self._orig
+        server._token_cache["token"] = None
+        self.env.stop()
+
+    def test_token_vended_from_box_and_used_on_rh(self):
+        self.http.route("GET", "box.test/token", {"token": "vended-1"})
+        self.http.route("GET", "/orders/", {"results": [], "next": None})
+        server.tool_get_trailing_stop_orders()
+        vend = self.http.calls[0]
+        self.assertIn("box.test/token", vend["url"])
+        self.assertEqual(vend["headers"]["Authorization"], "Bearer exec-bearer")
+        rh = self.http.calls[1]
+        self.assertEqual(rh["headers"]["Authorization"], "Bearer vended-1")
+
+    def test_rh_401_revends_once_and_retries(self):
+        tokens = iter(["stale", "fresh"])
+        self.http.route("GET", "box.test/token", lambda call: {"token": next(tokens)})
+
+        def orders(call):
+            if call["headers"]["Authorization"] == "Bearer stale":
+                raise server.HttpError(401, "HTTP 401 from rh")
+            return {"results": [], "next": None}
+        self.http.route("GET", "/orders/", orders)
+        out = server.tool_get_trailing_stop_orders()
+        self.assertEqual(out["count"], 0)
+        vends = [c for c in self.http.calls if "box.test/token" in c["url"]]
+        self.assertEqual(len(vends), 2)  # initial vend + forced re-vend
+
+    def test_non_401_error_is_not_retried(self):
+        self.http.route("GET", "box.test/token", {"token": "t1"})
+
+        def orders(call):
+            raise server.HttpError(503, "HTTP 503 from rh")
+        self.http.route("GET", "/orders/", orders)
+        with self.assertRaises(server.HttpError):
+            server.tool_get_trailing_stop_orders()
+        vends = [c for c in self.http.calls if "box.test/token" in c["url"]]
+        self.assertEqual(len(vends), 1)
+
+    def test_missing_env_is_a_clear_error(self):
+        self.env.stop()
+        with unittest.mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTH_SERVICE_URL", None)
+            os.environ.pop("AUTH_SERVICE_TOKEN", None)
+            with self.assertRaises(RuntimeError) as ctx:
+                server.rh_token()
+        self.env.start()  # so _restore's stop() stays balanced
+        self.assertIn("AUTH_SERVICE_URL", str(ctx.exception))
 
 
 class StdioSmokeTest(unittest.TestCase):
@@ -177,8 +243,7 @@ class StdioSmokeTest(unittest.TestCase):
         ]) + "\n"
         proc = subprocess.run(
             [sys.executable, os.path.join(os.path.dirname(__file__), "..", "server.py")],
-            input=lines, capture_output=True, text=True, timeout=30,
-            env={**os.environ, "RH_ACCESS_TOKEN": "test-token"})
+            input=lines, capture_output=True, text=True, timeout=30)
         responses = [json.loads(l) for l in proc.stdout.strip().splitlines()]
         self.assertEqual(len(responses), 2)  # notification produced no response
         self.assertEqual(responses[0]["id"], 1)

--- a/robinhood-mcp/tests/test_server.py
+++ b/robinhood-mcp/tests/test_server.py
@@ -1,0 +1,189 @@
+"""Tests for the local Robinhood MCP box — protocol + trade-safety (no network)."""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ["RH_ACCESS_TOKEN"] = "test-token"
+
+import server  # noqa: E402
+
+DESTRUCTIVE_FRAGMENTS = ("buy", "sell", "cancel", "transfer", "withdraw",
+                         "deposit", "execute", "submit", "close")
+
+
+class FakeHttp:
+    """Stub for server.http_json — canned responses keyed by (method, url prefix)."""
+
+    def __init__(self):
+        self.calls = []
+        self.routes = []
+
+    def route(self, method, url_part, response):
+        self.routes.append((method, url_part, response))
+
+    def __call__(self, method, url, body=None, headers=None, timeout=30):
+        self.calls.append({"method": method, "url": url, "body": body,
+                           "headers": headers or {}})
+        for m, part, resp in self.routes:
+            if m == method and part in url:
+                return resp(body) if callable(resp) else resp
+        raise AssertionError(f"unexpected {method} {url}")
+
+
+class ProtocolTests(unittest.TestCase):
+    def test_initialize(self):
+        resp = server.handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2025-03-26"}})
+        self.assertEqual(resp["result"]["protocolVersion"], "2025-03-26")
+        self.assertEqual(resp["result"]["serverInfo"]["name"], "robinhood-local")
+
+    def test_notifications_get_no_response(self):
+        self.assertIsNone(server.handle_message(
+            {"jsonrpc": "2.0", "method": "notifications/initialized"}))
+
+    def test_unknown_method_errors(self):
+        resp = server.handle_message({"jsonrpc": "2.0", "id": 2, "method": "bogus"})
+        self.assertEqual(resp["error"]["code"], -32601)
+
+    def test_tools_list_has_no_destructive_tools(self):
+        resp = server.handle_message({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
+        names = [t["name"] for t in resp["result"]["tools"]]
+        self.assertEqual(sorted(names), sorted(server.TOOLS))
+        for name in names:
+            if "trailing" in name:  # the sanctioned write
+                continue
+            for frag in DESTRUCTIVE_FRAGMENTS:
+                self.assertNotIn(frag, name, msg=name)
+
+    def test_unknown_tool_call_errors(self):
+        resp = server.handle_message(
+            {"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+             "params": {"name": "buy_stock", "arguments": {"symbol": "TSLA"}}})
+        self.assertIn("unknown tool", resp["error"]["message"])
+
+    def test_bad_arguments_become_tool_error_not_crash(self):
+        resp = server.handle_message(
+            {"jsonrpc": "2.0", "id": 5, "method": "tools/call",
+             "params": {"name": "get_stock_orders", "arguments": {"nope": 1}}})
+        self.assertTrue(resp["result"]["isError"])
+
+
+class ToolTests(unittest.TestCase):
+    def setUp(self):
+        self.http = FakeHttp()
+        self._orig = server.http_json
+        server.http_json = self.http
+        server._token_cache["token"] = "test-token"
+        server._symbol_cache.clear()
+        server._account_cache.clear()
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        server.http_json = self._orig
+        server._token_cache["token"] = None
+
+    def test_get_stock_orders_resolves_symbols(self):
+        self.http.route("GET", "/orders/", {
+            "results": [{"id": "o1", "state": "filled",
+                         "instrument": "https://api.robinhood.com/instruments/i1/"}],
+            "next": None})
+        self.http.route("GET", "/instruments/i1/", {"symbol": "TSLA"})
+        out = server.tool_get_stock_orders(limit=10)
+        self.assertEqual(out["count"], 1)
+        self.assertEqual(out["orders"][0]["symbol"], "TSLA")
+
+    def test_trailing_stop_filter(self):
+        self.http.route("GET", "/orders/", {"results": [
+            {"id": "t1", "state": "confirmed", "trigger": "stop",
+             "trailing_peg": {"type": "percentage", "percentage": "5"},
+             "instrument": ""},
+            {"id": "x1", "state": "confirmed", "trigger": "immediate", "instrument": ""},
+            {"id": "x2", "state": "filled", "trigger": "stop", "instrument": ""},
+        ], "next": None})
+        out = server.tool_get_trailing_stop_orders()
+        self.assertEqual([o["id"] for o in out["orders"]], ["t1"])
+
+    def _route_instrument_and_account(self):
+        self.http.route("GET", "/instruments/?symbol=", {
+            "results": [{"url": "https://api.robinhood.com/instruments/i1/",
+                         "symbol": "TSLA"}]})
+        self.http.route("GET", "/accounts/", {
+            "results": [{"url": "https://api.robinhood.com/accounts/A1/",
+                         "account_number": "A1"}]})
+
+    def test_place_trailing_stop_dry_run_default_and_shape(self):
+        self._route_instrument_and_account()
+        out = server.tool_place_trailing_stop("TSLA", "sell", 10, 5)
+        self.assertTrue(out["dry_run"])
+        p = out["payload"]
+        self.assertEqual(p["trigger"], "stop")
+        self.assertEqual(p["trailing_peg"], {"type": "percentage", "percentage": "5"})
+        self.assertEqual(p["type"], "market")
+        self.assertNotIn("price", p)
+        # dry run must never POST to RH
+        self.assertFalse([c for c in self.http.calls if c["method"] == "POST"])
+
+    def test_place_live_posts_to_orders(self):
+        self._route_instrument_and_account()
+        self.http.route("POST", "/orders/", {"id": "new-1"})
+        out = server.tool_place_trailing_stop("TSLA", "sell", 10, 5, dry_run=False)
+        self.assertEqual(out["id"], "new-1")
+        posts = [c for c in self.http.calls if c["method"] == "POST"]
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0]["body"]["trigger"], "stop")
+
+    def test_place_validation(self):
+        for kwargs in ({"side": "hold"}, {"quantity": 0}, {"trail_percent": 0},
+                       {"trail_percent": 200}):
+            args = {"symbol": "TSLA", "side": "sell", "quantity": 10,
+                    "trail_percent": 5, **kwargs}
+            with self.assertRaises(ValueError, msg=str(kwargs)):
+                server.tool_place_trailing_stop(**args)
+
+    def test_replace_targets_replace_url(self):
+        self._route_instrument_and_account()
+        out = server.tool_replace_trailing_stop("ord-9", "TSLA", "sell", 10, 5)
+        self.assertTrue(out["dry_run"])
+        self.assertIn("/orders/ord-9/replace/", out["url"])
+
+    def test_sync_trading_db_batches(self):
+        stock = [{"id": f"s{i}", "state": "filled", "instrument": ""}
+                 for i in range(150)]
+        # options route first: routes match in order and "/orders/" is a
+        # substring of "/options/orders/"
+        self.http.route("GET", "/options/orders/", {"results": [], "next": None})
+        self.http.route("GET", "/orders/", {"results": stock, "next": None})
+        self.http.route("POST", "/db-orders", lambda body: {
+            "data": {"stock_upserted": len(body.get("orders", [])),
+                     "option_upserted": len(body.get("option_orders", []))}})
+        out = server.tool_sync_trading_db()
+        self.assertEqual(out["pulled"]["stock"], 150)
+        self.assertEqual(out["upserted"]["stock"], 150)
+        posts = [c for c in self.http.calls if "/db-orders" in c["url"]]
+        self.assertEqual(len(posts), 2)  # 150 orders -> two batches of <=100
+
+
+class StdioSmokeTest(unittest.TestCase):
+    def test_initialize_and_list_over_stdio(self):
+        lines = "\n".join([
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+            json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+            json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+        ]) + "\n"
+        proc = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__), "..", "server.py")],
+            input=lines, capture_output=True, text=True, timeout=30,
+            env={**os.environ, "RH_ACCESS_TOKEN": "test-token"})
+        responses = [json.loads(l) for l in proc.stdout.strip().splitlines()]
+        self.assertEqual(len(responses), 2)  # notification produced no response
+        self.assertEqual(responses[0]["id"], 1)
+        self.assertIn("tools", responses[1]["result"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why (pre-emptive reference PR — nothing here is deployed)

Opens the auth-service hardening + the local Robinhood MCP box for other services to reference. The auth-service VM is untouched; nothing on Render redeploys from this.

## What other services should reference

### auth-service contract (`auth-service/README.md`)
- `GET /token` — vends the live RH bearer (behind the exec bearer). **Read-only consumers only.**
- `POST /exec/mcp` — JSON-RPC relay to the Robinhood MCP; falls back to the live RH bearer when `MCP_TOKEN` is unset (currently 401s at RH pending an agentic-OAuth token).
- **Trade-safety guardrails** (`auth-service/guardrails.py`, `403 GUARDRAIL_BLOCKED`):
  - `/orders/trailing_stop` (+`/replace`) now validate the payload *is* a percentage trailing stop — the allow-listed endpoint can no longer smuggle a plain buy/sell.
  - `/exec/mcp` blocks `tools/call` with destructive verbs (buy/sell/place/cancel/…) unless trailing-stop-related or in `[mcp] allowed_tools`; reads pass through.
  - `/exec` refuses commands referencing RH order/money-movement URLs.

### robinhood-mcp (new, standalone)
Local MCP server (stdio, stdlib-only) exposing our RH logic as tools, since the official Robinhood MCP requires an agentic-OAuth token we can't mint headlessly. Structurally safe: no buy/sell tools exist; the only write builds a trailing-stop payload from scalar args; `dry_run` defaults true. Reads live-verified against the real account.

### Service boundaries (CLAUDE.md + README)
Core-logic work touches only core-logic; auth-service work touches only `auth-service/`; runtime interaction between them is **read-only**.

## Testing
- `auth-service/tests` — 45 tests: full bearer-auth matrix (missing/wrong/malformed/empty token on all 8 privileged endpoints), token vend, dry-run defaults, every guardrail block/allow path. Stdlib unittest, no network.
- `robinhood-mcp/tests` — 14 tests: MCP protocol, no-destructive-tools invariant, payload construction, batching. Plus a live stdio read check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)