### PR TITLE
Add IBKR broker surface: orders + inter-broker fund transfer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # === Broker Selection ===
-ENABLED_BROKERS=robinhood,alpaca
+ENABLED_BROKERS=robinhood,alpaca,ibkr
 DEFAULT_BROKER=robinhood
 
 # === Robinhood ===
@@ -23,6 +23,14 @@ RH_PICKLE_NAME=taipei_session
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=
 ALPACA_PAPER=true
+
+# === IBKR (Client Portal Gateway) ===
+# A CP Gateway process must already be running and logged in via its
+# browser UI — this app never performs the IBKR login itself.
+IBKR_GATEWAY_URL=https://localhost:5000/v1/api
+IBKR_ACCOUNT_ID=                # Optional: pins a specific account; else the first one reported
+IBKR_VERIFY_SSL=false           # CP Gateway's default cert is self-signed
+IBKR_REQUEST_TIMEOUT=15
 
 # === Runtime Service ===
 RUNTIME_SERVICE_URL=https://route-runtime-service.netlify.app/api

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Allocation Engine 2.0
 
-Flask API service for portfolio monitoring and trade execution across **Robinhood** and **Alpaca** brokers. Deploys on Render via gunicorn.
+Flask API service for portfolio monitoring and trade execution across **Robinhood**, **Alpaca**, and **IBKR** brokers. Deploys on Render via gunicorn.
 
 ## How it works
 
@@ -54,8 +54,26 @@ python main.py --broker alpaca run
 | GET | `/api/portfolio[/<broker>]` | Account + positions combined |
 | GET | `/api/engine/status` | Background engine loop status |
 | POST | `/api/engine/tick` | Manually trigger reconciliation |
+| POST | `/api/trade/order[/<broker>]` | Place an order (market/limit/stop/stop_limit) |
+| POST | `/api/trade/buy[/<broker>]` | Convenience: place a BUY order |
+| POST | `/api/trade/sell[/<broker>]` | Convenience: place a SELL order |
+| POST/DELETE | `/api/trade/cancel/<order_id>[/<broker>]` | Cancel a specific order |
+| POST/DELETE | `/api/trade/cancel-all[/<broker>]` | Cancel all open orders |
+| GET | `/api/transfer/bank-accounts/<broker>` | Linked bank accounts for ACH transfer |
+| POST | `/api/transfer/deposit/<broker>` | Deposit from linked bank into the broker |
+| POST | `/api/transfer/withdraw/<broker>` | Withdraw from the broker to linked bank |
+| GET | `/api/transfer/history/<broker>` | Past ACH transfers |
+| POST | `/api/transfer/between` | Move funds between Robinhood and IBKR (two ACH legs) |
 
-Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca` or `/robinhood` to target a specific broker.
+Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca`, `/robinhood`, or `/ibkr` to target a specific broker.
+
+Trade and transfer endpoints respect `DRY_RUN` (or a per-request `dry_run` body field) — orders/transfers are validated
+and echoed back but not submitted unless `dry_run=false`.
+
+**IBKR funding note:** IBKR's Client Portal Web API doesn't expose ACH deposit/withdraw initiation for retail
+accounts, so `/api/transfer/*/ibkr` returns `501` — move IBKR-side funds via the Client Portal web/mobile app.
+Robinhood's side is fully functional. `/api/transfer/between` always does the Robinhood leg for real and reports
+the IBKR leg as unsupported until IBKR exposes that capability.
 
 ## Environment Variables
 
@@ -69,6 +87,9 @@ Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca` or `/robinhood` to
 | `ALPACA_API_KEY` | Alpaca API key | required for Alpaca |
 | `ALPACA_SECRET_KEY` | Alpaca secret key | required for Alpaca |
 | `ALPACA_PAPER` | Use Alpaca paper trading | `true` |
+| `IBKR_GATEWAY_URL` | IBKR Client Portal Gateway base URL | `https://localhost:5000/v1/api` |
+| `IBKR_ACCOUNT_ID` | Pin a specific IBKR account | first account reported by the gateway |
+| `IBKR_VERIFY_SSL` | Verify the gateway's TLS cert | `false` |
 | `RUNTIME_SERVICE_URL` | Runtime service base URL | `https://route-runtime-service.netlify.app/api` |
 | `POLL_INTERVAL_SECONDS` | Engine loop interval | `30` |
 | `DRY_RUN` | Log orders without submitting | `true` |
@@ -120,9 +141,11 @@ graph TD
 
     BROKER --> RH[RobinhoodTrader<br/><i>robin-stocks + pyotp</i>]
     BROKER --> ALP[AlpacaTrader<br/><i>alpaca-py</i>]
+    BROKER --> IBK[IBKRTrader<br/><i>REST vs CP Gateway</i>]
 
     RH -->|REST| RH_API[Robinhood API]
     ALP -->|REST| ALP_API[Alpaca API]
+    IBK -->|REST, local| IBK_GW[IBKR CP Gateway<br/><i>must already be logged in</i>]
 
     SCHEMAS[Pydantic Schemas<br/><i>deploy-time contract checks</i>] -.->|validates| FLASK
 ```
@@ -195,5 +218,9 @@ graph TD
 
     BREG --> ALP[alpaca_client.py]
     BREG --> RHC[robinhood_client.py]
-    ALP & RHC -.->|implements| BASE
+    BREG --> IBKC[ibkr_client.py]
+    ALP & RHC & IBKC -.->|implements| BASE
+
+    API --> TRF[transfer.py<br/><i>deposit / withdraw / between</i>]
+    TRF --> BREG
 ```

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -14,9 +14,11 @@ def register_blueprints(app):
     from app.api.events import bp as events_bp
     from app.api.robinhood_proxy import bp as robinhood_proxy_bp
     from app.api.claude_auth import bp as claude_auth_bp
+    from app.api.transfer import bp as transfer_bp
 
     for blueprint in [health_bp, account_bp, positions_bp, orders_bp,
                       portfolio_bp, engine_bp, trade_bp, quote_bp,
                       history_bp, options_bp, auth_bp, snapshot_bp,
-                      events_bp, robinhood_proxy_bp, claude_auth_bp]:
+                      events_bp, robinhood_proxy_bp, claude_auth_bp,
+                      transfer_bp]:
         app.register_blueprint(blueprint, url_prefix="/api")

--- a/app/api/transfer.py
+++ b/app/api/transfer.py
@@ -1,0 +1,212 @@
+"""Funding API — deposit/withdraw between a linked bank account and a broker,
+plus a convenience endpoint to move funds between our two broker accounts.
+
+There is no direct broker-to-broker rail: moving money "from Robinhood to
+IBKR" is two independent ACH legs against the same linked bank account
+(withdraw from one broker, deposit into the other), not a single transfer
+call. IBKR's Client Portal Web API does not expose fund-transfer initiation
+at all for retail accounts (see IBKRTrader), so IBKR-side deposit/withdraw/
+history calls return 501 until that changes — Robinhood's side is fully
+functional via robin_stocks' ACH endpoints.
+"""
+
+from flask import Blueprint, jsonify, request, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("transfer", __name__)
+
+
+def _unsupported(broker_name, e):
+    return jsonify({"error": str(e), "broker": broker_name, "supported": False}), 501
+
+
+def _dry_run(body: dict) -> bool:
+    return bool(body.get("dry_run", body.get("dryRun", current_app.config.get("DRY_RUN", True))))
+
+
+@bp.route("/transfer/bank-accounts/<broker_name>")
+def bank_accounts(broker_name):
+    try:
+        broker = get_broker(broker_name)
+        return jsonify({"broker": broker_name, "accounts": broker.linked_bank_accounts()})
+    except NotImplementedError as e:
+        return _unsupported(broker_name, e)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer/deposit/<broker_name>", methods=["POST"])
+def deposit(broker_name):
+    """Deposit funds from a linked bank account into `broker_name`.
+
+    Body JSON:
+        amount:           float (required) dollar amount, > 0
+        ach_relationship: str   (required for Robinhood) linked bank account id
+        dry_run:          bool  (optional) override global dry_run setting
+    """
+    body = request.get_json(silent=True) or {}
+    amount = body.get("amount")
+    if amount is None:
+        return jsonify({"error": "amount is required"}), 400
+    try:
+        amount = float(amount)
+    except (TypeError, ValueError):
+        return jsonify({"error": "amount must be a number"}), 400
+    if amount <= 0:
+        return jsonify({"error": "amount must be positive"}), 400
+
+    if _dry_run(body):
+        return jsonify({
+            "status": "simulated", "dry_run": True, "broker": broker_name, "amount": amount,
+            "message": "Deposit validated but not submitted (dry_run=true)",
+        })
+
+    try:
+        broker = get_broker(broker_name)
+        result = broker.deposit(amount, ach_relationship=body.get("ach_relationship"))
+        if result is None:
+            return jsonify({"error": "Broker rejected the deposit"}), 502
+        return jsonify({"status": "submitted", "broker": broker_name, **result}), 201
+    except NotImplementedError as e:
+        return _unsupported(broker_name, e)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer/withdraw/<broker_name>", methods=["POST"])
+def withdraw(broker_name):
+    """Withdraw funds from `broker_name` to a linked bank account.
+
+    Body JSON:
+        amount:           float (required) dollar amount, > 0
+        ach_relationship: str   (required for Robinhood) linked bank account id
+        dry_run:          bool  (optional) override global dry_run setting
+    """
+    body = request.get_json(silent=True) or {}
+    amount = body.get("amount")
+    if amount is None:
+        return jsonify({"error": "amount is required"}), 400
+    try:
+        amount = float(amount)
+    except (TypeError, ValueError):
+        return jsonify({"error": "amount must be a number"}), 400
+    if amount <= 0:
+        return jsonify({"error": "amount must be positive"}), 400
+
+    if _dry_run(body):
+        return jsonify({
+            "status": "simulated", "dry_run": True, "broker": broker_name, "amount": amount,
+            "message": "Withdrawal validated but not submitted (dry_run=true)",
+        })
+
+    try:
+        broker = get_broker(broker_name)
+        result = broker.withdraw(amount, ach_relationship=body.get("ach_relationship"))
+        if result is None:
+            return jsonify({"error": "Broker rejected the withdrawal"}), 502
+        return jsonify({"status": "submitted", "broker": broker_name, **result}), 201
+    except NotImplementedError as e:
+        return _unsupported(broker_name, e)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer/history/<broker_name>")
+def history(broker_name):
+    try:
+        broker = get_broker(broker_name)
+        return jsonify({
+            "broker": broker_name,
+            "transfers": broker.transfer_history(direction=request.args.get("direction")),
+        })
+    except NotImplementedError as e:
+        return _unsupported(broker_name, e)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer/between", methods=["POST"])
+def between():
+    """Move funds between our two broker accounts via their shared bank
+    account: withdraw `amount` from `from_broker`, then deposit it into
+    `to_broker`. The two legs are independent ACH calls — this does not wait
+    for the withdrawal to settle before firing the deposit, so keep amounts
+    within what the source account can safely float.
+
+    Body JSON:
+        from_broker: str   (required) "robinhood" or "ibkr"
+        to_broker:   str   (required) "robinhood" or "ibkr", must differ from from_broker
+        amount:      float (required) dollar amount, > 0
+        from_ach_relationship: str (required for Robinhood as source)
+        to_ach_relationship:   str (required for Robinhood as destination)
+        dry_run:     bool  (optional) override global dry_run setting
+    """
+    body = request.get_json(silent=True) or {}
+    from_broker = body.get("from_broker")
+    to_broker = body.get("to_broker")
+    amount = body.get("amount")
+
+    errors = []
+    if from_broker not in ("robinhood", "ibkr"):
+        errors.append("from_broker must be 'robinhood' or 'ibkr'")
+    if to_broker not in ("robinhood", "ibkr"):
+        errors.append("to_broker must be 'robinhood' or 'ibkr'")
+    if from_broker == to_broker and not errors:
+        errors.append("from_broker and to_broker must differ")
+    if amount is None:
+        errors.append("amount is required")
+    else:
+        try:
+            amount = float(amount)
+            if amount <= 0:
+                errors.append("amount must be positive")
+        except (TypeError, ValueError):
+            errors.append("amount must be a number")
+    if errors:
+        return jsonify({"error": "Validation failed", "details": errors}), 400
+
+    if _dry_run(body):
+        return jsonify({
+            "status": "simulated", "dry_run": True,
+            "from_broker": from_broker, "to_broker": to_broker, "amount": amount,
+            "message": "Transfer validated but not submitted (dry_run=true)",
+        })
+
+    try:
+        source = get_broker(from_broker)
+        withdrawal = source.withdraw(amount, ach_relationship=body.get("from_ach_relationship"))
+        if withdrawal is None:
+            return jsonify({"error": f"{from_broker} rejected the withdrawal"}), 502
+    except NotImplementedError as e:
+        return _unsupported(from_broker, e)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    try:
+        dest = get_broker(to_broker)
+        deposit_result = dest.deposit(amount, ach_relationship=body.get("to_ach_relationship"))
+    except Exception as e:
+        return jsonify({
+            "status": "partial",
+            "withdrawal": withdrawal,
+            "deposit_error": str(e),
+            "message": f"Withdrew from {from_broker} but the {to_broker} deposit "
+                       "failed or is unsupported — complete it manually.",
+        }), 207
+
+    if deposit_result is None:
+        return jsonify({
+            "status": "partial", "withdrawal": withdrawal,
+            "message": f"Withdrew from {from_broker} but {to_broker} rejected the deposit",
+        }), 207
+
+    return jsonify({
+        "status": "submitted", "from_broker": from_broker, "to_broker": to_broker,
+        "amount": amount, "withdrawal": withdrawal, "deposit": deposit_result,
+    }), 201

--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -6,7 +6,7 @@ _broker_cache: dict[str, BrokerClient] = {}
 
 
 def get_broker(name: str) -> BrokerClient:
-    """Get or create a broker client by name ('alpaca' or 'robinhood')."""
+    """Get or create a broker client by name ('alpaca', 'robinhood', or 'ibkr')."""
     if name in _broker_cache:
         return _broker_cache[name]
 
@@ -30,6 +30,14 @@ def get_broker(name: str) -> BrokerClient:
             totp_secret=config.get("RH_TOTP_SECRET", ""),
             pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
             account_number=config.get("RH_AUTOMATED_ACCOUNT_NUMBER", ""),
+        )
+    elif name == "ibkr":
+        from app.brokers.ibkr_client import IBKRTrader
+        client = IBKRTrader(
+            gateway_url=config["IBKR_GATEWAY_URL"],
+            account_id=config.get("IBKR_ACCOUNT_ID", ""),
+            verify_ssl=config.get("IBKR_VERIFY_SSL", False),
+            timeout=config.get("IBKR_REQUEST_TIMEOUT", 15),
         )
     else:
         raise ValueError(f"Unknown broker: {name}")

--- a/app/brokers/base.py
+++ b/app/brokers/base.py
@@ -39,3 +39,24 @@ class BrokerClient(ABC):
     def cancel_all(self) -> None:
         """Cancel all open orders."""
         pass
+
+    # -- funding: linked-bank deposit/withdraw (optional) --------------------
+    # Not every broker supports ACH transfer initiation via API; the default
+    # implementations below raise so callers get a clean, catchable error
+    # instead of an AttributeError. Brokers that do support it override these.
+
+    def linked_bank_accounts(self) -> list[dict]:
+        """Return linked bank accounts available for ACH transfer."""
+        raise NotImplementedError(f"{type(self).__name__} does not support linked bank accounts")
+
+    def deposit(self, amount: float, **kwargs) -> dict | None:
+        """Deposit funds from a linked bank account into the broker."""
+        raise NotImplementedError(f"{type(self).__name__} does not support deposits")
+
+    def withdraw(self, amount: float, **kwargs) -> dict | None:
+        """Withdraw funds from the broker to a linked bank account."""
+        raise NotImplementedError(f"{type(self).__name__} does not support withdrawals")
+
+    def transfer_history(self, **kwargs) -> list[dict]:
+        """Return past bank transfers (deposits and withdrawals)."""
+        raise NotImplementedError(f"{type(self).__name__} does not support transfer history")

--- a/app/brokers/ibkr_client.py
+++ b/app/brokers/ibkr_client.py
@@ -1,0 +1,329 @@
+"""IBKR trading client — talks to a locally running IBKR Client Portal
+Gateway (CP Gateway) over its REST API.
+
+Unlike the Robinhood client, there is no auth-service box for IBKR: the CP
+Gateway process itself owns the session. IBKR requires an interactive
+browser login against the gateway to establish that session — this cannot
+be automated from here, so this client never attempts to log in. It only
+talks to an already-authenticated gateway and pings `/tickle` to keep the
+session alive, mirroring the "never authenticate ourselves" posture the
+Robinhood client takes toward the auth-service box.
+
+Reference: IBKR Client Portal Web API — https://interactivebrokers.github.io/cpwebapi/
+
+Note: IBKR's Client Portal Web API does not expose fund-transfer (ACH
+deposit/withdraw) initiation for retail accounts, so the funding methods
+below raise NotImplementedError — see BrokerClient's defaults and
+app/api/transfer.py for how that surfaces to callers.
+"""
+
+import logging
+
+import requests
+
+from app.brokers.base import BrokerClient
+from app.enums import OrderType
+
+log = logging.getLogger(__name__)
+
+# Cache symbol -> contract id (conid) resolutions to avoid repeated lookups.
+_conid_cache: dict[str, int] = {}
+
+_IBKR_TYPE_TO_ORDER_TYPE = {
+    "MKT": OrderType.MARKET,
+    "LMT": OrderType.LIMIT,
+    "STP": OrderType.STOP,
+    "STOP_LIMIT": OrderType.STOP_LIMIT,
+}
+
+_OPEN_STATUSES = {"PendingSubmit", "PreSubmitted", "Submitted", "PendingCancel", "ApiPending"}
+
+
+class IBKRTrader(BrokerClient):
+    def __init__(
+        self,
+        gateway_url: str = "https://localhost:5000/v1/api",
+        account_id: str = "",
+        verify_ssl: bool = False,
+        timeout: int = 15,
+    ):
+        self.base_url = gateway_url.rstrip("/")
+        self.account_id = account_id
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+        self._session = requests.Session()
+        if not verify_ssl:
+            # CP Gateway ships with a self-signed cert by default.
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning
+            )
+
+    # -- low-level request helper --------------------------------------------
+
+    def _request(self, method: str, path: str, **kwargs):
+        url = f"{self.base_url}{path}"
+        resp = self._session.request(
+            method, url, timeout=self.timeout, verify=self.verify_ssl, **kwargs
+        )
+        resp.raise_for_status()
+        if not resp.content:
+            return {}
+        return resp.json()
+
+    # -- session --------------------------------------------------------------
+
+    def _ensure_auth(self):
+        """Verify the CP Gateway session is authenticated. Never logs in —
+        the gateway requires an interactive browser login out-of-band."""
+        try:
+            status = self._request("GET", "/iserver/auth/status")
+        except requests.RequestException as e:
+            raise RuntimeError(f"IBKR CP Gateway unreachable at {self.base_url}: {e}") from e
+
+        if not status.get("authenticated") and status.get("connected"):
+            # SSO session still alive but the brokerage session lapsed —
+            # this reauth is a re-handshake, not a login.
+            try:
+                self._request("POST", "/iserver/reauthenticate")
+                status = self._request("GET", "/iserver/auth/status")
+            except requests.RequestException:
+                pass
+
+        if not status.get("authenticated"):
+            gateway_root = self.base_url.split("/v1/api")[0]
+            raise RuntimeError(
+                "IBKR CP Gateway is not authenticated — log in via the "
+                f"gateway's browser UI at {gateway_root}"
+            )
+
+        try:
+            self._request("POST", "/tickle")
+        except requests.RequestException:
+            log.warning("IBKR /tickle keep-alive failed", exc_info=True)
+
+    def _resolve_account_id(self) -> str:
+        if self.account_id:
+            return self.account_id
+        accounts = self._request("GET", "/iserver/accounts")
+        ids = accounts.get("accounts") or []
+        if not ids:
+            raise RuntimeError("IBKR gateway returned no accounts")
+        self.account_id = ids[0]
+        return self.account_id
+
+    # -- contract resolution ---------------------------------------------------
+
+    def _conid(self, symbol: str) -> int:
+        symbol = symbol.upper()
+        if symbol in _conid_cache:
+            return _conid_cache[symbol]
+        results = self._request("GET", "/iserver/secdef/search", params={"symbol": symbol}) or []
+        for r in results:
+            if not isinstance(r, dict) or not r.get("conid"):
+                continue
+            if r.get("secType", "STK") == "STK":
+                conid = int(r["conid"])
+                _conid_cache[symbol] = conid
+                return conid
+        raise ValueError(f"Could not resolve IBKR contract id for symbol {symbol}")
+
+    # -- account / positions ----------------------------------------------------
+
+    def account(self) -> dict:
+        self._ensure_auth()
+        account_id = self._resolve_account_id()
+        summary = self._request("GET", f"/portfolio/{account_id}/summary") or {}
+
+        def amt(key):
+            return float((summary.get(key) or {}).get("amount", 0) or 0)
+
+        return {
+            "equity": amt("netliquidation"),
+            "cash": amt("totalcashvalue"),
+            "buying_power": amt("buyingpower"),
+            "portfolio_value": amt("netliquidation"),
+        }
+
+    def positions(self) -> list[dict]:
+        self._ensure_auth()
+        account_id = self._resolve_account_id()
+        result = []
+        page = 0
+        while True:
+            raw = self._request("GET", f"/portfolio/{account_id}/positions/{page}") or []
+            if not raw:
+                break
+            for pos in raw:
+                qty = float(pos.get("position", 0) or 0)
+                if qty == 0:
+                    continue
+                avg_cost = float(pos.get("avgCost", 0) or 0)
+                mkt_price = float(pos.get("mktPrice", avg_cost) or avg_cost)
+                mkt_value = float(pos.get("mktValue", qty * mkt_price) or (qty * mkt_price))
+                cost_basis = qty * avg_cost
+                unrealized_pl = mkt_value - cost_basis
+                result.append({
+                    "symbol": pos.get("ticker") or pos.get("contractDesc", "UNKNOWN"),
+                    "qty": qty,
+                    "side": "long" if qty > 0 else "short",
+                    "market_value": round(mkt_value, 2),
+                    "avg_entry": avg_cost,
+                    "unrealized_pl": round(unrealized_pl, 2),
+                    "unrealized_pl_pct": round(unrealized_pl / cost_basis, 4) if cost_basis else 0.0,
+                })
+            if len(raw) < 100:  # IBKR paginates positions at 100/page
+                break
+            page += 1
+        return result
+
+    def open_orders(self) -> list[dict]:
+        self._ensure_auth()
+        raw = self._request("GET", "/iserver/account/orders") or {}
+        orders = raw.get("orders", []) if isinstance(raw, dict) else []
+        result = []
+        for o in orders:
+            if not isinstance(o, dict) or o.get("status") not in _OPEN_STATUSES:
+                continue
+            qty = o.get("remainingQuantity")
+            if qty is None:
+                qty = o.get("totalSize", 0)
+            result.append({
+                "id": str(o.get("orderId", "")),
+                "symbol": o.get("ticker", ""),
+                "side": (o.get("side") or "").upper(),
+                "qty": float(qty or 0),
+                "type": _IBKR_TYPE_TO_ORDER_TYPE.get(o.get("orderType", ""), "market"),
+                "limit_price": float(o["price"]) if o.get("price") else None,
+                "stop_price": float(o["auxPrice"]) if o.get("auxPrice") else None,
+                "status": o.get("status", "unknown"),
+            })
+        return result
+
+    # -- order submission ---------------------------------------------------
+
+    def submit_order(self, order: dict) -> dict | None:
+        self._ensure_auth()
+        account_id = self._resolve_account_id()
+        symbol = order["symbol"]
+        side = order["side"].upper()
+        qty = float(order["quantity"])
+        otype = order.get("order_type", OrderType.MARKET).lower()
+        limit_px = order.get("limit_price")
+        stop_px = order.get("stop_price")
+
+        try:
+            conid = self._conid(symbol)
+        except ValueError as e:
+            log.error("IBKR order error: %s", e)
+            return None
+
+        payload = {"conid": conid, "side": side, "quantity": qty, "tif": "GTC", "acctId": account_id}
+        if otype == OrderType.LIMIT and limit_px is not None:
+            payload["orderType"] = "LMT"
+            payload["price"] = float(limit_px)
+        elif otype == OrderType.STOP and stop_px is not None:
+            payload["orderType"] = "STP"
+            payload["auxPrice"] = float(stop_px)
+        elif otype == OrderType.STOP_LIMIT and limit_px is not None and stop_px is not None:
+            payload["orderType"] = "STOP_LIMIT"
+            payload["price"] = float(limit_px)
+            payload["auxPrice"] = float(stop_px)
+        else:
+            payload["orderType"] = "MKT"
+
+        try:
+            resp = self._request(
+                "POST", f"/iserver/account/{account_id}/orders", json={"orders": [payload]}
+            )
+            resp = self._confirm_order_questions(resp)
+
+            if isinstance(resp, list) and resp:
+                first = resp[0]
+                order_id = first.get("order_id") or first.get("orderId")
+                if order_id:
+                    log.info("IBKR order submitted: %s %s %s @ %s -> %s",
+                             side, qty, symbol, limit_px or stop_px or "MKT", order_id)
+                    return {
+                        "id": str(order_id),
+                        "symbol": symbol,
+                        "status": first.get("order_status", "submitted"),
+                    }
+            log.error("IBKR order response had no order id: %s", resp)
+            return None
+        except requests.RequestException as e:
+            log.error("IBKR order error for %s %s %s: %s", side, qty, symbol, e)
+            return None
+
+    def _confirm_order_questions(self, resp, _depth: int = 0):
+        """IBKR sometimes replies with precaution questions (e.g. an order
+        value warning) instead of a fill — auto-confirm up to a few rounds
+        rather than leaving the order stuck unconfirmed."""
+        if _depth > 5 or not isinstance(resp, list):
+            return resp
+        pending = [r for r in resp if isinstance(r, dict) and r.get("id") and "message" in r]
+        if not pending:
+            return resp
+        for q in pending:
+            resp = self._request("POST", f"/iserver/reply/{q['id']}", json={"confirmed": True})
+        return self._confirm_order_questions(resp, _depth + 1)
+
+    def cancel_order(self, order_id: str):
+        self._ensure_auth()
+        account_id = self._resolve_account_id()
+        self._request("DELETE", f"/iserver/account/{account_id}/order/{order_id}")
+        log.info("Cancelled IBKR order %s", order_id)
+
+    def cancel_all(self):
+        """IBKR's CPAPI has no bulk-cancel endpoint — cancel each open order."""
+        for o in self.open_orders():
+            try:
+                self.cancel_order(o["id"])
+            except requests.RequestException:
+                log.exception("Failed to cancel IBKR order %s", o["id"])
+        log.info("All IBKR orders cancelled")
+
+    # -- auth status ----------------------------------------------------------
+
+    def auth_status(self) -> dict:
+        try:
+            status = self._request("GET", "/iserver/auth/status")
+        except requests.RequestException as e:
+            return {"authenticated": False, "connected": False, "error": str(e),
+                     "gateway_url": self.base_url}
+        return {
+            "authenticated": bool(status.get("authenticated")),
+            "connected": bool(status.get("connected")),
+            "competing": bool(status.get("competing")),
+            "gateway_url": self.base_url,
+        }
+
+    # -- funding: not available via IBKR's retail Web API ---------------------
+    # IBKR's Client Portal Web API does not expose ACH deposit/withdraw
+    # initiation for retail accounts — funding must be done through the
+    # Client Portal web or mobile app. These overrides just give a more
+    # specific message than BrokerClient's generic default.
+
+    def linked_bank_accounts(self) -> list[dict]:
+        raise NotImplementedError(
+            "IBKR's Client Portal Web API does not expose linked bank "
+            "accounts — manage bank instructions via the Client Portal "
+            "web or mobile app."
+        )
+
+    def deposit(self, amount: float, **kwargs) -> dict | None:
+        raise NotImplementedError(
+            "IBKR's Client Portal Web API does not support initiating ACH "
+            "deposits — use the Client Portal web or mobile app."
+        )
+
+    def withdraw(self, amount: float, **kwargs) -> dict | None:
+        raise NotImplementedError(
+            "IBKR's Client Portal Web API does not support initiating ACH "
+            "withdrawals — use the Client Portal web or mobile app."
+        )
+
+    def transfer_history(self, **kwargs) -> list[dict]:
+        raise NotImplementedError(
+            "IBKR's Client Portal Web API does not expose transfer history — "
+            "check the Client Portal web or mobile app."
+        )

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -538,6 +538,61 @@ class RobinhoodTrader(BrokerClient):
                 break
         return result
 
+    # -- funding: linked-bank ACH deposit/withdraw ---------------------------
+
+    def linked_bank_accounts(self) -> list[dict]:
+        """List bank accounts linked for ACH transfer."""
+        self._ensure_auth()
+        raw = rh.account.get_linked_bank_accounts() or []
+        return [
+            {
+                "id": b.get("id"),
+                "bank_name": b.get("bank_name") or b.get("name"),
+                "account_type": b.get("type"),
+                "verified": b.get("verified"),
+            }
+            for b in raw if isinstance(b, dict)
+        ]
+
+    def deposit(self, amount: float, ach_relationship: str = "", **kwargs) -> dict | None:
+        """Deposit funds from a linked bank account into Robinhood via ACH."""
+        if not ach_relationship:
+            raise ValueError("ach_relationship is required for Robinhood deposits")
+        self._ensure_auth()
+        result = rh.account.deposit_funds_to_robinhood_account(ach_relationship, amount)
+        if result and result.get("id"):
+            log.info("RH deposit initiated: $%s -> %s", amount, result["id"])
+            return {"id": result["id"], "amount": float(amount), "state": result.get("state")}
+        log.error("RH deposit failed for $%s: %s", amount, result)
+        return None
+
+    def withdraw(self, amount: float, ach_relationship: str = "", **kwargs) -> dict | None:
+        """Withdraw funds from Robinhood to a linked bank account via ACH."""
+        if not ach_relationship:
+            raise ValueError("ach_relationship is required for Robinhood withdrawals")
+        self._ensure_auth()
+        result = rh.account.withdrawl_funds_to_bank_account(ach_relationship, amount)
+        if result and result.get("id"):
+            log.info("RH withdrawal initiated: $%s -> %s", amount, result["id"])
+            return {"id": result["id"], "amount": float(amount), "state": result.get("state")}
+        log.error("RH withdrawal failed for $%s: %s", amount, result)
+        return None
+
+    def transfer_history(self, direction: str | None = None, **kwargs) -> list[dict]:
+        """Return past ACH transfers (direction: 'deposit', 'withdraw', or None for both)."""
+        self._ensure_auth()
+        raw = rh.account.get_bank_transfers(direction=direction) or []
+        return [
+            {
+                "id": t.get("id"),
+                "amount": float(t.get("amount", 0) or 0),
+                "direction": t.get("direction"),
+                "state": t.get("state"),
+                "created_at": t.get("created_at"),
+            }
+            for t in raw if isinstance(t, dict)
+        ]
+
     # -- auth status --------------------------------------------------------
 
     def auth_status(self) -> dict:

--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,15 @@ class Config:
     # -- Robinhood session persistence --
     RH_RETRY_HOUR_ET = int(os.getenv("RH_RETRY_HOUR_ET", "11"))
 
+    # -- IBKR (Client Portal Gateway) --
+    # A CP Gateway process must already be running and logged in (interactive
+    # browser login, out-of-band — see app/brokers/ibkr_client.py). This is
+    # just where we point at it.
+    IBKR_GATEWAY_URL = os.getenv("IBKR_GATEWAY_URL", "https://localhost:5000/v1/api")
+    IBKR_ACCOUNT_ID = os.getenv("IBKR_ACCOUNT_ID", "")
+    IBKR_VERIFY_SSL = os.getenv("IBKR_VERIFY_SSL", "false").lower() == "true"
+    IBKR_REQUEST_TIMEOUT = int(os.getenv("IBKR_REQUEST_TIMEOUT", "15"))
+
     @classmethod
     def rh_credentials(cls) -> tuple[str, str]:
         """Return (email, password) for the active Robinhood account."""

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def serve():
 def main():
     parser = argparse.ArgumentParser(description="Allocation Engine 2.0")
     parser.add_argument("--broker", default=Config.ENGINE_BROKER,
-                        choices=["alpaca", "robinhood"],
+                        choices=["alpaca", "robinhood", "ibkr"],
                         help="Broker to use (default: ENGINE_BROKER env var)")
     sub = parser.add_subparsers(dest="command")
 

--- a/tests/test_ibkr_client.py
+++ b/tests/test_ibkr_client.py
@@ -1,0 +1,178 @@
+"""Offline tests for app/brokers/ibkr_client.py — mocks the CP Gateway's
+REST responses so nothing here talks to a real gateway or the network.
+"""
+
+import pytest
+import requests
+
+from app.brokers import ibkr_client as ibkr_mod
+from app.brokers.ibkr_client import IBKRTrader
+
+BASE_URL = "https://gw:5000/v1/api"
+
+
+@pytest.fixture(autouse=True)
+def clear_conid_cache():
+    ibkr_mod._conid_cache.clear()
+    yield
+    ibkr_mod._conid_cache.clear()
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.content = b"x" if payload is not None else b""
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def make_trader(router: dict, account_id="U123"):
+    """router maps (method, path) -> payload returned verbatim for every
+    call to that key. Each test's paths are distinct enough (submit vs.
+    reply, etc.) that no per-call sequencing is needed."""
+    calls = []
+
+    def fake_request(method, url, **kwargs):
+        path = url[len(BASE_URL):]
+        calls.append((method, path, kwargs))
+        key = (method, path)
+        if key not in router:
+            raise AssertionError(f"unexpected request {key}")
+        return FakeResponse(router[key])
+
+    trader = IBKRTrader(gateway_url=BASE_URL, account_id=account_id, verify_ssl=False, timeout=5)
+    trader._session.request = fake_request
+    trader._calls = calls
+    return trader
+
+
+def _auth_ok(extra=None):
+    return {
+        ("GET", "/iserver/auth/status"): {"authenticated": True, "connected": True},
+        ("POST", "/tickle"): {},
+        **(extra or {}),
+    }
+
+
+def test_ensure_auth_raises_when_gateway_not_logged_in():
+    router = {("GET", "/iserver/auth/status"): {"authenticated": False, "connected": False}}
+    trader = make_trader(router)
+    with pytest.raises(RuntimeError, match="not authenticated"):
+        trader._ensure_auth()
+
+
+def test_account_maps_summary_fields():
+    router = _auth_ok({
+        ("GET", "/portfolio/U123/summary"): {
+            "netliquidation": {"amount": 10000.5},
+            "totalcashvalue": {"amount": 2000.0},
+            "buyingpower": {"amount": 4000.0},
+        },
+    })
+    trader = make_trader(router)
+    acct = trader.account()
+    assert acct == {
+        "equity": 10000.5, "cash": 2000.0, "buying_power": 4000.0, "portfolio_value": 10000.5,
+    }
+
+
+def test_positions_skips_zero_qty_and_computes_pl():
+    router = _auth_ok({
+        ("GET", "/portfolio/U123/positions/0"): [
+            {"ticker": "AAPL", "position": 10, "avgCost": 100.0, "mktPrice": 150.0, "mktValue": 1500.0},
+            {"ticker": "MSFT", "position": 0, "avgCost": 50.0},
+        ],
+    })
+    trader = make_trader(router)
+    positions = trader.positions()
+    assert len(positions) == 1
+    p = positions[0]
+    assert p["symbol"] == "AAPL"
+    assert p["qty"] == 10
+    assert p["market_value"] == 1500.0
+    assert p["unrealized_pl"] == 500.0
+
+
+def test_open_orders_filters_to_open_states():
+    router = _auth_ok({
+        ("GET", "/iserver/account/orders"): {"orders": [
+            {"orderId": 111, "ticker": "AAPL", "side": "BUY", "remainingQuantity": 5,
+             "orderType": "LMT", "price": 150.0, "status": "Submitted"},
+            {"orderId": 222, "ticker": "MSFT", "side": "SELL", "remainingQuantity": 0,
+             "orderType": "MKT", "status": "Filled"},
+        ]},
+    })
+    trader = make_trader(router)
+    orders = trader.open_orders()
+    assert len(orders) == 1
+    assert orders[0]["id"] == "111"
+    assert orders[0]["type"] == "limit"
+    assert orders[0]["limit_price"] == 150.0
+
+
+def test_submit_order_market_resolves_conid_and_submits():
+    router = _auth_ok({
+        ("GET", "/iserver/secdef/search"): [{"conid": 265598, "secType": "STK"}],
+        ("POST", "/iserver/account/U123/orders"): [{"order_id": "999", "order_status": "Submitted"}],
+    })
+    trader = make_trader(router)
+    result = trader.submit_order({"symbol": "AAPL", "side": "BUY", "quantity": 5})
+    assert result == {"id": "999", "symbol": "AAPL", "status": "Submitted"}
+
+
+def test_submit_order_auto_confirms_precaution_questions():
+    router = _auth_ok({
+        ("GET", "/iserver/secdef/search"): [{"conid": 265598, "secType": "STK"}],
+        ("POST", "/iserver/account/U123/orders"): [{"id": "q1", "message": ["order value warning"]}],
+        ("POST", "/iserver/reply/q1"): [{"order_id": "999", "order_status": "Submitted"}],
+    })
+    trader = make_trader(router)
+    result = trader.submit_order({
+        "symbol": "AAPL", "side": "BUY", "quantity": 5,
+        "order_type": "limit", "limit_price": 150.0,
+    })
+    assert result == {"id": "999", "symbol": "AAPL", "status": "Submitted"}
+
+
+def test_submit_order_unknown_symbol_returns_none():
+    router = _auth_ok({("GET", "/iserver/secdef/search"): []})
+    trader = make_trader(router)
+    result = trader.submit_order({"symbol": "ZZZZ", "side": "BUY", "quantity": 1})
+    assert result is None
+
+
+def test_cancel_all_cancels_each_open_order():
+    router = _auth_ok({
+        ("GET", "/iserver/account/orders"): {"orders": [
+            {"orderId": 111, "ticker": "AAPL", "side": "BUY", "remainingQuantity": 5,
+             "orderType": "MKT", "status": "Submitted"},
+            {"orderId": 222, "ticker": "MSFT", "side": "SELL", "remainingQuantity": 3,
+             "orderType": "MKT", "status": "PreSubmitted"},
+        ]},
+        ("DELETE", "/iserver/account/U123/order/111"): {},
+        ("DELETE", "/iserver/account/U123/order/222"): {},
+    })
+    trader = make_trader(router)
+    trader.cancel_all()
+    deletes = [c for c in trader._calls if c[0] == "DELETE"]
+    assert {c[1] for c in deletes} == {
+        "/iserver/account/U123/order/111", "/iserver/account/U123/order/222",
+    }
+
+
+def test_funding_methods_are_not_implemented():
+    trader = make_trader(_auth_ok())
+    with pytest.raises(NotImplementedError):
+        trader.deposit(100)
+    with pytest.raises(NotImplementedError):
+        trader.withdraw(100)
+    with pytest.raises(NotImplementedError):
+        trader.linked_bank_accounts()
+    with pytest.raises(NotImplementedError):
+        trader.transfer_history()

--- a/tests/test_robinhood_funding.py
+++ b/tests/test_robinhood_funding.py
@@ -1,0 +1,83 @@
+"""Offline tests for RobinhoodTrader's ACH deposit/withdraw wrappers.
+
+These call through the same box-injected robin_stocks session as every
+other RobinhoodTrader method (no separate login), so tests just stub
+_ensure_auth and mock the underlying robin_stocks.robinhood.account calls.
+"""
+
+from unittest import mock
+
+import pytest
+import robin_stocks.robinhood as rh
+
+from app.brokers.robinhood_client import RobinhoodTrader
+
+
+def make_trader():
+    trader = object.__new__(RobinhoodTrader)
+    trader.email = "trader@example.com"
+    trader.account_number = ""
+    trader._authenticated = True
+    trader._ensure_auth = lambda: None
+    return trader
+
+
+def test_deposit_requires_ach_relationship():
+    trader = make_trader()
+    with pytest.raises(ValueError):
+        trader.deposit(100)
+
+
+def test_deposit_success():
+    trader = make_trader()
+    with mock.patch.object(rh.account, "deposit_funds_to_robinhood_account",
+                            return_value={"id": "d1", "state": "pending"}) as m:
+        result = trader.deposit(100, ach_relationship="ach-1")
+    m.assert_called_once_with("ach-1", 100)
+    assert result == {"id": "d1", "amount": 100.0, "state": "pending"}
+
+
+def test_deposit_failure_returns_none():
+    trader = make_trader()
+    with mock.patch.object(rh.account, "deposit_funds_to_robinhood_account", return_value=None):
+        assert trader.deposit(100, ach_relationship="ach-1") is None
+
+
+def test_withdraw_requires_ach_relationship():
+    trader = make_trader()
+    with pytest.raises(ValueError):
+        trader.withdraw(50)
+
+
+def test_withdraw_success():
+    trader = make_trader()
+    with mock.patch.object(rh.account, "withdrawl_funds_to_bank_account",
+                            return_value={"id": "w1", "state": "pending"}) as m:
+        result = trader.withdraw(50, ach_relationship="ach-1")
+    m.assert_called_once_with("ach-1", 50)
+    assert result == {"id": "w1", "amount": 50.0, "state": "pending"}
+
+
+def test_withdraw_failure_returns_none():
+    trader = make_trader()
+    with mock.patch.object(rh.account, "withdrawl_funds_to_bank_account", return_value=None):
+        assert trader.withdraw(50, ach_relationship="ach-1") is None
+
+
+def test_linked_bank_accounts_maps_fields():
+    trader = make_trader()
+    raw = [{"id": "b1", "bank_name": "Chase", "type": "checking", "verified": True}]
+    with mock.patch.object(rh.account, "get_linked_bank_accounts", return_value=raw):
+        accounts = trader.linked_bank_accounts()
+    assert accounts == [{"id": "b1", "bank_name": "Chase", "account_type": "checking", "verified": True}]
+
+
+def test_transfer_history_maps_fields():
+    trader = make_trader()
+    raw = [{"id": "t1", "amount": "25.00", "direction": "deposit",
+            "state": "completed", "created_at": "2026-01-01"}]
+    with mock.patch.object(rh.account, "get_bank_transfers", return_value=raw) as m:
+        history = trader.transfer_history(direction="deposit")
+    m.assert_called_once_with(direction="deposit")
+    assert history[0]["amount"] == 25.0
+    assert history[0]["direction"] == "deposit"

--- a/tests/test_transfer_api.py
+++ b/tests/test_transfer_api.py
@@ -1,0 +1,145 @@
+"""Offline tests for app/api/transfer.py — mocks get_broker() so nothing
+here constructs a real broker or touches the network."""
+
+from unittest import mock
+
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class FakeBroker:
+    def __init__(self):
+        self.deposit_calls = []
+        self.withdraw_calls = []
+
+    def deposit(self, amount, **kwargs):
+        self.deposit_calls.append((amount, kwargs))
+        return {"id": "dep-1", "amount": amount, "state": "pending"}
+
+    def withdraw(self, amount, **kwargs):
+        self.withdraw_calls.append((amount, kwargs))
+        return {"id": "wd-1", "amount": amount, "state": "pending"}
+
+    def linked_bank_accounts(self):
+        return [{"id": "b1"}]
+
+    def transfer_history(self, **kwargs):
+        return [{"id": "t1"}]
+
+
+class UnsupportedBroker:
+    def deposit(self, amount, **kwargs):
+        raise NotImplementedError("IBKR does not support deposits")
+
+    def withdraw(self, amount, **kwargs):
+        raise NotImplementedError("IBKR does not support withdrawals")
+
+    def linked_bank_accounts(self):
+        raise NotImplementedError("IBKR does not support linked bank accounts")
+
+    def transfer_history(self, **kwargs):
+        raise NotImplementedError("IBKR does not support transfer history")
+
+
+def test_deposit_dry_run_does_not_call_broker(client):
+    with mock.patch("app.api.transfer.get_broker") as gb:
+        resp = client.post("/api/transfer/deposit/robinhood", json={"amount": 100})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "simulated"
+    gb.assert_not_called()
+
+
+def test_deposit_rejects_non_positive_amount(client):
+    resp = client.post("/api/transfer/deposit/robinhood", json={"amount": 0, "dry_run": False})
+    assert resp.status_code == 400
+
+
+def test_deposit_submits_when_not_dry_run(client):
+    fake = FakeBroker()
+    with mock.patch("app.api.transfer.get_broker", return_value=fake):
+        resp = client.post("/api/transfer/deposit/robinhood",
+                            json={"amount": 100, "ach_relationship": "ach-1", "dry_run": False})
+    assert resp.status_code == 201
+    assert resp.get_json()["status"] == "submitted"
+    assert fake.deposit_calls == [(100.0, {"ach_relationship": "ach-1"})]
+
+
+def test_deposit_unsupported_broker_returns_501(client):
+    with mock.patch("app.api.transfer.get_broker", return_value=UnsupportedBroker()):
+        resp = client.post("/api/transfer/deposit/ibkr", json={"amount": 100, "dry_run": False})
+    assert resp.status_code == 501
+    assert resp.get_json()["supported"] is False
+
+
+def test_withdraw_submits_when_not_dry_run(client):
+    fake = FakeBroker()
+    with mock.patch("app.api.transfer.get_broker", return_value=fake):
+        resp = client.post("/api/transfer/withdraw/robinhood",
+                            json={"amount": 40, "ach_relationship": "ach-1", "dry_run": False})
+    assert resp.status_code == 201
+    assert fake.withdraw_calls == [(40.0, {"ach_relationship": "ach-1"})]
+
+
+def test_bank_accounts_unsupported_broker_returns_501(client):
+    with mock.patch("app.api.transfer.get_broker", return_value=UnsupportedBroker()):
+        resp = client.get("/api/transfer/bank-accounts/ibkr")
+    assert resp.status_code == 501
+
+
+def test_between_validates_broker_names(client):
+    resp = client.post("/api/transfer/between", json={
+        "from_broker": "robinhood", "to_broker": "robinhood", "amount": 10, "dry_run": False,
+    })
+    assert resp.status_code == 400
+
+
+def test_between_dry_run(client):
+    resp = client.post("/api/transfer/between", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 50,
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "simulated"
+
+
+def test_between_partial_when_destination_unsupported(client):
+    fake_rh = FakeBroker()
+    fake_ibkr = UnsupportedBroker()
+
+    def fake_get_broker(name):
+        return fake_rh if name == "robinhood" else fake_ibkr
+
+    with mock.patch("app.api.transfer.get_broker", side_effect=fake_get_broker):
+        resp = client.post("/api/transfer/between", json={
+            "from_broker": "robinhood", "to_broker": "ibkr", "amount": 50, "dry_run": False,
+        })
+    assert resp.status_code == 207
+    body = resp.get_json()
+    assert body["status"] == "partial"
+    assert body["withdrawal"]["id"] == "wd-1"
+    assert fake_rh.withdraw_calls == [(50.0, {"ach_relationship": None})]
+
+
+def test_between_submits_both_legs_when_both_supported(client):
+    fake_rh, fake_other = FakeBroker(), FakeBroker()
+
+    def fake_get_broker(name):
+        return fake_rh if name == "robinhood" else fake_other
+
+    with mock.patch("app.api.transfer.get_broker", side_effect=fake_get_broker):
+        resp = client.post("/api/transfer/between", json={
+            "from_broker": "robinhood", "to_broker": "ibkr", "amount": 50, "dry_run": False,
+        })
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["status"] == "submitted"
+    assert body["withdrawal"]["id"] == "wd-1"
+    assert body["deposit"]["id"] == "dep-1"


### PR DESCRIPTION
## Summary

- Adds `IBKRTrader` (`app/brokers/ibkr_client.py`) implementing the existing `BrokerClient` interface against a locally running IBKR Client Portal (CP) Gateway: account summary, positions, open orders, and market/limit/stop/stop_limit order submission (with symbol→conid resolution and auto-confirmation of IBKR's order precaution questions), plus cancel/cancel-all. Because the existing API routes (`/api/trade/*`, `/api/account`, `/api/positions`, `/api/orders`, `/api/portfolio`) already parameterize by `broker_name`, IBKR works through them immediately once `ibkr` is added to `ENABLED_BROKERS` — no route changes needed there.
- Adds optional funding methods to `BrokerClient` (`linked_bank_accounts`, `deposit`, `withdraw`, `transfer_history`), defaulting to `NotImplementedError` so callers get a clean, catchable error. `RobinhoodTrader` implements these for real via robin_stocks' confirmed ACH functions (`deposit_funds_to_robinhood_account`, `withdrawl_funds_to_bank_account`, `get_linked_bank_accounts`, `get_bank_transfers`), reusing the box-vended session already injected for order submission — no new auth path.
- New `app/api/transfer.py`: `deposit`/`withdraw`/`history`/`bank-accounts` per broker, plus `/api/transfer/between` to move funds between our Robinhood and IBKR accounts as two independent ACH legs (withdraw from source, deposit to destination). Mirrors `/api/trade/order`'s `dry_run` behavior — nothing moves unless `dry_run=false`.

## Key assumption worth flagging

IBKR's Client Portal Web API does not expose ACH deposit/withdraw initiation for retail accounts — funding has to go through the Client Portal web/mobile app. `IBKRTrader`'s funding methods therefore raise `NotImplementedError`, and `/api/transfer/*/ibkr` returns `501`. `/api/transfer/between` still executes the Robinhood leg for real and reports the IBKR leg as unsupported/partial (`207`) rather than pretending it succeeded. If IBKR exposes this later (or there's an existing account-specific workflow I should target instead), that's a follow-up.

IBKR connectivity also assumes a CP Gateway process is already running and logged in elsewhere (`IBKR_GATEWAY_URL`, default `https://localhost:5000/v1/api`) — this client never attempts an IBKR login itself, matching the repo's existing stance that broker auth flows live outside core-logic.

## Test plan

- [x] `pytest tests/` — 115 passed, including new `test_ibkr_client.py` (auth, account/positions/orders mapping, order submission incl. precaution-question confirmation, cancel-all), `test_robinhood_funding.py` (ACH deposit/withdraw/history), and `test_transfer_api.py` (dry-run, validation, per-broker 501, `between` partial/success paths) — all mocked, no live gateway or broker credentials touched.
- [x] `scripts/check_schemas.py` — deploy-time contract check still passes.
- [x] `python -m py_compile` on all changed modules.
- [ ] Not exercised against a real CP Gateway (none available in this environment) — field-mapping assumptions for IBKR's order/position payload shapes are based on IBKR's published Client Portal Web API docs and are worth a smoke test against a real gateway before relying on it in production.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhbMJr4iH3F8ZogTuC4hpW)_