### PR TITLE
Live trailing-stop placement: real qty + instrument/account resolution

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -209,20 +209,29 @@ def start_engine_thread(app):
                         token=config.get("RH_AUTH_SERVICE_REQUEST_TOKEN", ""))
                 tickers = [t.strip().upper() for t in
                            config.get("STOP_TICKERS", "").split(",") if t.strip()]
-                tickers += [p.get("symbol", "").upper() for p in current_positions
-                            if p.get("symbol")]
-                tickers = sorted(set(tickers))
+                qty_map = {p["symbol"].upper(): p.get("qty")
+                           for p in current_positions if p.get("symbol")}
+                tickers = sorted(set(tickers) | set(qty_map))
                 dry = config.get("STOP_SWEEP_DRY_RUN", True)
+                if not dry and not qty_map:
+                    # Live sweeps need real position sizes; wait for a tick
+                    # where positions have loaded rather than latching the day.
+                    log.info("[stop-sweeper] live sweep deferred — positions "
+                             "not loaded yet")
+                    return
                 log.info("[stop-sweeper] starting daily sweep "
                          "(tickers=%s, trail=%.0f%%, dry_run=%s)",
                          tickers or "book-only", sw.TRAIL_PERCENT, dry)
-                out = sw.sweep(sweeper_client, sweeper_store, tickers, dry_run=dry)
+                out = sw.sweep(sweeper_client, sweeper_store, tickers,
+                               dry_run=dry, qty_map=qty_map,
+                               account_url=sw.account_url_from_box())
                 log.info("[stop-sweeper] sweep done: %d active in RH book, "
-                         "placed=%s, renewed=%s, pruned=%s",
+                         "placed=%s, renewed=%s, pruned=%s, skipped=%s",
                          out["active_from_rh"],
                          [p["symbol"] for p in out["placed"]] or "none",
                          [r.get("symbol") for r in out["renewed"]] or "none",
-                         out["pruned"] or "none")
+                         out["pruned"] or "none",
+                         [s["symbol"] for s in out.get("skipped", [])] or "none")
 
             import time as _time
             _engine_status["last_error"] = f"pre_loop_v3_{int(_time.time())}"
@@ -264,11 +273,6 @@ def start_engine_thread(app):
 
                 # --- Normal tick ---
                 try:
-                    try:
-                        _maybe_stop_sweep(positions)
-                    except Exception as sweep_err:
-                        log.exception("[stop-sweeper] sweep failed: %s", sweep_err)
-
                     if is_live:
                         log.info("Live mode: refreshing broker state")
                     else:
@@ -281,6 +285,13 @@ def start_engine_thread(app):
                     positions = broker.positions()
                     open_orders = broker.open_orders()
                     account = broker.account()
+
+                    # Sweep after positions load so the universe (and live
+                    # quantities) reflect the real book.
+                    try:
+                        _maybe_stop_sweep(positions)
+                    except Exception as sweep_err:
+                        log.exception("[stop-sweeper] sweep failed: %s", sweep_err)
 
                     # --- Fetch options positions & orders ---
                     options_positions = []

--- a/app/stop_sweeper.py
+++ b/app/stop_sweeper.py
@@ -335,8 +335,37 @@ def _symbol_of(order):
     return (order.get("symbol") or order.get("chain_symbol") or "").upper()
 
 
-def sweep(client, store, tickers, trail_percent=TRAIL_PERCENT, dry_run=True):
-    """The start-of-day pass: mirror RH stops into sqlite, cover naked tickers."""
+def resolve_instrument_url(symbol):
+    """Resolve a ticker to its RH instrument URL (public endpoint, no auth)."""
+    try:
+        r = requests.get("https://api.robinhood.com/instruments/",
+                         params={"symbol": symbol.upper()}, timeout=15)
+        r.raise_for_status()
+        results = r.json().get("results") or []
+        return results[0].get("url", "") if results else ""
+    except Exception as e:  # noqa: BLE001
+        log.warning("instrument lookup failed for %s: %s", symbol, e)
+        return ""
+
+
+def account_url_from_box():
+    """Derive the RH account URL from the box token cached in sqlite."""
+    try:
+        from app.box_session import get_cached_token
+        n = (get_cached_token() or {}).get("account_number", "")
+        return f"https://api.robinhood.com/accounts/{n}/" if n else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def sweep(client, store, tickers, trail_percent=TRAIL_PERCENT, dry_run=True,
+          qty_map=None, account_url="", instrument_resolver=resolve_instrument_url):
+    """The start-of-day pass: mirror RH stops into sqlite, cover naked tickers.
+
+    Live placement (dry_run=False) requires a real position quantity from
+    qty_map plus account/instrument URLs — anything unresolvable is skipped
+    and logged, never guessed.
+    """
     log.info("sweep: reading active trailing stops from RH")
     orders = client.get_stops()
     covered = {}
@@ -349,18 +378,41 @@ def sweep(client, store, tickers, trail_percent=TRAIL_PERCENT, dry_run=True):
     if pruned:
         log.info("sweep: pruned stale rows: %s", pruned)
 
-    placed, renewed = [], []
+    qty_map = {k.upper(): v for k, v in (qty_map or {}).items()}
+    placed, renewed, skipped = [], [], []
     for t in (x.upper() for x in tickers):
-        row = store.get(t)
         if t not in covered:
+            qty = qty_map.get(t)
+            instrument_url = ""
+            if not dry_run:
+                if not qty:
+                    log.warning("sweep: %s LIVE placement skipped — no position "
+                                "quantity known", t)
+                    skipped.append({"symbol": t, "reason": "no_quantity"})
+                    continue
+                instrument_url = instrument_resolver(t)
+                if not instrument_url or not account_url:
+                    log.warning("sweep: %s LIVE placement skipped — unresolved "
+                                "instrument/account URL", t)
+                    skipped.append({"symbol": t, "reason": "unresolved_urls"})
+                    continue
             log.info("sweep: %s has no active stop — placing %.0f%% trailing stop"
-                     " (dry_run=%s)", t, trail_percent, dry_run)
-            payload = build_payload(t, "sell", 1, trail_percent)
-            result = client.place_stop(payload, dry_run=dry_run)
+                     " qty=%s (dry_run=%s)", t, float(trail_percent),
+                     qty or 1, dry_run)
+            payload = build_payload(t, "sell", qty or 1, trail_percent,
+                                    account_url=account_url,
+                                    instrument_url=instrument_url)
+            try:
+                result = client.place_stop(payload, dry_run=dry_run)
+            except GuardrailViolation as e:
+                log.warning("sweep: %s placement blocked by guardrail: %s", t, e)
+                skipped.append({"symbol": t, "reason": str(e)})
+                continue
             placed.append({"symbol": t, "result": result})
-            store.upsert(t, {"id": None, "state": "dry_run" if dry_run else "submitted",
+            store.upsert(t, {"id": (result or {}).get("id"),
+                             "state": "dry_run" if dry_run else "submitted",
                              "created_at": _now_iso(), "side": "sell",
-                             "quantity": "1",
+                             "quantity": str(qty or 1),
                              "trailing_peg": {"type": "percentage",
                                               "percentage": str(trail_percent)}})
         elif _expiring_soon(store.get(t)):
@@ -368,7 +420,7 @@ def sweep(client, store, tickers, trail_percent=TRAIL_PERCENT, dry_run=True):
 
     store.set_meta("last_sweep_at", _now_iso())
     return {"active_from_rh": len(covered), "placed": placed,
-            "renewed": renewed, "pruned": pruned}
+            "renewed": renewed, "pruned": pruned, "skipped": skipped}
 
 
 def renew(client, store, symbol, dry_run=True):

--- a/tests/test_stop_sweeper.py
+++ b/tests/test_stop_sweeper.py
@@ -235,6 +235,43 @@ def test_renew_skips_buy_side_stop_instead_of_crashing(store):
     assert c.replaced == []
 
 
+def test_live_sweep_places_with_real_qty_and_urls(store):
+    c = FakeClient()
+    out = sweep(c, store, ["AAPL"], dry_run=False,
+                qty_map={"AAPL": 42.5},
+                account_url="https://api.robinhood.com/accounts/X/",
+                instrument_resolver=lambda s: f"https://api.robinhood.com/instruments/{s}/")
+    assert [p["symbol"] for p in out["placed"]] == ["AAPL"]
+    payload, dry = c.placed[0]
+    assert dry is False
+    assert payload["quantity"] == "42.5"
+    assert payload["account"] and payload["instrument"]
+    assert store.get("AAPL")["state"] == "submitted"
+
+
+def test_live_sweep_skips_without_quantity(store):
+    c = FakeClient()
+    out = sweep(c, store, ["AAPL"], dry_run=False, qty_map={},
+                account_url="https://a/", instrument_resolver=lambda s: "https://i/")
+    assert c.placed == []
+    assert out["skipped"] == [{"symbol": "AAPL", "reason": "no_quantity"}]
+
+
+def test_live_sweep_skips_unresolved_instrument(store):
+    c = FakeClient()
+    out = sweep(c, store, ["AAPL"], dry_run=False, qty_map={"AAPL": 5},
+                account_url="https://a/", instrument_resolver=lambda s: "")
+    assert c.placed == []
+    assert out["skipped"][0]["reason"] == "unresolved_urls"
+
+
+def test_dry_run_sweep_unchanged_without_urls(store):
+    c = FakeClient()
+    out = sweep(c, store, ["AAPL"], dry_run=True)
+    assert [p["symbol"] for p in out["placed"]] == ["AAPL"]
+    assert c.placed[0][1] is True
+
+
 def test_prune_removes_rows_gone_from_rh(store):
     c = FakeClient(book=[rh_order("AAPL"), rh_order("IWN")])
     sweep(c, store, ["AAPL", "IWN"])


### PR DESCRIPTION
Sizes live stops from actual positions, resolves instrument/account URLs (public endpoint + box token cache), sweeps after positions load. Skips-and-logs anything unresolvable. 79/79 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)