### PR TITLE
App-side auth-service integration: Robinhood proxy, Claude reauth, trailing-stop sweeper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .env
+data/
 venv/
 .venv/
 *.egg-info/

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -12,9 +12,11 @@ def register_blueprints(app):
     from app.api.auth import bp as auth_bp
     from app.api.snapshot import bp as snapshot_bp
     from app.api.events import bp as events_bp
+    from app.api.robinhood_proxy import bp as robinhood_proxy_bp
+    from app.api.claude_auth import bp as claude_auth_bp
 
     for blueprint in [health_bp, account_bp, positions_bp, orders_bp,
                       portfolio_bp, engine_bp, trade_bp, quote_bp,
                       history_bp, options_bp, auth_bp, snapshot_bp,
-                      events_bp]:
+                      events_bp, robinhood_proxy_bp, claude_auth_bp]:
         app.register_blueprint(blueprint, url_prefix="/api")

--- a/app/api/claude_auth.py
+++ b/app/api/claude_auth.py
@@ -1,0 +1,124 @@
+"""Reauth Claude Code from inside the box.
+
+POST /api/claude/reauth
+    Start the Claude login flow (CLAUDE_LOGIN_CMD), capture the browser
+    callback URL it prints, and return it so it can be opened. Optionally
+    ``wait`` for verification to complete.
+GET  /api/claude/reauth/<session_id>
+    Poll a pending login: reports success once verification completes.
+
+Single gunicorn worker (4 threads) → the in-process session registry is shared.
+Requires the Claude CLI to be installed in the box; verify after first deploy.
+"""
+
+import logging
+import os
+import re
+import shlex
+import subprocess
+import threading
+import uuid
+
+from flask import Blueprint, jsonify, request, current_app
+
+log = logging.getLogger(__name__)
+
+bp = Blueprint("claude_auth", __name__)
+
+_URL_RE = re.compile(r"https?://\S+")
+_sessions: dict[str, dict] = {}
+_lock = threading.Lock()
+
+
+def _reader(session_id, proc):
+    """Drain the login process output; capture the first URL it prints."""
+    for raw in iter(proc.stdout.readline, ""):
+        line = raw.rstrip("\n")
+        with _lock:
+            sess = _sessions.get(session_id)
+            if sess is None:
+                break
+            sess["output"].append(line)
+            if sess["auth_url"] is None:
+                match = _URL_RE.search(line)
+                if match:
+                    sess["auth_url"] = match.group(0)
+    proc.stdout.close()
+    proc.wait()
+    with _lock:
+        sess = _sessions.get(session_id)
+        if sess is not None:
+            sess["returncode"] = proc.returncode
+
+
+def _verified() -> bool:
+    """True once the Claude credentials file exists (verification complete)."""
+    return os.path.exists(current_app.config.get("CLAUDE_CREDENTIALS_PATH", ""))
+
+
+def _status(session_id, sess) -> dict:
+    rc = sess.get("returncode")
+    if rc is None:
+        state = "pending"
+    elif rc == 0 and _verified():
+        state = "success"
+    else:
+        state = "failed"
+    return {
+        "session_id": session_id,
+        "status": state,
+        "auth_url": sess.get("auth_url"),
+        "returncode": rc,
+        "verified": _verified(),
+    }
+
+
+@bp.route("/claude/reauth", methods=["POST"])
+def reauth():
+    cmd = current_app.config.get("CLAUDE_LOGIN_CMD", "")
+    if not cmd:
+        return jsonify({"error": "CLAUDE_LOGIN_CMD is not set"}), 503
+
+    try:
+        proc = subprocess.Popen(
+            shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except (OSError, ValueError) as e:
+        log.error("claude reauth failed to start '%s': %s", cmd, e)
+        return jsonify({"error": "failed to start login", "detail": str(e)}), 500
+
+    session_id = uuid.uuid4().hex
+    with _lock:
+        _sessions[session_id] = {"auth_url": None, "output": [], "returncode": None,
+                                 "proc": proc}
+    threading.Thread(target=_reader, args=(session_id, proc), daemon=True).start()
+
+    # Give the login flow a moment to emit its callback URL.
+    body = request.get_json(silent=True) or {}
+    wait = body.get("wait", request.args.get("wait"))
+    deadline = float(wait) if wait not in (None, "", True) else (30.0 if wait else 5.0)
+
+    try:
+        proc.wait(timeout=deadline)
+    except subprocess.TimeoutExpired:
+        pass  # still running — return the URL for the user to approve
+
+    with _lock:
+        sess = _sessions[session_id]
+        result = _status(session_id, sess)
+    if result["status"] == "pending" and result["auth_url"] is None:
+        log.warning("claude reauth: no callback URL captured within %ss", deadline)
+    return jsonify(result)
+
+
+@bp.route("/claude/reauth/<session_id>", methods=["GET"])
+def reauth_status(session_id):
+    with _lock:
+        sess = _sessions.get(session_id)
+        if sess is None:
+            return jsonify({"error": "unknown session_id"}), 404
+        return jsonify(_status(session_id, sess))

--- a/app/api/robinhood_proxy.py
+++ b/app/api/robinhood_proxy.py
@@ -1,0 +1,98 @@
+"""Robinhood calls routed through the external auth-service.
+
+- GET/POST /api/robinhood/trailing-stop  — allow-listed direct calls (RH session)
+- POST     /api/robinhood/mcp            — JSON-RPC passthrough to Robinhood MCP
+"""
+
+from flask import Blueprint, jsonify, request, current_app
+
+from app.auth_service_client import (
+    AuthServiceClient,
+    AuthServiceNotConfigured,
+    AuthServiceError,
+    OTPRequired,
+    build_trailing_stop_payload,
+)
+
+bp = Blueprint("robinhood_proxy", __name__)
+
+
+def _handle(fn):
+    """Run an auth-service call and map its errors to HTTP responses."""
+    try:
+        return jsonify(fn())
+    except AuthServiceNotConfigured as e:
+        return jsonify({"error": "auth-service not configured", "detail": str(e)}), 503
+    except OTPRequired as e:
+        return jsonify({"error": "OTP needed", "otp_needed": True, "detail": str(e)}), 409
+    except AuthServiceError as e:
+        return jsonify({"error": "auth-service call failed", "detail": str(e)}), 502
+
+
+@bp.route("/robinhood/trailing-stop", methods=["GET"])
+def get_trailing_stop():
+    """Read active percentage trailing-stop orders (allow-listed direct call)."""
+    client = AuthServiceClient()
+    return _handle(client.get_trailing_stop_orders)
+
+
+@bp.route("/robinhood/trailing-stop", methods=["POST"])
+def place_trailing_stop():
+    """Build and place a trailing-stop order (allow-listed direct call).
+
+    Body JSON — either a pre-built ``payload`` object, or the fields to build one:
+        account, instrument, symbol, side, quantity, trail_percent,
+        stop_price (optional), time_in_force (optional)
+    Plus optional ``dry_run`` (defaults to the service DRY_RUN setting).
+    """
+    body = request.get_json(silent=True) or {}
+    dry_run = body.get("dry_run", current_app.config.get("DRY_RUN", True))
+
+    payload = body.get("payload")
+    if payload is None:
+        required = ("account", "instrument", "symbol", "side", "quantity", "trail_percent")
+        missing = [f for f in required if body.get(f) is None]
+        if missing:
+            return jsonify({
+                "error": "provide a 'payload' object or the fields to build one",
+                "missing": missing,
+            }), 400
+        payload = build_trailing_stop_payload(
+            account_url=body["account"],
+            instrument_url=body["instrument"],
+            symbol=body["symbol"],
+            side=body["side"],
+            quantity=body["quantity"],
+            trail_percent=body["trail_percent"],
+            stop_price=body.get("stop_price"),
+            time_in_force=body.get("time_in_force", "gtc"),
+        )
+
+    client = AuthServiceClient()
+    return _handle(lambda: client.place_trailing_stop(payload, dry_run=dry_run))
+
+
+@bp.route("/robinhood/mcp", methods=["POST"])
+def run_mcp():
+    """Relay a JSON-RPC call to the official Robinhood MCP via the auth-service.
+
+    Body JSON — either a raw JSON-RPC ``payload``:
+        {"payload": {"jsonrpc":"2.0","id":1,"method":"tools/list"}}
+    or the convenience form:
+        {"method": "tools/call", "params": {...}, "id": 1}
+    Optional ``session_id`` propagates the MCP's Mcp-Session-Id.
+    """
+    body = request.get_json(silent=True) or {}
+    session_id = body.get("session_id")
+    client = AuthServiceClient()
+
+    payload = body.get("payload")
+    if payload is not None:
+        return _handle(lambda: client.mcp_relay(payload, session_id=session_id))
+
+    method = body.get("method")
+    if not method:
+        return jsonify({"error": "provide a JSON-RPC 'payload' or a 'method'"}), 400
+    return _handle(lambda: client.mcp_call(
+        method, params=body.get("params"),
+        req_id=body.get("id", 1), session_id=session_id))

--- a/app/auth_service_client.py
+++ b/app/auth_service_client.py
@@ -1,0 +1,177 @@
+"""Client for the standalone auth-service that holds the Robinhood session.
+
+The auth-service runs on an external box, authenticates to Robinhood, and
+exposes a small HTTP surface. This service reaches it with a Bearer token
+(`RH_AUTH_SERVICE_REQUEST_TOKEN`) over HTTPS.
+
+Two order calls are allow-listed as direct (non-MCP) calls against the
+auth-service, using its Robinhood password session:
+    GET  /orders/trailing_stop   — read active percentage trailing-stop orders
+    POST /orders/trailing_stop   — build/place a trailing-stop order
+Everything else is routed through the MCP passthrough (POST /exec/mcp), which
+relays a JSON-RPC 2.0 payload to the official Robinhood MCP
+(agent.robinhood.com/mcp/trading); the MCP's own OAuth token is attached by the
+auth-service.
+
+If the auth-service reports it needs an OTP / device approval, we log
+``OTP needed`` and raise ``OTPRequired`` so the caller can surface it.
+"""
+
+import logging
+import uuid
+
+import requests
+
+from app.config import Config
+
+log = logging.getLogger(__name__)
+
+# Auth-service statuses / error codes that mean a human must approve a device
+# push or provide an OTP before the session can proceed.
+_OTP_MARKERS = {"MFA_REQUIRED", "OTP_REQUIRED", "DEVICE_APPROVAL_NEEDED"}
+
+
+class AuthServiceError(RuntimeError):
+    """Auth-service call failed (network, non-2xx, or bad response)."""
+
+
+class AuthServiceNotConfigured(AuthServiceError):
+    """AUTH_SERVICE_URL / token missing, or URL is not https."""
+
+
+class OTPRequired(AuthServiceError):
+    """The auth-service needs an OTP / device approval to continue."""
+
+
+def build_trailing_stop_payload(*, account_url, instrument_url, symbol, side,
+                                quantity, trail_percent, stop_price=None,
+                                time_in_force="gtc"):
+    """Construct a percentage trailing-stop order payload (trailing_peg shape).
+
+    Mirrors the auth-service's own builder so callers can pass friendly fields
+    instead of a pre-assembled payload.
+    """
+    payload = {
+        "account": account_url,
+        "instrument": instrument_url,
+        "symbol": symbol,
+        "type": "market",
+        "time_in_force": time_in_force,
+        "trigger": "stop",
+        "side": side,
+        "quantity": str(quantity),
+        "trailing_peg": {"type": "percentage", "percentage": str(trail_percent)},
+        "ref_id": str(uuid.uuid4()),
+    }
+    if stop_price is not None:
+        payload["stop_price"] = str(stop_price)
+    return payload
+
+
+class AuthServiceClient:
+    # (method, path) pairs allowed as direct exec against the auth-service.
+    DIRECT_ALLOW_LIST = frozenset({
+        ("GET", "/orders/trailing_stop"),
+        ("POST", "/orders/trailing_stop"),
+    })
+
+    def __init__(self, base_url=None, token=None, timeout=None):
+        self.base_url = (base_url if base_url is not None
+                         else Config.AUTH_SERVICE_URL).rstrip("/")
+        self.token = token if token is not None else Config.RH_AUTH_SERVICE_REQUEST_TOKEN
+        self.timeout = timeout or Config.AUTH_SERVICE_TIMEOUT
+
+    # -- internals --
+
+    def _check_config(self):
+        if not self.base_url:
+            raise AuthServiceNotConfigured("AUTH_SERVICE_URL is not set")
+        if not self.token:
+            raise AuthServiceNotConfigured("RH_AUTH_SERVICE_REQUEST_TOKEN is not set")
+        # Never send the bearer token over plaintext.
+        if not self.base_url.startswith("https://"):
+            raise AuthServiceNotConfigured(
+                "AUTH_SERVICE_URL must be https — refusing to send the request "
+                f"token over plaintext ({self.base_url})"
+            )
+
+    def _flag_otp(self, method, path, data):
+        """Log ``OTP needed`` and raise if the response signals an OTP/approval."""
+        status = str(data.get("status") or "").upper()
+        code = str(data.get("error_code") or "").upper()
+        detail = str(data.get("detail") or "")
+        needs_otp = (
+            status in _OTP_MARKERS
+            or code in _OTP_MARKERS
+            or "DEVICE APPROVAL" in detail.upper()
+        )
+        if needs_otp:
+            log.warning("OTP needed — auth-service %s %s requires device "
+                        "approval/OTP (status=%s code=%s detail=%s)",
+                        method, path, status, code, detail)
+            raise OTPRequired(detail or "OTP needed")
+
+    def _request(self, method, path, json_body=None):
+        self._check_config()
+        url = f"{self.base_url}{path}"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.request(method, url, json=json_body,
+                                    headers=headers, timeout=self.timeout)
+        except requests.RequestException as e:
+            log.error("auth-service %s %s failed: %s", method, path, e)
+            raise AuthServiceError(f"auth-service request failed: {e}") from e
+
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {"raw": resp.text}
+        if not isinstance(data, dict):
+            data = {"result": data}
+
+        self._flag_otp(method, path, data)
+
+        if resp.status_code >= 400:
+            log.error("auth-service %s %s -> %s %s",
+                      method, path, resp.status_code, data)
+            raise AuthServiceError(
+                f"auth-service {method} {path} returned {resp.status_code}: {data}"
+            )
+        return data
+
+    # -- allow-listed direct calls --
+
+    def get_trailing_stop_orders(self):
+        return self._request("GET", "/orders/trailing_stop")
+
+    def place_trailing_stop(self, payload, dry_run=True):
+        return self._request("POST", "/orders/trailing_stop",
+                             {"payload": payload, "dry_run": dry_run})
+
+    # -- MCP passthrough (official Robinhood MCP, via POST /exec/mcp) --
+
+    def mcp_relay(self, payload, session_id=None):
+        """Relay a raw JSON-RPC 2.0 payload to the Robinhood MCP through the box.
+
+        Returns the auth-service relay envelope: {ok, status, session_id,
+        result|body, error_code?}. MCP-level failures come back as ok=false with
+        an error_code (e.g. MCP_HTTP_401) rather than raising.
+        """
+        body = {"payload": payload}
+        if session_id:
+            body["session_id"] = session_id
+        return self._request("POST", "/exec/mcp", body)
+
+    def mcp_call(self, method, params=None, req_id=1, session_id=None):
+        """Build a JSON-RPC 2.0 request and relay it to the Robinhood MCP."""
+        payload = {"jsonrpc": "2.0", "id": req_id, "method": method,
+                   "params": params or {}}
+        return self.mcp_relay(payload, session_id=session_id)
+
+    # -- status (does not raise on OTP; the OTP state IS the answer) --
+
+    def auth_status(self):
+        try:
+            return self._request("GET", "/auth/status")
+        except OTPRequired as e:
+            return {"authenticated": False, "otp_needed": True, "detail": str(e)}

--- a/app/background.py
+++ b/app/background.py
@@ -184,6 +184,46 @@ def start_engine_thread(app):
             open_orders = []
             account = {}
 
+            # --- Trailing-stop sweeper (via auth-service) ---
+            # One sweep per day: mirror the RH trailing-stop book into the
+            # local sqlite queue, cover naked tickers with a 16% stop, renew
+            # stops near GTC expiry. Never breaks the tick; every action is
+            # logged so it is visible in Render logs.
+            sweeper_client = None
+            sweeper_store = None
+
+            def _maybe_stop_sweep(current_positions):
+                nonlocal sweeper_client, sweeper_store
+                from app import stop_sweeper as sw
+                if sweeper_store is None:
+                    sweeper_store = sw.StopStore(config.get("STOP_DB_PATH", sw.DEFAULT_DB))
+                if sweeper_store.swept_today():
+                    return
+                from zoneinfo import ZoneInfo
+                hour_et = datetime.now(ZoneInfo("America/New_York")).hour
+                if hour_et < int(config.get("STOP_SWEEP_HOUR_ET", 0)):
+                    return
+                if sweeper_client is None:
+                    sweeper_client = sw.BoxClient(
+                        base=config.get("AUTH_SERVICE_URL", ""),
+                        token=config.get("RH_AUTH_SERVICE_REQUEST_TOKEN", ""))
+                tickers = [t.strip().upper() for t in
+                           config.get("STOP_TICKERS", "").split(",") if t.strip()]
+                tickers += [p.get("symbol", "").upper() for p in current_positions
+                            if p.get("symbol")]
+                tickers = sorted(set(tickers))
+                dry = config.get("STOP_SWEEP_DRY_RUN", True)
+                log.info("[stop-sweeper] starting daily sweep "
+                         "(tickers=%s, trail=%.0f%%, dry_run=%s)",
+                         tickers or "book-only", sw.TRAIL_PERCENT, dry)
+                out = sw.sweep(sweeper_client, sweeper_store, tickers, dry_run=dry)
+                log.info("[stop-sweeper] sweep done: %d active in RH book, "
+                         "placed=%s, renewed=%s, pruned=%s",
+                         out["active_from_rh"],
+                         [p["symbol"] for p in out["placed"]] or "none",
+                         [r.get("symbol") for r in out["renewed"]] or "none",
+                         out["pruned"] or "none")
+
             import time as _time
             _engine_status["last_error"] = f"pre_loop_v3_{int(_time.time())}"
             log.info("[engine] About to enter main loop")
@@ -224,6 +264,11 @@ def start_engine_thread(app):
 
                 # --- Normal tick ---
                 try:
+                    try:
+                        _maybe_stop_sweep(positions)
+                    except Exception as sweep_err:
+                        log.exception("[stop-sweeper] sweep failed: %s", sweep_err)
+
                     if is_live:
                         log.info("Live mode: refreshing broker state")
                     else:

--- a/app/config.py
+++ b/app/config.py
@@ -58,6 +58,18 @@ class Config:
     RH_AUTH_SERVICE_REQUEST_TOKEN = os.getenv("RH_AUTH_SERVICE_REQUEST_TOKEN", "")
     AUTH_SERVICE_TIMEOUT = int(os.getenv("AUTH_SERVICE_TIMEOUT", "30"))
 
+    # -- Trailing-stop sweeper (runs in the background engine loop) --
+    # Universe beyond current positions; comma-separated symbols.
+    STOP_TICKERS = os.getenv("STOP_TICKERS", "")
+    # Sweeper writes stay dry-run unless explicitly armed.
+    STOP_SWEEP_DRY_RUN = os.getenv("STOP_SWEEP_DRY_RUN", "true").lower() == "true"
+    # Earliest ET hour for the daily sweep (0 = first tick of the day).
+    STOP_SWEEP_HOUR_ET = int(os.getenv("STOP_SWEEP_HOUR_ET", "0"))
+    STOP_DB_PATH = os.getenv(
+        "STOP_DB_PATH",
+        os.path.join(os.path.dirname(__file__), "..", "data", "stops.sqlite3"),
+    )
+
     # -- Claude Code reauth (in-box login flow) --
     # Command that starts the Claude login and prints a browser callback URL.
     CLAUDE_LOGIN_CMD = os.getenv("CLAUDE_LOGIN_CMD", "claude setup-token")

--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,21 @@ class Config:
             return cls.RH_AUTO_EMAIL, cls.RH_AUTO_PASSWORD
         return cls.RH_MAIN_EMAIL, cls.RH_MAIN_PASSWORD
 
+    # -- Auth-service (Robinhood session on the external box) --
+    # Base URL must be https — the request token is sent as a Bearer header.
+    AUTH_SERVICE_URL = os.getenv("AUTH_SERVICE_URL", "")
+    RH_AUTH_SERVICE_REQUEST_TOKEN = os.getenv("RH_AUTH_SERVICE_REQUEST_TOKEN", "")
+    AUTH_SERVICE_TIMEOUT = int(os.getenv("AUTH_SERVICE_TIMEOUT", "30"))
+
+    # -- Claude Code reauth (in-box login flow) --
+    # Command that starts the Claude login and prints a browser callback URL.
+    CLAUDE_LOGIN_CMD = os.getenv("CLAUDE_LOGIN_CMD", "claude setup-token")
+    # File that appears/updates once Claude verification completes.
+    CLAUDE_CREDENTIALS_PATH = os.getenv(
+        "CLAUDE_CREDENTIALS_PATH",
+        os.path.expanduser("~/.claude/.credentials.json"),
+    )
+
     # -- Runtime service --
     RUNTIME_SERVICE_URL = os.getenv(
         "RUNTIME_SERVICE_URL",

--- a/app/stop_sweeper.py
+++ b/app/stop_sweeper.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Daily trailing-stop sweeper with a local SQLite cache/queue.
+
+One sweep at start of day:
+  1. Read active trailing-stop orders from RH (through the auth-service) and
+     mirror them into SQLite.
+  2. For every ticker in the universe, ensure a percentage trailing stop
+     (default 16%) exists — place one (dry_run by default) if missing.
+  3. Compute expiry (RH cancels GTC orders after ~90 days) and flag stops
+     expiring soon.
+
+Between sweeps, other services read SQLite as the queue — RH is only
+consulted when SQLite says a stop is about to expire (then we re-read and
+renew via the replace/PUT path). If the DB is missing or empty, a sweep
+re-populates it. A weekly reconciliation sweeper (SQLite vs RH book) comes
+later.
+
+Transport:
+  --via proxy  (default) — the deployed Render API's /api/robinhood/* proxy;
+               works from a laptop (the box's :443 only admits Render Ohio).
+               Replace/renew is NOT exposed here (logged + skipped).
+  --via box    — direct auth-service URL + bearer token; supports replace.
+               Use when running on Render or the box itself.
+
+Usage:
+  python scripts/stop_sweeper.py sweep --tickers AAPL,MSFT [--live]
+  python scripts/stop_sweeper.py check SYMBOL     # queue read (sqlite-first)
+  python scripts/stop_sweeper.py list             # dump sqlite state
+"""
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+log = logging.getLogger("stop_sweeper")
+
+DEFAULT_DB = os.getenv("STOP_DB_PATH", os.path.join(os.path.dirname(__file__), "..", "data", "stops.sqlite3"))
+PROXY_BASE = os.getenv("RH_PROXY_BASE", "https://allocation-engine-api.onrender.com/api/robinhood")
+BOX_BASE = os.getenv("AUTH_SERVICE_URL", "")
+BOX_TOKEN = os.getenv("RH_AUTH_SERVICE_REQUEST_TOKEN", "")
+
+TRAIL_PERCENT = float(os.getenv("STOP_TRAIL_PERCENT", "16"))
+GTC_LIFETIME_DAYS = 90          # RH cancels GTC orders after ~90 days
+EXPIRY_LEAD_DAYS = int(os.getenv("STOP_EXPIRY_LEAD_DAYS", "7"))
+
+
+# --------------------------------------------------------------------------- #
+# guardrails — this tool manages protective trailing stops, nothing else.
+# Every payload passes validate_trailing_stop_payload() at the client layer,
+# so no code path can submit a plain buy/sell/limit order through it.
+# --------------------------------------------------------------------------- #
+
+class GuardrailViolation(ValueError):
+    """Payload or MCP call outside the allowed trailing-stop surface."""
+
+
+_ALLOWED_PAYLOAD_KEYS = {
+    "account", "instrument", "symbol", "type", "time_in_force", "trigger",
+    "side", "quantity", "trailing_peg", "ref_id", "stop_price",
+}
+
+# MCP is read-only from this tool: market/portfolio reads are fine, anything
+# that could move money is not.
+MCP_READ_ONLY_TOOLS = {
+    "get_positions", "get_portfolio", "get_accounts", "get_balances",
+    "get_orders", "get_order_history", "get_quote", "get_quotes",
+    "search_symbols", "get_watchlists",
+}
+_MCP_ALLOWED_METHODS = {"initialize", "notifications/initialized",
+                        "tools/list", "tools/call", "ping"}
+
+
+def validate_trailing_stop_payload(payload, live=False):
+    """Reject anything that is not a percentage trailing-stop SELL order."""
+    if not isinstance(payload, dict):
+        raise GuardrailViolation("payload must be a dict")
+    unknown = set(payload) - _ALLOWED_PAYLOAD_KEYS
+    if unknown:
+        raise GuardrailViolation(f"unexpected payload keys: {sorted(unknown)}")
+    if payload.get("trigger") != "stop":
+        raise GuardrailViolation("trigger must be 'stop' (no immediate orders)")
+    if payload.get("side") != "sell":
+        raise GuardrailViolation("side must be 'sell' — protective stops only")
+    if payload.get("type") != "market":
+        raise GuardrailViolation("type must be 'market' (no limit orders)")
+    if payload.get("time_in_force") != "gtc":
+        raise GuardrailViolation("time_in_force must be 'gtc'")
+    peg = payload.get("trailing_peg")
+    if not isinstance(peg, dict) or peg.get("type") != "percentage":
+        raise GuardrailViolation("trailing_peg.type must be 'percentage'")
+    try:
+        pct = float(peg.get("percentage"))
+    except (TypeError, ValueError):
+        raise GuardrailViolation("trailing_peg.percentage must be numeric")
+    if not 0 < pct <= 50:
+        raise GuardrailViolation(f"trail percentage {pct} outside (0, 50]")
+    try:
+        qty = float(payload.get("quantity"))
+    except (TypeError, ValueError):
+        raise GuardrailViolation("quantity must be numeric")
+    if qty <= 0:
+        raise GuardrailViolation("quantity must be positive")
+    if live and (not payload.get("account") or not payload.get("instrument")):
+        raise GuardrailViolation(
+            "live placement requires account and instrument URLs")
+    return payload
+
+
+def validate_mcp_call(payload):
+    """Allow only read-only MCP traffic from this tool."""
+    if not isinstance(payload, dict):
+        raise GuardrailViolation("MCP payload must be a dict")
+    method = payload.get("method")
+    if method not in _MCP_ALLOWED_METHODS:
+        raise GuardrailViolation(f"MCP method '{method}' not allowed")
+    if method == "tools/call":
+        tool = (payload.get("params") or {}).get("name", "")
+        if tool not in MCP_READ_ONLY_TOOLS:
+            raise GuardrailViolation(
+                f"MCP tool '{tool}' is not read-only — blocked")
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# transports
+# --------------------------------------------------------------------------- #
+
+class ProxyClient:
+    """Talk to RH through the deployed Render proxy (works off-network)."""
+
+    def __init__(self, base=PROXY_BASE, timeout=45):
+        self.base = base.rstrip("/")
+        self.timeout = timeout
+
+    def get_stops(self):
+        r = requests.get(f"{self.base}/trailing-stop", timeout=self.timeout)
+        r.raise_for_status()
+        return r.json().get("orders", [])
+
+    def place_stop(self, payload, dry_run=True):
+        validate_trailing_stop_payload(payload, live=not dry_run)
+        r = requests.post(f"{self.base}/trailing-stop",
+                          json={"payload": payload, "dry_run": dry_run},
+                          timeout=self.timeout)
+        r.raise_for_status()
+        return r.json()
+
+    def replace_stop(self, order_id, payload, dry_run=True):
+        raise NotImplementedError(
+            "replace is not exposed via the Render proxy — run with --via box")
+
+    def mcp_call(self, payload):
+        validate_mcp_call(payload)
+        r = requests.post(f"{self.base}/mcp", json={"payload": payload},
+                          timeout=self.timeout)
+        r.raise_for_status()
+        return r.json()
+
+
+class BoxClient:
+    """Talk to the auth-service directly (Render/box network only)."""
+
+    def __init__(self, base=BOX_BASE, token=BOX_TOKEN, timeout=45):
+        if not base or not token:
+            raise SystemExit("AUTH_SERVICE_URL / RH_AUTH_SERVICE_REQUEST_TOKEN not set")
+        self.base = base.rstrip("/")
+        self.headers = {"Authorization": f"Bearer {token}"}
+        self.timeout = timeout
+
+    def get_stops(self):
+        r = requests.get(f"{self.base}/orders/trailing_stop",
+                         headers=self.headers, timeout=self.timeout)
+        r.raise_for_status()
+        return r.json().get("orders", [])
+
+    def place_stop(self, payload, dry_run=True):
+        validate_trailing_stop_payload(payload, live=not dry_run)
+        r = requests.post(f"{self.base}/orders/trailing_stop",
+                          json={"payload": payload, "dry_run": dry_run},
+                          headers=self.headers, timeout=self.timeout)
+        r.raise_for_status()
+        return r.json()
+
+    def replace_stop(self, order_id, payload, dry_run=True):
+        validate_trailing_stop_payload(payload, live=not dry_run)
+        if not order_id:
+            raise GuardrailViolation("replace requires an existing order_id")
+        r = requests.post(f"{self.base}/orders/trailing_stop/replace",
+                          json={"order_id": order_id, "payload": payload,
+                                "dry_run": dry_run},
+                          headers=self.headers, timeout=self.timeout)
+        r.raise_for_status()
+        return r.json()
+
+    def mcp_call(self, payload):
+        validate_mcp_call(payload)
+        r = requests.post(f"{self.base}/exec/mcp", json={"payload": payload},
+                          headers=self.headers, timeout=self.timeout)
+        r.raise_for_status()
+        return r.json()
+
+
+# --------------------------------------------------------------------------- #
+# sqlite store (the queue other services read)
+# --------------------------------------------------------------------------- #
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS stops (
+  symbol        TEXT PRIMARY KEY,
+  order_id      TEXT,
+  state         TEXT,
+  trail_percent REAL,
+  quantity      TEXT,
+  side          TEXT,
+  created_at    TEXT,
+  expires_at    TEXT,
+  last_synced   TEXT,
+  raw           TEXT
+);
+CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
+"""
+
+
+class StopStore:
+    def __init__(self, path=DEFAULT_DB):
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        self.path = path
+        self.db = sqlite3.connect(path)
+        self.db.row_factory = sqlite3.Row
+        self.db.executescript(SCHEMA)
+
+    def upsert(self, symbol, order):
+        created = order.get("created_at") or _now_iso()
+        expires = _plus_days(created, GTC_LIFETIME_DAYS)
+        peg = order.get("trailing_peg") or {}
+        self.db.execute(
+            """INSERT INTO stops(symbol, order_id, state, trail_percent, quantity,
+                                 side, created_at, expires_at, last_synced, raw)
+               VALUES(?,?,?,?,?,?,?,?,?,?)
+               ON CONFLICT(symbol) DO UPDATE SET
+                 order_id=excluded.order_id, state=excluded.state,
+                 trail_percent=excluded.trail_percent, quantity=excluded.quantity,
+                 side=excluded.side, created_at=excluded.created_at,
+                 expires_at=excluded.expires_at, last_synced=excluded.last_synced,
+                 raw=excluded.raw""",
+            (symbol, order.get("id"), order.get("state"),
+             float(peg.get("percentage") or 0) or None,
+             order.get("quantity"), order.get("side"),
+             created, expires, _now_iso(), json.dumps(order)))
+        self.db.commit()
+
+    def get(self, symbol):
+        row = self.db.execute("SELECT * FROM stops WHERE symbol=?", (symbol,)).fetchone()
+        return dict(row) if row else None
+
+    def all(self):
+        return [dict(r) for r in self.db.execute("SELECT * FROM stops ORDER BY symbol")]
+
+    def prune_missing(self, live_symbols):
+        rows = self.db.execute("SELECT symbol FROM stops").fetchall()
+        gone = [r["symbol"] for r in rows if r["symbol"] not in live_symbols]
+        for s in gone:
+            self.db.execute("DELETE FROM stops WHERE symbol=?", (s,))
+        if gone:
+            self.db.commit()
+        return gone
+
+    def set_meta(self, key, value):
+        self.db.execute("INSERT INTO meta(key,value) VALUES(?,?) "
+                        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                        (key, value))
+        self.db.commit()
+
+    def get_meta(self, key):
+        row = self.db.execute("SELECT value FROM meta WHERE key=?", (key,)).fetchone()
+        return row["value"] if row else None
+
+    def swept_today(self):
+        last = self.get_meta("last_sweep_at")
+        return bool(last) and last[:10] == _now_iso()[:10]
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _plus_days(iso, days):
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        dt = datetime.now(timezone.utc)
+    return (dt + timedelta(days=days)).isoformat()
+
+
+def _expiring_soon(row, lead_days=EXPIRY_LEAD_DAYS):
+    if not row or not row.get("expires_at"):
+        return False
+    exp = datetime.fromisoformat(row["expires_at"])
+    return exp - datetime.now(timezone.utc) <= timedelta(days=lead_days)
+
+
+# --------------------------------------------------------------------------- #
+# sweep + queue logic
+# --------------------------------------------------------------------------- #
+
+def build_payload(symbol, side, quantity, trail_percent,
+                  account_url="", instrument_url=""):
+    """trailing_peg percentage payload (matches the auth-service builder).
+
+    account/instrument URLs are required by RH for live placement; when empty
+    (local dry-run) the box still logs/echoes the payload without sending.
+    """
+    return {
+        "account": account_url,
+        "instrument": instrument_url,
+        "symbol": symbol,
+        "type": "market",
+        "time_in_force": "gtc",
+        "trigger": "stop",
+        "side": side,
+        "quantity": str(quantity),
+        "trailing_peg": {"type": "percentage", "percentage": str(trail_percent)},
+        "ref_id": str(uuid.uuid4()),
+    }
+
+
+def _symbol_of(order):
+    return (order.get("symbol") or order.get("chain_symbol") or "").upper()
+
+
+def sweep(client, store, tickers, trail_percent=TRAIL_PERCENT, dry_run=True):
+    """The start-of-day pass: mirror RH stops into sqlite, cover naked tickers."""
+    log.info("sweep: reading active trailing stops from RH")
+    orders = client.get_stops()
+    covered = {}
+    for o in orders:
+        sym = _symbol_of(o)
+        if sym:
+            covered[sym] = o
+            store.upsert(sym, o)
+    pruned = store.prune_missing(set(covered) | {t.upper() for t in tickers})
+    if pruned:
+        log.info("sweep: pruned stale rows: %s", pruned)
+
+    placed, renewed = [], []
+    for t in (x.upper() for x in tickers):
+        row = store.get(t)
+        if t not in covered:
+            log.info("sweep: %s has no active stop — placing %.0f%% trailing stop"
+                     " (dry_run=%s)", t, trail_percent, dry_run)
+            payload = build_payload(t, "sell", 1, trail_percent)
+            result = client.place_stop(payload, dry_run=dry_run)
+            placed.append({"symbol": t, "result": result})
+            store.upsert(t, {"id": None, "state": "dry_run" if dry_run else "submitted",
+                             "created_at": _now_iso(), "side": "sell",
+                             "quantity": "1",
+                             "trailing_peg": {"type": "percentage",
+                                              "percentage": str(trail_percent)}})
+        elif _expiring_soon(store.get(t)):
+            renewed.append(renew(client, store, t, dry_run=dry_run))
+
+    store.set_meta("last_sweep_at", _now_iso())
+    return {"active_from_rh": len(covered), "placed": placed,
+            "renewed": renewed, "pruned": pruned}
+
+
+def renew(client, store, symbol, dry_run=True):
+    """Stop is near expiry: confirm against RH, then replace (PUT) to renew."""
+    log.info("renew: %s near expiry — re-checking RH book", symbol)
+    live = {_symbol_of(o): o for o in client.get_stops()}
+    order = live.get(symbol.upper())
+    if not order:
+        log.warning("renew: %s not in RH book — will be re-placed next sweep", symbol)
+        return {"symbol": symbol, "action": "missing_in_rh"}
+    payload = build_payload(
+        symbol, order.get("side", "sell"), order.get("quantity", "1"),
+        (order.get("trailing_peg") or {}).get("percentage", TRAIL_PERCENT),
+        account_url=order.get("account", ""),
+        instrument_url=order.get("instrument", ""))
+    try:
+        result = client.replace_stop(order["id"], payload, dry_run=dry_run)
+    except (NotImplementedError, GuardrailViolation) as e:
+        log.warning("renew: %s", e)
+        return {"symbol": symbol, "action": "renew_skipped", "reason": str(e)}
+    # A live replace yields a NEW order (fresh created_at -> fresh expiry);
+    # mirror that, or expires_at never advances and we renew forever.
+    if not dry_run and isinstance(result, dict) and result.get("created_at"):
+        store.upsert(symbol.upper(), result)
+    else:
+        store.upsert(symbol.upper(), order)
+    return {"symbol": symbol, "action": "renewed", "result": result}
+
+
+def check(client, store, symbol):
+    """Queue read for other services: sqlite-first, RH only when near expiry."""
+    row = store.get(symbol.upper())
+    if row is None and not store.swept_today():
+        log.info("check: sqlite empty/stale for %s — repopulating via sweep", symbol)
+        sweep(client, store, [symbol])
+        row = store.get(symbol.upper())
+    if row and _expiring_soon(row):
+        log.info("check: %s expiring soon -> explicit RH check + renew", symbol)
+        renew(client, store, symbol)
+        row = store.get(symbol.upper())
+    if row:
+        row["expiring_soon"] = _expiring_soon(row)
+        row.pop("raw", None)
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# cli
+# --------------------------------------------------------------------------- #
+
+def main():
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)-7s %(name)s  %(message)s",
+                        datefmt="%H:%M:%S")
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("command", choices=["sweep", "check", "list"])
+    ap.add_argument("symbol", nargs="?", help="symbol for 'check'")
+    ap.add_argument("--tickers", default="", help="comma-separated universe for sweep")
+    ap.add_argument("--via", choices=["proxy", "box"], default="proxy")
+    ap.add_argument("--live", action="store_true", help="disable dry_run (real orders)")
+    ap.add_argument("--db", default=DEFAULT_DB)
+    args = ap.parse_args()
+
+    client = BoxClient() if args.via == "box" else ProxyClient()
+    store = StopStore(args.db)
+
+    if args.command == "sweep":
+        tickers = [t for t in args.tickers.split(",") if t.strip()]
+        out = sweep(client, store, tickers, dry_run=not args.live)
+    elif args.command == "check":
+        if not args.symbol:
+            ap.error("check requires a symbol")
+        out = check(client, store, args.symbol)
+    else:
+        out = {"db": os.path.abspath(args.db), "rows": store.all(),
+               "last_sweep_at": store.get_meta("last_sweep_at")}
+
+    print(json.dumps(out, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stop_sweeper.py
+++ b/tests/test_stop_sweeper.py
@@ -1,0 +1,244 @@
+"""Offline tests for scripts/stop_sweeper.py — guardrails + queue semantics.
+
+No network: a FakeClient stands in for the auth-service. The point of the
+guard tests is that NOTHING outside a percentage trailing-stop SELL order can
+leave this tool, and MCP traffic is read-only.
+"""
+
+import uuid
+
+import pytest
+
+from app import stop_sweeper as sw
+from app.stop_sweeper import (
+    GuardrailViolation,
+    StopStore,
+    build_payload,
+    check,
+    renew,
+    sweep,
+    validate_mcp_call,
+    validate_trailing_stop_payload,
+)
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+
+class FakeClient:
+    """In-memory stand-in for the auth-service; validates like real clients."""
+
+    def __init__(self, book=None):
+        self.book = book or []          # orders "on RH"
+        self.rh_reads = 0               # how often we hit "RH"
+        self.placed = []
+        self.replaced = []
+
+    def get_stops(self):
+        self.rh_reads += 1
+        return list(self.book)
+
+    def place_stop(self, payload, dry_run=True):
+        validate_trailing_stop_payload(payload, live=not dry_run)
+        self.placed.append((payload, dry_run))
+        return {"dry_run": dry_run, "payload": payload}
+
+    def replace_stop(self, order_id, payload, dry_run=True):
+        validate_trailing_stop_payload(payload, live=not dry_run)
+        if not order_id:
+            raise GuardrailViolation("replace requires an existing order_id")
+        self.replaced.append((order_id, payload, dry_run))
+        return {"dry_run": dry_run, "order_id": order_id}
+
+    def mcp_call(self, payload):
+        validate_mcp_call(payload)
+        return {"ok": True}
+
+
+def rh_order(symbol, side="sell", pct="16", order_id=None, created=None):
+    return {
+        "id": order_id or str(uuid.uuid4()),
+        "symbol": symbol,
+        "state": "confirmed",
+        "side": side,
+        "quantity": "5",
+        "trigger": "stop",
+        "created_at": created or "2026-07-01T00:00:00+00:00",
+        "account": "https://api.robinhood.com/accounts/X/",
+        "instrument": "https://api.robinhood.com/instruments/Y/",
+        "trailing_peg": {"type": "percentage", "percentage": pct},
+    }
+
+
+@pytest.fixture
+def store(tmp_path):
+    return StopStore(str(tmp_path / "stops.sqlite3"))
+
+
+# --------------------------------------------------------------------------- #
+# payload guardrails — destructive orders must not get out
+# --------------------------------------------------------------------------- #
+
+def valid_payload(**over):
+    p = build_payload("AAPL", "sell", 1, 16)
+    p.update(over)
+    return p
+
+
+def test_built_payload_passes_guard():
+    validate_trailing_stop_payload(valid_payload())
+
+
+@pytest.mark.parametrize("mutation,why", [
+    ({"side": "buy"}, "buy order"),
+    ({"trigger": "immediate"}, "plain market sell (no stop trigger)"),
+    ({"type": "limit"}, "limit order"),
+    ({"time_in_force": "gfd"}, "non-GTC"),
+    ({"trailing_peg": None}, "missing trailing peg"),
+    ({"trailing_peg": {"type": "price", "price": "5"}}, "price peg"),
+    ({"trailing_peg": {"type": "percentage", "percentage": "0"}}, "0% trail"),
+    ({"trailing_peg": {"type": "percentage", "percentage": "80"}}, ">50% trail"),
+    ({"trailing_peg": {"type": "percentage", "percentage": "nope"}}, "NaN trail"),
+    ({"quantity": "0"}, "zero quantity"),
+    ({"quantity": "-3"}, "negative quantity"),
+    ({"price": "250.00"}, "smuggled limit price key"),
+])
+def test_guard_rejects_destructive_payloads(mutation, why):
+    with pytest.raises(GuardrailViolation):
+        validate_trailing_stop_payload(valid_payload(**mutation)), why
+
+
+def test_live_placement_requires_account_and_instrument():
+    # dry-run tolerates empty URLs, live must not
+    validate_trailing_stop_payload(valid_payload(), live=False)
+    with pytest.raises(GuardrailViolation):
+        validate_trailing_stop_payload(valid_payload(), live=True)
+    validate_trailing_stop_payload(
+        valid_payload(account="https://a/", instrument="https://i/"), live=True)
+
+
+def test_fake_client_enforces_guard_on_place():
+    c = FakeClient()
+    with pytest.raises(GuardrailViolation):
+        c.place_stop(valid_payload(side="buy"))
+    assert c.placed == []
+
+
+def test_replace_requires_order_id():
+    c = FakeClient()
+    with pytest.raises(GuardrailViolation):
+        c.replace_stop("", valid_payload())
+
+
+# --------------------------------------------------------------------------- #
+# MCP guardrails — read-only surface
+# --------------------------------------------------------------------------- #
+
+def mcp(method, tool=None):
+    p = {"jsonrpc": "2.0", "id": 1, "method": method, "params": {}}
+    if tool:
+        p["params"] = {"name": tool, "arguments": {}}
+    return p
+
+
+def test_mcp_allows_readonly():
+    for payload in [mcp("initialize"), mcp("tools/list"),
+                    mcp("tools/call", "get_positions"),
+                    mcp("tools/call", "get_quote")]:
+        validate_mcp_call(payload)
+
+
+@pytest.mark.parametrize("payload", [
+    mcp("tools/call", "place_order"),
+    mcp("tools/call", "buy"),
+    mcp("tools/call", "sell_shares"),
+    mcp("tools/call", "cancel_order"),
+    mcp("tools/call", ""),
+    mcp("resources/read"),
+    mcp("completion/complete"),
+])
+def test_mcp_blocks_destructive_or_unknown(payload):
+    with pytest.raises(GuardrailViolation):
+        validate_mcp_call(payload)
+
+
+# --------------------------------------------------------------------------- #
+# sweep + queue semantics
+# --------------------------------------------------------------------------- #
+
+def test_sweep_places_only_for_uncovered(store):
+    c = FakeClient(book=[rh_order("IWN")])
+    out = sweep(c, store, ["AAPL", "IWN"])
+    assert [p["symbol"] for p in out["placed"]] == ["AAPL"]
+    assert all(dry for _, dry in c.placed), "sweep must default to dry_run"
+    assert store.get("IWN")["state"] == "confirmed"
+    assert store.get("AAPL")["state"] == "dry_run"
+
+
+def test_check_is_sqlite_first_no_rh_call(store):
+    c = FakeClient(book=[rh_order("IWN")])
+    sweep(c, store, ["IWN"])
+    reads_after_sweep = c.rh_reads
+    row = check(c, store, "IWN")
+    assert row["symbol"] == "IWN"
+    assert not row["expiring_soon"]
+    assert c.rh_reads == reads_after_sweep, "check must not hit RH when fresh"
+
+
+def test_check_repopulates_when_db_empty(store):
+    c = FakeClient(book=[rh_order("IWN")])
+    row = check(c, store, "IWN")            # empty db -> sweep -> row
+    assert row is not None
+    assert c.rh_reads >= 1
+
+
+def test_expiring_stop_triggers_explicit_rh_check_and_renew(store):
+    old = rh_order("IWN", created="2026-04-10T00:00:00+00:00")  # ~86d ago
+    c = FakeClient(book=[old])
+    sweep(c, store, ["IWN"])          # sweep itself renews the expiring stop
+    reads = c.rh_reads
+    row = check(c, store, "IWN")      # dry-run didn't change RH -> renews again
+    assert row["expiring_soon"]
+    assert c.rh_reads > reads, "near-expiry must force an RH re-read"
+    assert {r[0] for r in c.replaced} == {old["id"]}
+    assert all(r[2] is True for r in c.replaced), "renew must default to dry_run"
+
+
+def test_live_renew_refreshes_expiry_so_check_stops_renewing(store):
+    old = rh_order("IWN", created="2026-04-10T00:00:00+00:00")
+    c = FakeClient(book=[old])
+    sweep(c, store, ["IWN"], dry_run=False)   # live sweep renews for real
+
+    # simulate RH returning the replacement order with a fresh created_at
+    class LiveClient(FakeClient):
+        def replace_stop(self, order_id, payload, dry_run=True):
+            super().replace_stop(order_id, payload, dry_run)
+            return rh_order("IWN", created=sw._now_iso())
+
+    c2 = LiveClient(book=[old])
+    renew(c2, store, "IWN", dry_run=False)
+    row = store.get("IWN")
+    assert not sw._expiring_soon(row), "live renew must advance expires_at"
+    replaced_before = len(c2.replaced)
+    check(c2, store, "IWN")                    # fresh row -> no more renews
+    assert len(c2.replaced) == replaced_before
+
+
+def test_renew_skips_buy_side_stop_instead_of_crashing(store):
+    # a buy-side stop in the book must never be replayed by our sell-only tool
+    weird = rh_order("SHORTY", side="buy", created="2026-04-10T00:00:00+00:00")
+    c = FakeClient(book=[weird])
+    sweep(c, store, ["SHORTY"])
+    out = renew(c, store, "SHORTY")
+    assert out["action"] == "renew_skipped"
+    assert c.replaced == []
+
+
+def test_prune_removes_rows_gone_from_rh(store):
+    c = FakeClient(book=[rh_order("AAPL"), rh_order("IWN")])
+    sweep(c, store, ["AAPL", "IWN"])
+    c.book = [rh_order("AAPL")]              # IWN vanished from RH
+    out = sweep(c, store, ["AAPL"])
+    assert out["pruned"] == ["IWN"]
+    assert store.get("IWN") is None


### PR DESCRIPTION
## Summary
- `AuthServiceClient`: HTTPS-enforced Bearer calls to the auth-service box; logs `OTP needed` and raises on MFA/device-approval; JSON-RPC MCP passthrough via `/exec/mcp`
- New endpoints: `GET/POST /api/robinhood/trailing-stop` (allow-listed direct calls), `POST /api/robinhood/mcp` (MCP relay), `POST /api/claude/reauth` (+ status polling)
- Trailing-stop sweeper in the core engine loop: daily sweep mirrors the RH book into a local sqlite queue, places 16% trailing stops for uncovered tickers, renews near-expiry stops; sqlite-first reads (RH consulted only near expiry); all actions logged with `[stop-sweeper]` tag
- Guardrails at the client layer: only percentage trailing-stop SELL orders can leave the sweeper; MCP surface read-only; writes stay dry-run unless `STOP_SWEEP_DRY_RUN=false`

**App-side only — no `auth-service/` paths are modified** (verified: empty diff vs main under `auth-service/`).

Verified live on Render (`allocation-engine-api`): Render → Caddy → box → Robinhood round trip returns the trailing-stop book; sweeper logs visible in deploy `dep-d952657…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)