### PR TITLE
Trading DB write path (stock+option orders) + sqlite dir fix

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -173,6 +173,8 @@ def start_engine_thread(app):
             is_live = not config["DRY_RUN"]
             blob_interval = 15 * 60  # 15 minutes
             last_blob_sync = 0.0
+            db_sync_interval = config.get("TRADING_DB_SYNC_SECONDS", 900)
+            last_db_sync = 0.0
             retry_hour = config.get("RH_RETRY_HOUR_ET", 11)
 
             data_broker_name = config.get("DATA_BROKER", "")
@@ -232,6 +234,35 @@ def start_engine_thread(app):
                          [r.get("symbol") for r in out["renewed"]] or "none",
                          out["pruned"] or "none",
                          [s["symbol"] for s in out.get("skipped", [])] or "none")
+
+                if not dry:
+                    # Live sweeper actions land in the bot-activity feed
+                    # (de-duped on {order_id}:{status} downstream).
+                    events = []
+                    for p in out["placed"]:
+                        result = p.get("result") or {}
+                        if result.get("id"):
+                            events.append({
+                                "order_id": result["id"],
+                                "type": "TRAILING_STOP_ORDER",
+                                "status": result.get("state", "submitted"),
+                                "symbol": p["symbol"],
+                                "quantity": float(qty_map.get(p["symbol"]) or 0),
+                            })
+                    for r in out["renewed"]:
+                        result = r.get("result") or {}
+                        if r.get("action") == "renewed" and result.get("id"):
+                            events.append({
+                                "order_id": result["id"],
+                                "type": "TRAILING_STOP_REPLACED",
+                                "status": result.get("state", "submitted"),
+                                "symbol": r.get("symbol", ""),
+                            })
+                    if events:
+                        from app.trading_db import post_bot_activity
+                        res = post_bot_activity(events)
+                        log.info("[trading-db] bot activity posted: %s",
+                                 (res or {}).get("data", "failed"))
 
             import time as _time
             _engine_status["last_error"] = f"pre_loop_v3_{int(_time.time())}"
@@ -446,6 +477,24 @@ def start_engine_thread(app):
                         log.exception("Option history sync error")
 
                     now_mono = time.monotonic()
+
+                    # --- Trading DB write path (stock + option orders) ---
+                    # Not gated on is_live: dry-run engines still read the
+                    # real book and the frontend should reflect it.
+                    if (now_mono - last_db_sync) >= db_sync_interval:
+                        try:
+                            from app.trading_db import post_orders
+                            res = post_orders(
+                                open_orders=open_orders,
+                                recent_option_orders=options_open_orders,
+                            )
+                            if res:
+                                log.info("[trading-db] orders synced: %s",
+                                         res.get("data"))
+                            last_db_sync = now_mono
+                        except Exception:
+                            log.exception("[trading-db] order sync error")
+
                     if is_live and (now_mono - last_blob_sync) >= blob_interval:
                         try:
                             sync_to_blob(

--- a/app/box_session.py
+++ b/app/box_session.py
@@ -29,8 +29,17 @@ def _db_path():
     return Config.STOP_DB_PATH
 
 
+def _ensure_dir(path):
+    import os
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
 def _read_meta(path, key):
     # Short-lived connection per call — safe across Flask/engine threads.
+    # Ensure the parent dir exists (ephemeral FS: data/ may not exist yet).
+    _ensure_dir(path)
     with sqlite3.connect(path) as db:
         db.execute(_SCHEMA)
         row = db.execute("SELECT value FROM meta WHERE key=?", (key,)).fetchone()
@@ -38,8 +47,7 @@ def _read_meta(path, key):
 
 
 def _write_meta(path, key, value):
-    import os
-    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    _ensure_dir(path)
     with sqlite3.connect(path) as db:
         db.execute(_SCHEMA)
         db.execute("INSERT INTO meta(key,value) VALUES(?,?) "

--- a/app/config.py
+++ b/app/config.py
@@ -70,6 +70,13 @@ class Config:
         os.path.join(os.path.dirname(__file__), "..", "data", "stops.sqlite3"),
     )
 
+    # -- Trading DB write path (5thstreetcapital Netlify functions) --
+    TRADING_DB_URL = os.getenv(
+        "TRADING_DB_URL", "https://5thstreetcapital.org/.netlify/functions"
+    )
+    TRADING_DB_TOKEN = os.getenv("TRADING_DB_TOKEN", "")
+    TRADING_DB_SYNC_SECONDS = int(os.getenv("TRADING_DB_SYNC_SECONDS", "900"))
+
     # -- Claude Code reauth (in-box login flow) --
     # Command that starts the Claude login and prints a browser callback URL.
     CLAUDE_LOGIN_CMD = os.getenv("CLAUDE_LOGIN_CMD", "claude setup-token")

--- a/app/trading_db.py
+++ b/app/trading_db.py
@@ -1,0 +1,67 @@
+"""Write-path client for the 5thstreetcapital Trading DB (Netlify functions).
+
+POST {TRADING_DB_URL}/db-orders        — idempotent upsert keyed on order_id;
+                                         accepts the engine-blob dump shape
+                                         (open_orders / recent_orders /
+                                         open_option_orders / recent_option_orders)
+POST {TRADING_DB_URL}/db-bot-activity  — append-only events, de-duped on
+                                         {order_id}:{status}
+
+Writes are currently open; when TRADING_DB_TOKEN is set we send it as a
+Bearer. Both calls log-and-return-None on failure — a frontend outage must
+never break an engine tick.
+"""
+
+import logging
+
+import requests
+
+from app.config import Config
+
+log = logging.getLogger(__name__)
+
+
+def _headers():
+    h = {"Content-Type": "application/json"}
+    if Config.TRADING_DB_TOKEN:
+        h["Authorization"] = f"Bearer {Config.TRADING_DB_TOKEN}"
+    return h
+
+
+def _post(path, body):
+    url = f"{Config.TRADING_DB_URL.rstrip('/')}{path}"
+    try:
+        r = requests.post(url, json=body, headers=_headers(), timeout=20)
+        data = r.json() if r.content else {}
+        if not r.ok or data.get("ok") is False:
+            log.warning("[trading-db] POST %s -> %s %s", path, r.status_code,
+                        str(data)[:300])
+            return None
+        return data
+    except Exception as e:  # noqa: BLE001
+        log.warning("[trading-db] POST %s failed: %s", path, e)
+        return None
+
+
+def post_orders(open_orders=None, recent_orders=None,
+                open_option_orders=None, recent_option_orders=None):
+    """Upsert stock + option orders (engine-blob dump shape)."""
+    body = {}
+    if open_orders:
+        body["open_orders"] = list(open_orders)
+    if recent_orders:
+        body["recent_orders"] = list(recent_orders)
+    if open_option_orders:
+        body["open_option_orders"] = [dict(o) for o in open_option_orders]
+    if recent_option_orders:
+        body["recent_option_orders"] = [dict(o) for o in recent_option_orders]
+    if not body:
+        return None
+    return _post("/db-orders", body)
+
+
+def post_bot_activity(events):
+    """Append bot activity events (de-dup key {order_id}:{status})."""
+    if not events:
+        return None
+    return _post("/db-bot-activity", {"events": list(events)})

--- a/tests/test_trading_db.py
+++ b/tests/test_trading_db.py
@@ -1,0 +1,66 @@
+"""Offline tests for app/trading_db.py — Trading DB write path."""
+
+from unittest import mock
+
+from app import trading_db as tdb
+
+
+def _ok_response(payload=None):
+    r = mock.Mock()
+    r.ok = True
+    r.status_code = 200
+    r.content = b"{}"
+    r.json.return_value = payload or {"ok": True, "data": {}}
+    return r
+
+
+def test_post_orders_engine_dump_shape():
+    with mock.patch.object(tdb.requests, "post", return_value=_ok_response()) as p:
+        tdb.post_orders(open_orders=[{"id": "1"}],
+                        recent_option_orders=[{"order_id": "2", "legs": []}])
+        url = p.call_args.args[0]
+        body = p.call_args.kwargs["json"]
+        assert url.endswith("/db-orders")
+        assert body == {"open_orders": [{"id": "1"}],
+                        "recent_option_orders": [{"order_id": "2", "legs": []}]}
+
+
+def test_post_orders_skips_when_empty():
+    with mock.patch.object(tdb.requests, "post") as p:
+        assert tdb.post_orders() is None
+        assert tdb.post_orders(open_orders=[], recent_option_orders=[]) is None
+        p.assert_not_called()
+
+
+def test_post_bot_activity_shape():
+    with mock.patch.object(tdb.requests, "post", return_value=_ok_response()) as p:
+        tdb.post_bot_activity([{"order_id": "x", "type": "TRAILING_STOP_ORDER",
+                                "status": "confirmed", "symbol": "AAPL"}])
+        assert p.call_args.args[0].endswith("/db-bot-activity")
+        assert "events" in p.call_args.kwargs["json"]
+
+
+def test_failures_never_raise():
+    with mock.patch.object(tdb.requests, "post",
+                           side_effect=tdb.requests.RequestException("down")):
+        assert tdb.post_orders(open_orders=[{"id": "1"}]) is None
+        assert tdb.post_bot_activity([{"order_id": "x", "status": "s"}]) is None
+
+
+def test_ok_false_treated_as_failure():
+    bad = _ok_response({"ok": False, "error": {"message": "bad shape"}})
+    with mock.patch.object(tdb.requests, "post", return_value=bad):
+        assert tdb.post_orders(open_orders=[{"id": "1"}]) is None
+
+
+def test_token_header_when_configured(monkeypatch):
+    monkeypatch.setattr(tdb.Config, "TRADING_DB_TOKEN", "sekret")
+    with mock.patch.object(tdb.requests, "post", return_value=_ok_response()) as p:
+        tdb.post_orders(open_orders=[{"id": "1"}])
+        assert p.call_args.kwargs["headers"]["Authorization"] == "Bearer sekret"
+
+
+def test_no_token_header_by_default():
+    with mock.patch.object(tdb.requests, "post", return_value=_ok_response()) as p:
+        tdb.post_orders(open_orders=[{"id": "1"}])
+        assert "Authorization" not in p.call_args.kwargs["headers"]


### PR DESCRIPTION
Syncs stock + option orders to db-orders and live sweeper actions to db-bot-activity. Fixes worker crashloop (sqlite parent dir missing on ephemeral FS). 86/86 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)