### PR TITLE
Add IBKR broker surface and cross-broker ACH transfer API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # === Broker Selection ===
-ENABLED_BROKERS=robinhood,alpaca
+ENABLED_BROKERS=robinhood,alpaca,ibkr
 DEFAULT_BROKER=robinhood
 
 # === Robinhood ===
@@ -23,6 +23,20 @@ RH_PICKLE_NAME=taipei_session
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=
 ALPACA_PAPER=true
+
+# === IBKR (Client Portal Web API) ===
+# clientportal.gw must already be running + authenticated (browser login)
+# on a box we control (Tailscale / GCP) — this is just where we reach it.
+IBKR_BASE_URL=              # e.g. https://100.x.x.x:5000/v1/api
+IBKR_ACCOUNT_ID=
+IBKR_VERIFY_SSL=false       # gateway usually presents a self-signed cert
+
+# === Money movement (deposit / transfer between broker accounts) ===
+# Linked bank relationship id to use for Robinhood ACH deposit/withdraw.
+RH_ACH_RELATIONSHIP_ID=
+# Separate gate from the general engine DRY_RUN — real money only moves
+# when this is false AND the request body also sets armed=true.
+TRANSFERS_DRY_RUN=true
 
 # === Runtime Service ===
 RUNTIME_SERVICE_URL=https://route-runtime-service.netlify.app/api

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,10 @@ ALPACA_PAPER=true
 # on a box we control (Tailscale / GCP) — this is just where we reach it.
 IBKR_BASE_URL=              # e.g. https://100.x.x.x:5000/v1/api
 IBKR_ACCOUNT_ID=
-IBKR_VERIFY_SSL=false       # gateway usually presents a self-signed cert
+# Verifies the gateway's certificate by default. Only set to false for a
+# self-signed gateway cert on a trusted network (Tailscale / private GCP)
+# — never for a gateway reachable over the open internet.
+IBKR_VERIFY_SSL=true
 
 # === Money movement (deposit / transfer between broker accounts) ===
 # Linked bank relationship id to use for Robinhood ACH deposit/withdraw.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,44 @@ If you deploy first, the service downloads the old/stale pickle from Netlify and
 - `GET /api/auth/status/robinhood` — broker-specific status
 - `GET /api/health` — general service health
 
+## IBKR Surface & Cross-Broker Transfers
+
+`app/brokers/ibkr_client.py` implements the same `BrokerClient` interface as
+Alpaca/Robinhood — `/api/account/ibkr`, `/api/positions/ibkr`,
+`/api/orders/ibkr`, and `/api/trade/{order,buy,sell,cancel}/ibkr` work the
+same way they do for the other brokers.
+
+- **Connection**: IBKR's Client Portal Web API (REST), not TWS/`ib_insync`.
+  It talks to a `clientportal.gw` gateway process reachable via
+  `IBKR_BASE_URL` (Tailscale or a GCP box) — that gateway's own
+  browser-based login/2FA and session refresh is infra we manage out of
+  band, not something this client can do headlessly. Sessions idle-timeout
+  quickly, so every call tickles the gateway (`/tickle`) first.
+- **Order confirmations**: CPAPI often returns one or more risk-warning
+  "replies" before an order is actually accepted. `submit_order()`
+  auto-confirms them (logging each message) since this runs unattended.
+- **No funding API**: IBKR does not expose a retail deposit/withdraw
+  endpoint via CPAPI — `deposit()`/`withdraw()` raise `NotImplementedError`
+  on purpose rather than faking success. Funding IBKR still requires the
+  Client Portal UI.
+
+**Transfers** (`app/api/transfer.py`) move money between broker accounts as
+two independent ACH legs — there is no real broker-to-broker transfer API:
+- `POST /api/transfer/deposit/<broker>` / `.../withdraw/<broker>` — single
+  leg against that broker's own linked bank account.
+- `POST /api/transfer` — withdraws from `from_broker`, then deposits to
+  `to_broker`. **Not atomic**: if the deposit leg fails after a successful
+  withdrawal, the response says so explicitly (`leg: "deposit"`, a
+  `warning` with the withdrawal id) instead of retrying or rolling back.
+- Gated by `TRANSFERS_DRY_RUN` (default `true`, separate from the engine's
+  general `DRY_RUN`) **and** an explicit `armed: true` in the request body
+  — both must be satisfied before real money moves.
+- Robinhood's ACH transfer endpoint isn't wrapped by `robin_stocks`;
+  `RobinhoodTrader.deposit()`/`withdraw()` call it directly through the
+  same box-vended session `submit_order()` already uses (`RH_ACH_RELATIONSHIP_ID`
+  selects the linked bank) — no new login path, consistent with the
+  auth-service boundary above.
+
 ## Render CLI
 
 ```bash

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -14,9 +14,11 @@ def register_blueprints(app):
     from app.api.events import bp as events_bp
     from app.api.robinhood_proxy import bp as robinhood_proxy_bp
     from app.api.claude_auth import bp as claude_auth_bp
+    from app.api.transfer import bp as transfer_bp
 
     for blueprint in [health_bp, account_bp, positions_bp, orders_bp,
                       portfolio_bp, engine_bp, trade_bp, quote_bp,
                       history_bp, options_bp, auth_bp, snapshot_bp,
-                      events_bp, robinhood_proxy_bp, claude_auth_bp]:
+                      events_bp, robinhood_proxy_bp, claude_auth_bp,
+                      transfer_bp]:
         app.register_blueprint(blueprint, url_prefix="/api")

--- a/app/api/transfer.py
+++ b/app/api/transfer.py
@@ -1,0 +1,168 @@
+"""Transfer API — deposit/withdraw against a broker's own linked bank
+account, and orchestrated cross-broker transfers (Robinhood <-> IBKR).
+
+There is no direct broker-to-broker transfer API: a "transfer" here is two
+independent ACH legs (withdraw from the source's linked bank, deposit to
+the destination's linked bank). It is NOT atomic — either leg can fail
+independently, and ACH settlement takes days. Real money only moves when
+TRANSFERS_DRY_RUN=false AND the request body sets armed=true.
+"""
+
+from flask import Blueprint, jsonify, request, current_app
+from app.brokers import get_broker
+
+bp = Blueprint("transfer", __name__)
+
+
+def _resolve_dry_run(body: dict) -> bool:
+    if "dry_run" in body or "dryRun" in body:
+        return bool(body.get("dry_run", body.get("dryRun")))
+    return current_app.config.get("TRANSFERS_DRY_RUN", True)
+
+
+def _validate_amount(body: dict):
+    amount = body.get("amount")
+    if amount is None:
+        return None, "amount is required"
+    try:
+        amount = float(amount)
+    except (TypeError, ValueError):
+        return None, "amount must be a number"
+    if amount <= 0:
+        return None, "amount must be positive"
+    return amount, None
+
+
+def _do_leg(broker_name: str, amount: float, action: str) -> dict:
+    """action: 'deposit' or 'withdraw'. Returns a result dict; raises on failure."""
+    broker = get_broker(broker_name)
+    fn = getattr(broker, action, None)
+    if fn is None:
+        raise LookupError(f"{broker_name} does not support {action}")
+    result = fn(amount)
+    if result is None:
+        raise RuntimeError(f"{broker_name} rejected the {action}")
+    return result
+
+
+@bp.route("/transfer/deposit/<broker_name>", methods=["POST"])
+def deposit(broker_name):
+    """Deposit from broker_name's own linked bank account into broker_name."""
+    body = request.get_json(silent=True) or {}
+    amount, err = _validate_amount(body)
+    if err:
+        return jsonify({"error": err}), 400
+
+    dry_run = _resolve_dry_run(body)
+    if dry_run:
+        return jsonify({
+            "status": "simulated", "dry_run": True, "broker": broker_name,
+            "action": "deposit", "amount": amount,
+            "message": "Deposit validated but not submitted (dry_run=true)",
+        })
+    if not body.get("armed", False):
+        return jsonify({"error": "armed=true is required to submit a real deposit"}), 400
+
+    try:
+        result = _do_leg(broker_name, amount, "deposit")
+        return jsonify({"status": "submitted", "broker": broker_name, "action": "deposit",
+                        "amount": amount, "result": result}), 201
+    except NotImplementedError as e:
+        return jsonify({"error": str(e)}), 501
+    except LookupError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer/withdraw/<broker_name>", methods=["POST"])
+def withdraw(broker_name):
+    """Withdraw from broker_name to broker_name's own linked bank account."""
+    body = request.get_json(silent=True) or {}
+    amount, err = _validate_amount(body)
+    if err:
+        return jsonify({"error": err}), 400
+
+    dry_run = _resolve_dry_run(body)
+    if dry_run:
+        return jsonify({
+            "status": "simulated", "dry_run": True, "broker": broker_name,
+            "action": "withdraw", "amount": amount,
+            "message": "Withdrawal validated but not submitted (dry_run=true)",
+        })
+    if not body.get("armed", False):
+        return jsonify({"error": "armed=true is required to submit a real withdrawal"}), 400
+
+    try:
+        result = _do_leg(broker_name, amount, "withdraw")
+        return jsonify({"status": "submitted", "broker": broker_name, "action": "withdraw",
+                        "amount": amount, "result": result}), 201
+    except NotImplementedError as e:
+        return jsonify({"error": str(e)}), 501
+    except LookupError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/transfer", methods=["POST"])
+def transfer():
+    """Move money between two broker accounts: withdraw from from_broker's
+    linked bank, deposit to to_broker's linked bank. Two independent ACH
+    legs, not atomic — if the deposit leg fails after a successful
+    withdrawal, the response says so explicitly rather than pretending the
+    transfer completed or rolled back.
+    """
+    body = request.get_json(silent=True) or {}
+    from_broker = body.get("from_broker")
+    to_broker = body.get("to_broker")
+    if not from_broker or not to_broker:
+        return jsonify({"error": "from_broker and to_broker are required"}), 400
+    if from_broker == to_broker:
+        return jsonify({"error": "from_broker and to_broker must differ"}), 400
+
+    amount, err = _validate_amount(body)
+    if err:
+        return jsonify({"error": err}), 400
+
+    dry_run = _resolve_dry_run(body)
+    if dry_run:
+        return jsonify({
+            "status": "simulated", "dry_run": True,
+            "from_broker": from_broker, "to_broker": to_broker, "amount": amount,
+            "message": "Transfer validated but not submitted (dry_run=true)",
+        })
+    if not body.get("armed", False):
+        return jsonify({"error": "armed=true is required to submit a real transfer"}), 400
+
+    try:
+        withdraw_result = _do_leg(from_broker, amount, "withdraw")
+    except NotImplementedError as e:
+        return jsonify({"error": str(e), "leg": "withdraw"}), 501
+    except LookupError as e:
+        return jsonify({"error": str(e), "leg": "withdraw"}), 400
+    except Exception as e:
+        return jsonify({"error": str(e), "leg": "withdraw"}), 500
+
+    try:
+        deposit_result = _do_leg(to_broker, amount, "deposit")
+    except Exception as e:
+        status = 501 if isinstance(e, NotImplementedError) else 502
+        return jsonify({
+            "error": str(e),
+            "leg": "deposit",
+            "warning": (
+                f"${amount} was already withdrawn from {from_broker} "
+                f"(id={withdraw_result.get('id')}) but the deposit into "
+                f"{to_broker} failed — this is NOT rolled back automatically, "
+                "follow up manually."
+            ),
+            "withdraw_result": withdraw_result,
+        }), status
+
+    return jsonify({
+        "status": "submitted",
+        "from_broker": from_broker, "to_broker": to_broker, "amount": amount,
+        "withdraw_result": withdraw_result,
+        "deposit_result": deposit_result,
+    }), 201

--- a/app/api/transfer.py
+++ b/app/api/transfer.py
@@ -8,6 +8,8 @@ independently, and ACH settlement takes days. Real money only moves when
 TRANSFERS_DRY_RUN=false AND the request body sets armed=true.
 """
 
+from decimal import Decimal, InvalidOperation
+
 from flask import Blueprint, jsonify, request, current_app
 from app.brokers import get_broker
 
@@ -20,17 +22,27 @@ def _resolve_dry_run(body: dict) -> bool:
     return current_app.config.get("TRANSFERS_DRY_RUN", True)
 
 
+def _is_armed(body: dict) -> bool:
+    """Require the literal JSON boolean `true` — a string like "false" or a
+    stray `1` must not be able to authorize a real money movement."""
+    return body.get("armed") is True
+
+
 def _validate_amount(body: dict):
-    amount = body.get("amount")
-    if amount is None:
+    raw_amount = body.get("amount")
+    if raw_amount is None:
         return None, "amount is required"
+    if isinstance(raw_amount, bool):
+        return None, "amount must be a finite number"
     try:
-        amount = float(amount)
-    except (TypeError, ValueError):
-        return None, "amount must be a number"
-    if amount <= 0:
+        amount = Decimal(str(raw_amount))
+    except (InvalidOperation, TypeError, ValueError):
+        return None, "amount must be a finite number"
+    if not amount.is_finite() or amount <= 0:
         return None, "amount must be positive"
-    return amount, None
+    if amount.as_tuple().exponent < -2:
+        return None, "amount must have at most two decimal places"
+    return float(amount), None
 
 
 def _do_leg(broker_name: str, amount: float, action: str) -> dict:
@@ -60,7 +72,7 @@ def deposit(broker_name):
             "action": "deposit", "amount": amount,
             "message": "Deposit validated but not submitted (dry_run=true)",
         })
-    if not body.get("armed", False):
+    if not _is_armed(body):
         return jsonify({"error": "armed=true is required to submit a real deposit"}), 400
 
     try:
@@ -90,7 +102,7 @@ def withdraw(broker_name):
             "action": "withdraw", "amount": amount,
             "message": "Withdrawal validated but not submitted (dry_run=true)",
         })
-    if not body.get("armed", False):
+    if not _is_armed(body):
         return jsonify({"error": "armed=true is required to submit a real withdrawal"}), 400
 
     try:
@@ -132,7 +144,7 @@ def transfer():
             "from_broker": from_broker, "to_broker": to_broker, "amount": amount,
             "message": "Transfer validated but not submitted (dry_run=true)",
         })
-    if not body.get("armed", False):
+    if not _is_armed(body):
         return jsonify({"error": "armed=true is required to submit a real transfer"}), 400
 
     try:

--- a/app/brokers/__init__.py
+++ b/app/brokers/__init__.py
@@ -30,6 +30,14 @@ def get_broker(name: str) -> BrokerClient:
             totp_secret=config.get("RH_TOTP_SECRET", ""),
             pickle_name=config.get("RH_PICKLE_NAME", "taipei_session"),
             account_number=config.get("RH_AUTOMATED_ACCOUNT_NUMBER", ""),
+            ach_relationship_id=config.get("RH_ACH_RELATIONSHIP_ID", ""),
+        )
+    elif name == "ibkr":
+        from app.brokers.ibkr_client import IBKRTrader
+        client = IBKRTrader(
+            base_url=config["IBKR_BASE_URL"],
+            account_id=config["IBKR_ACCOUNT_ID"],
+            verify_ssl=config.get("IBKR_VERIFY_SSL", False),
         )
     else:
         raise ValueError(f"Unknown broker: {name}")

--- a/app/brokers/ibkr_client.py
+++ b/app/brokers/ibkr_client.py
@@ -1,0 +1,262 @@
+"""IBKR trading client — talks to a running IBKR Client Portal Web API gateway.
+
+This client does not manage the gateway's brokerage session: the Client
+Portal Gateway (clientportal.gw) must already be running and authenticated
+(browser-based login + 2FA) on a box we control (Tailscale / GCP), with
+IBKR_BASE_URL pointing at it. That login/refresh lifecycle is infrastructure,
+not something this client can do headlessly.
+
+CPAPI quirks handled here:
+  - Sessions go idle-timeout after a few minutes without traffic, so every
+    call tickles the gateway first (`/tickle`) to keep it alive within its
+    24h authenticated window.
+  - Placing an order can come back as one or more confirmation "replies"
+    (risk/warning messages) that must be POSTed back with `{"confirmed":
+    true}` before the order actually gets accepted. We auto-confirm since
+    this runs unattended, logging each message we wave through.
+"""
+
+import logging
+
+import requests
+import urllib3
+
+from app.brokers.base import BrokerClient
+from app.enums import OrderType
+
+log = logging.getLogger(__name__)
+
+_ORDER_TYPE_MAP = {
+    OrderType.MARKET: "MKT",
+    OrderType.LIMIT: "LMT",
+    OrderType.STOP: "STOP",
+    OrderType.STOP_LIMIT: "STOP_LIMIT",
+}
+_REVERSE_ORDER_TYPE_MAP = {v: k for k, v in _ORDER_TYPE_MAP.items()}
+
+
+class IBKRTrader(BrokerClient):
+    def __init__(self, base_url: str, account_id: str, verify_ssl: bool = False, timeout: int = 15):
+        self.base_url = base_url.rstrip("/")
+        self.account_id = account_id
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+        self._conid_cache: dict[str, int] = {}
+
+        if not verify_ssl:
+            # The gateway typically presents a self-signed cert on a private
+            # network (Tailscale / GCP box) — this is expected, not a threat.
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    # -- transport ------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _get(self, path: str, params: dict | None = None):
+        resp = requests.get(self._url(path), params=params,
+                             verify=self.verify_ssl, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+    def _post(self, path: str, payload: dict):
+        resp = requests.post(self._url(path), json=payload,
+                              verify=self.verify_ssl, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+    def _delete(self, path: str, params: dict | None = None):
+        resp = requests.delete(self._url(path), params=params,
+                                verify=self.verify_ssl, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json() if resp.content else None
+
+    def _tickle(self):
+        """Best-effort keep-alive; a failed tickle just means the next real
+        call will surface the stale-session error itself."""
+        try:
+            self._post("/tickle", {})
+        except requests.RequestException:
+            log.warning("[ibkr] tickle failed — gateway session may need re-auth")
+
+    # -- symbol resolution ------------------------------------------------------
+
+    def _resolve_conid(self, symbol: str) -> int | None:
+        if symbol in self._conid_cache:
+            return self._conid_cache[symbol]
+        try:
+            results = self._get("/iserver/secdef/search", params={"symbol": symbol}) or []
+        except requests.RequestException:
+            log.exception("[ibkr] secdef search failed for %s", symbol)
+            return None
+
+        conid = None
+        for item in results:
+            if item.get("symbol", "").upper() != symbol.upper():
+                continue
+            if any(s.get("secType") == "STK" for s in item.get("sections", [])):
+                conid = item.get("conid")
+                break
+        if conid is not None:
+            self._conid_cache[symbol] = int(conid)
+        return conid
+
+    # -- account / positions ------------------------------------------------
+
+    def account(self) -> dict:
+        self._tickle()
+        summary = self._get(f"/portfolio/{self.account_id}/summary") or {}
+
+        def amt(key):
+            v = summary.get(key)
+            if isinstance(v, dict):
+                return float(v.get("amount", 0) or 0)
+            return float(v or 0)
+
+        return {
+            "equity": amt("netliquidation"),
+            "cash": amt("totalcashvalue") or amt("availablefunds"),
+            "buying_power": amt("buyingpower"),
+            "portfolio_value": amt("netliquidation"),
+        }
+
+    def positions(self) -> list[dict]:
+        self._tickle()
+        raw = self._get(f"/portfolio/{self.account_id}/positions/0") or []
+        result = []
+        for p in raw:
+            qty = float(p.get("position", 0) or 0)
+            if qty == 0:
+                continue
+            avg_cost = float(p.get("avgCost", 0) or 0)
+            market_value = float(p.get("mktValue", 0) or 0)
+            unrealized_pl = float(p.get("unrealizedPnl", 0) or 0)
+            cost_basis = qty * avg_cost
+            result.append({
+                "symbol": p.get("ticker") or p.get("contractDesc", ""),
+                "qty": qty,
+                "side": "long" if qty > 0 else "short",
+                "market_value": round(market_value, 2),
+                "avg_entry": avg_cost,
+                "unrealized_pl": round(unrealized_pl, 2),
+                "unrealized_pl_pct": round(unrealized_pl / cost_basis, 4) if cost_basis else 0.0,
+            })
+        return result
+
+    def open_orders(self) -> list[dict]:
+        self._tickle()
+        data = self._get("/iserver/account/orders", params={"accountId": self.account_id}) or {}
+        raw = data.get("orders", []) if isinstance(data, dict) else []
+        result = []
+        for o in raw:
+            price = o.get("price")
+            aux_price = o.get("auxPrice")
+            result.append({
+                "id": str(o.get("orderId", "")),
+                "symbol": o.get("ticker", ""),
+                "side": (o.get("side") or "").upper(),
+                "qty": float(o.get("totalSize", 0) or 0),
+                "type": _REVERSE_ORDER_TYPE_MAP.get(o.get("orderType", ""), "market"),
+                "limit_price": float(price) if price not in (None, "") else None,
+                "stop_price": float(aux_price) if aux_price not in (None, "") else None,
+                "status": o.get("status", "unknown"),
+            })
+        return result
+
+    # -- order submission ---------------------------------------------------
+
+    def _confirm_replies(self, data, max_rounds: int = 5):
+        """Auto-confirm IBKR's order-reply chain (risk warnings, etc.)."""
+        for _ in range(max_rounds):
+            if not isinstance(data, list) or not data:
+                return data
+            item = data[0]
+            reply_id = item.get("id")
+            already_placed = "order_id" in item or "orderId" in item
+            if reply_id and not already_placed:
+                log.warning("[ibkr] auto-confirming order message: %s", item.get("message"))
+                data = self._post(f"/iserver/reply/{reply_id}", {"confirmed": True})
+            else:
+                return data
+        return data
+
+    def submit_order(self, order: dict) -> dict | None:
+        self._tickle()
+        symbol = order["symbol"]
+        side = order["side"].upper()
+        qty = float(order["quantity"])
+        otype = order.get("order_type", OrderType.MARKET).lower()
+        limit_px = order.get("limit_price")
+        stop_px = order.get("stop_price")
+
+        conid = self._resolve_conid(symbol)
+        if conid is None:
+            log.error("[ibkr] could not resolve conid for symbol %s", symbol)
+            return None
+
+        ibkr_order = {
+            "conid": conid,
+            "orderType": _ORDER_TYPE_MAP.get(otype, "MKT"),
+            "side": side,
+            "quantity": qty,
+            "tif": "GTC",
+            "acctId": self.account_id,
+        }
+        if otype in (OrderType.LIMIT, OrderType.STOP_LIMIT) and limit_px is not None:
+            ibkr_order["price"] = float(limit_px)
+        if otype in (OrderType.STOP, OrderType.STOP_LIMIT) and stop_px is not None:
+            ibkr_order["auxPrice"] = float(stop_px)
+
+        try:
+            resp = self._post(f"/iserver/account/{self.account_id}/orders",
+                               {"orders": [ibkr_order]})
+            result = self._confirm_replies(resp)
+        except requests.RequestException as e:
+            log.error("IBKR order error for %s %s %s: %s", side, qty, symbol, e)
+            return None
+
+        if not isinstance(result, list) or not result:
+            return None
+        item = result[0]
+        order_id = item.get("order_id") or item.get("orderId")
+        if not order_id:
+            log.error("[ibkr] order submission returned no order id: %s", item)
+            return None
+        log.info("IBKR order submitted: %s %s %s @ %s -> %s",
+                 side, qty, symbol, limit_px or "MKT", order_id)
+        return {
+            "id": str(order_id),
+            "symbol": symbol,
+            "status": item.get("order_status", "submitted"),
+        }
+
+    def cancel_order(self, order_id: str):
+        self._tickle()
+        self._delete(f"/iserver/account/{self.account_id}/order/{order_id}",
+                      params={"accountId": self.account_id})
+        log.info("Cancelled IBKR order %s", order_id)
+
+    def cancel_all(self):
+        for o in self.open_orders():
+            self.cancel_order(o["id"])
+        log.info("All open IBKR orders cancelled")
+
+    # -- funding --------------------------------------------------------------
+
+    def deposit(self, amount: float) -> dict | None:
+        """IBKR's Client Portal Web API has no public deposit endpoint for
+        retail accounts — funding is initiated via the Client Portal UI
+        (bank link + DocuSign), not this API. Not implementable here."""
+        raise NotImplementedError(
+            "IBKR does not expose a retail deposit/funding endpoint via the "
+            "Client Portal Web API — initiate deposits from the Client "
+            "Portal UI instead."
+        )
+
+    def withdraw(self, amount: float) -> dict | None:
+        """See deposit() — same API gap for withdrawals."""
+        raise NotImplementedError(
+            "IBKR does not expose a retail withdrawal endpoint via the "
+            "Client Portal Web API — initiate withdrawals from the Client "
+            "Portal UI instead."
+        )

--- a/app/brokers/ibkr_client.py
+++ b/app/brokers/ibkr_client.py
@@ -29,10 +29,12 @@ log = logging.getLogger(__name__)
 _ORDER_TYPE_MAP = {
     OrderType.MARKET: "MKT",
     OrderType.LIMIT: "LMT",
-    OrderType.STOP: "STOP",
-    OrderType.STOP_LIMIT: "STOP_LIMIT",
+    OrderType.STOP: "STP",
+    OrderType.STOP_LIMIT: "STP_LMT",
 }
 _REVERSE_ORDER_TYPE_MAP = {v: k for k, v in _ORDER_TYPE_MAP.items()}
+
+_POSITIONS_PAGE_SIZE = 100
 
 
 class IBKRTrader(BrokerClient):
@@ -42,6 +44,7 @@ class IBKRTrader(BrokerClient):
         self.verify_ssl = verify_ssl
         self.timeout = timeout
         self._conid_cache: dict[str, int] = {}
+        self._portfolio_context_ready = False
 
         if not verify_ssl:
             # The gateway typically presents a self-signed cert on a private
@@ -53,29 +56,36 @@ class IBKRTrader(BrokerClient):
     def _url(self, path: str) -> str:
         return f"{self.base_url}{path}"
 
-    def _get(self, path: str, params: dict | None = None):
+    def _get(self, path: str, params: dict | None = None, tickle: bool = True):
+        if tickle:
+            self._tickle()
         resp = requests.get(self._url(path), params=params,
                              verify=self.verify_ssl, timeout=self.timeout)
         resp.raise_for_status()
         return resp.json() if resp.content else None
 
-    def _post(self, path: str, payload: dict):
+    def _post(self, path: str, payload: dict, tickle: bool = True):
+        if tickle:
+            self._tickle()
         resp = requests.post(self._url(path), json=payload,
                               verify=self.verify_ssl, timeout=self.timeout)
         resp.raise_for_status()
         return resp.json() if resp.content else None
 
-    def _delete(self, path: str, params: dict | None = None):
+    def _delete(self, path: str, params: dict | None = None, tickle: bool = True):
+        if tickle:
+            self._tickle()
         resp = requests.delete(self._url(path), params=params,
                                 verify=self.verify_ssl, timeout=self.timeout)
         resp.raise_for_status()
         return resp.json() if resp.content else None
 
     def _tickle(self):
-        """Best-effort keep-alive; a failed tickle just means the next real
-        call will surface the stale-session error itself."""
+        """Best-effort keep-alive, called before every other CPAPI request
+        (see _get/_post/_delete) so a stale session never silently skips it.
+        A failed tickle just means the next real call surfaces the error."""
         try:
-            self._post("/tickle", {})
+            self._post("/tickle", {}, tickle=False)
         except requests.RequestException:
             log.warning("[ibkr] tickle failed — gateway session may need re-auth")
 
@@ -103,8 +113,17 @@ class IBKRTrader(BrokerClient):
 
     # -- account / positions ------------------------------------------------
 
+    def _ensure_portfolio_context(self):
+        """CPAPI requires /portfolio/accounts to have been called at least
+        once before any /portfolio/{accountId}/* endpoint will respond —
+        this establishes the session's account context."""
+        if self._portfolio_context_ready:
+            return
+        self._get("/portfolio/accounts")
+        self._portfolio_context_ready = True
+
     def account(self) -> dict:
-        self._tickle()
+        self._ensure_portfolio_context()
         summary = self._get(f"/portfolio/{self.account_id}/summary") or {}
 
         def amt(key):
@@ -121,44 +140,61 @@ class IBKRTrader(BrokerClient):
         }
 
     def positions(self) -> list[dict]:
-        self._tickle()
-        raw = self._get(f"/portfolio/{self.account_id}/positions/0") or []
+        """Fetch every position page — CPAPI returns up to 100 positions per
+        zero-indexed page, so keep paging until a short page signals the end."""
+        self._ensure_portfolio_context()
         result = []
-        for p in raw:
-            qty = float(p.get("position", 0) or 0)
-            if qty == 0:
-                continue
-            avg_cost = float(p.get("avgCost", 0) or 0)
-            market_value = float(p.get("mktValue", 0) or 0)
-            unrealized_pl = float(p.get("unrealizedPnl", 0) or 0)
-            cost_basis = qty * avg_cost
-            result.append({
-                "symbol": p.get("ticker") or p.get("contractDesc", ""),
-                "qty": qty,
-                "side": "long" if qty > 0 else "short",
-                "market_value": round(market_value, 2),
-                "avg_entry": avg_cost,
-                "unrealized_pl": round(unrealized_pl, 2),
-                "unrealized_pl_pct": round(unrealized_pl / cost_basis, 4) if cost_basis else 0.0,
-            })
+        page = 0
+        while True:
+            raw = self._get(f"/portfolio/{self.account_id}/positions/{page}") or []
+            for p in raw:
+                qty = float(p.get("position", 0) or 0)
+                if qty == 0:
+                    continue
+                avg_cost = float(p.get("avgCost", 0) or 0)
+                market_value = float(p.get("mktValue", 0) or 0)
+                unrealized_pl = float(p.get("unrealizedPnl", 0) or 0)
+                cost_basis = qty * avg_cost
+                result.append({
+                    "symbol": p.get("ticker") or p.get("contractDesc", ""),
+                    "qty": qty,
+                    "side": "long" if qty > 0 else "short",
+                    "market_value": round(market_value, 2),
+                    "avg_entry": avg_cost,
+                    "unrealized_pl": round(unrealized_pl, 2),
+                    "unrealized_pl_pct": round(unrealized_pl / abs(cost_basis), 4) if cost_basis else 0.0,
+                })
+            if len(raw) < _POSITIONS_PAGE_SIZE:
+                break
+            page += 1
         return result
 
     def open_orders(self) -> list[dict]:
-        self._tickle()
         data = self._get("/iserver/account/orders", params={"accountId": self.account_id}) or {}
         raw = data.get("orders", []) if isinstance(data, dict) else []
         result = []
         for o in raw:
+            ibkr_type = o.get("orderType", "")
             price = o.get("price")
             aux_price = o.get("auxPrice")
+            price_f = float(price) if price not in (None, "") else None
+            aux_price_f = float(aux_price) if aux_price not in (None, "") else None
+            # STP carries the stop price in `price`; STP_LMT carries the
+            # limit price in `price` and the stop price in `auxPrice`.
+            if ibkr_type == "STP":
+                limit_price, stop_price = None, price_f
+            elif ibkr_type == "STP_LMT":
+                limit_price, stop_price = price_f, aux_price_f
+            else:
+                limit_price, stop_price = price_f, None
             result.append({
                 "id": str(o.get("orderId", "")),
                 "symbol": o.get("ticker", ""),
                 "side": (o.get("side") or "").upper(),
                 "qty": float(o.get("totalSize", 0) or 0),
-                "type": _REVERSE_ORDER_TYPE_MAP.get(o.get("orderType", ""), "market"),
-                "limit_price": float(price) if price not in (None, "") else None,
-                "stop_price": float(aux_price) if aux_price not in (None, "") else None,
+                "type": _REVERSE_ORDER_TYPE_MAP.get(ibkr_type, "market"),
+                "limit_price": limit_price,
+                "stop_price": stop_price,
                 "status": o.get("status", "unknown"),
             })
         return result
@@ -181,7 +217,6 @@ class IBKRTrader(BrokerClient):
         return data
 
     def submit_order(self, order: dict) -> dict | None:
-        self._tickle()
         symbol = order["symbol"]
         side = order["side"].upper()
         qty = float(order["quantity"])
@@ -202,9 +237,16 @@ class IBKRTrader(BrokerClient):
             "tif": "GTC",
             "acctId": self.account_id,
         }
-        if otype in (OrderType.LIMIT, OrderType.STOP_LIMIT) and limit_px is not None:
+        # CPAPI price fields differ by order type: LMT/STP_LMT carry the
+        # limit price in `price`; STP carries its stop price in `price`
+        # instead (there's no separate limit leg); STP_LMT's stop price
+        # goes in `auxPrice`.
+        if otype == OrderType.LIMIT and limit_px is not None:
             ibkr_order["price"] = float(limit_px)
-        if otype in (OrderType.STOP, OrderType.STOP_LIMIT) and stop_px is not None:
+        elif otype == OrderType.STOP and stop_px is not None:
+            ibkr_order["price"] = float(stop_px)
+        elif otype == OrderType.STOP_LIMIT and limit_px is not None and stop_px is not None:
+            ibkr_order["price"] = float(limit_px)
             ibkr_order["auxPrice"] = float(stop_px)
 
         try:
@@ -231,7 +273,6 @@ class IBKRTrader(BrokerClient):
         }
 
     def cancel_order(self, order_id: str):
-        self._tickle()
         self._delete(f"/iserver/account/{self.account_id}/order/{order_id}",
                       params={"accountId": self.account_id})
         log.info("Cancelled IBKR order %s", order_id)

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -60,12 +60,14 @@ class RobinhoodTrader(BrokerClient):
         totp_secret: str = "",
         pickle_name: str = "",
         account_number: str = "",
+        ach_relationship_id: str = "",
     ):
         # email is kept for status reporting; password/totp/pickle are legacy
         # arguments accepted (and ignored) so get_broker() stays unchanged —
         # authentication lives exclusively in the auth-service box.
         self.email = email
         self.account_number = account_number
+        self.ach_relationship_id = ach_relationship_id
         self._authenticated = False
 
         global _init_phase
@@ -537,6 +539,51 @@ class RobinhoodTrader(BrokerClient):
             if len(result) >= limit:
                 break
         return result
+
+    # -- funding (ACH deposit / withdraw) ------------------------------------
+    # Robinhood's ACH transfer endpoint isn't wrapped by robin_stocks — this
+    # calls it directly through the same authenticated session (box-vended
+    # token) that submit_order() already uses. No login/auth happens here.
+
+    def get_linked_bank_accounts(self) -> list[dict]:
+        """List ACH-linked bank relationships for this account."""
+        self._ensure_auth()
+        data = rh.helper.request_get(
+            "https://api.robinhood.com/ach/relationships/", dataType="results"
+        )
+        return data or []
+
+    def _ach_transfer(self, amount: float, direction: str) -> dict | None:
+        self._ensure_auth()
+        if not self.ach_relationship_id:
+            raise ValueError("RH_ACH_RELATIONSHIP_ID is not configured")
+        payload = {
+            "ach_relationship": (
+                f"https://api.robinhood.com/ach/relationships/{self.ach_relationship_id}/"
+            ),
+            "amount": f"{amount:.2f}",
+            "direction": direction,
+        }
+        try:
+            result = rh.helper.request_post(
+                "https://api.robinhood.com/ach/transfers/", payload
+            )
+            if result and result.get("id"):
+                log.info("RH ACH %s submitted: $%.2f -> %s", direction, amount, result["id"])
+                return {"id": result["id"], "state": result.get("state"), "amount": amount}
+            log.error("RH ACH %s failed, no id in response: %s", direction, result)
+            return None
+        except Exception as e:
+            log.error("RH ACH %s error for $%.2f: %s", direction, amount, e)
+            return None
+
+    def deposit(self, amount: float) -> dict | None:
+        """Deposit funds from the linked bank into Robinhood."""
+        return self._ach_transfer(amount, "deposit")
+
+    def withdraw(self, amount: float) -> dict | None:
+        """Withdraw funds from Robinhood to the linked bank."""
+        return self._ach_transfer(amount, "withdraw")
 
     # -- auth status --------------------------------------------------------
 

--- a/app/brokers/robinhood_client.py
+++ b/app/brokers/robinhood_client.py
@@ -565,9 +565,22 @@ class RobinhoodTrader(BrokerClient):
             "direction": direction,
         }
         try:
-            result = rh.helper.request_post(
-                "https://api.robinhood.com/ach/transfers/", payload
+            # jsonify_data=False so we can see the HTTP status code — the
+            # default jsonify_data=True silently returns the decoded error
+            # body, which looks identical to a real (bad) response and hides
+            # an expired box token from us.
+            resp = rh.helper.request_post(
+                "https://api.robinhood.com/ach/transfers/", payload, jsonify_data=False
             )
+            if resp is not None and resp.status_code == 401:
+                log.warning(
+                    "RH ACH %s got 401 — re-vending box token and retrying once", direction
+                )
+                self._box_auth(force=True)
+                resp = rh.helper.request_post(
+                    "https://api.robinhood.com/ach/transfers/", payload, jsonify_data=False
+                )
+            result = resp.json() if resp is not None else None
             if result and result.get("id"):
                 log.info("RH ACH %s submitted: $%.2f -> %s", direction, amount, result["id"])
                 return {"id": result["id"], "state": result.get("state"), "amount": amount}

--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,21 @@ class Config:
     # -- Robinhood session persistence --
     RH_RETRY_HOUR_ET = int(os.getenv("RH_RETRY_HOUR_ET", "11"))
 
+    # -- IBKR (Client Portal Web API) --
+    # clientportal.gw must already be running + authenticated (browser login)
+    # on a box we control (Tailscale / GCP); this is just where we reach it.
+    IBKR_BASE_URL = os.getenv("IBKR_BASE_URL", "")
+    IBKR_ACCOUNT_ID = os.getenv("IBKR_ACCOUNT_ID", "")
+    IBKR_VERIFY_SSL = os.getenv("IBKR_VERIFY_SSL", "false").lower() == "true"
+
+    # -- Money movement (deposit / transfer between broker accounts) --
+    # Linked bank relationship to use for Robinhood ACH deposit/withdraw.
+    RH_ACH_RELATIONSHIP_ID = os.getenv("RH_ACH_RELATIONSHIP_ID", "")
+    # Separate gate from the general engine DRY_RUN — transfers move real
+    # money and stay simulated until explicitly turned off AND armed=true
+    # is passed on the request itself.
+    TRANSFERS_DRY_RUN = os.getenv("TRANSFERS_DRY_RUN", "true").lower() == "true"
+
     @classmethod
     def rh_credentials(cls) -> tuple[str, str]:
         """Return (email, password) for the active Robinhood account."""

--- a/app/config.py
+++ b/app/config.py
@@ -50,7 +50,11 @@ class Config:
     # on a box we control (Tailscale / GCP); this is just where we reach it.
     IBKR_BASE_URL = os.getenv("IBKR_BASE_URL", "")
     IBKR_ACCOUNT_ID = os.getenv("IBKR_ACCOUNT_ID", "")
-    IBKR_VERIFY_SSL = os.getenv("IBKR_VERIFY_SSL", "false").lower() == "true"
+    # Defaults to verifying the gateway's certificate. Only set this to
+    # false for a gateway with a self-signed cert on a network we trust
+    # (Tailscale / private GCP) — never for a gateway reachable over the
+    # open internet.
+    IBKR_VERIFY_SSL = os.getenv("IBKR_VERIFY_SSL", "true").lower() == "true"
 
     # -- Money movement (deposit / transfer between broker accounts) --
     # Linked bank relationship to use for Robinhood ACH deposit/withdraw.

--- a/tests/test_ibkr_client.py
+++ b/tests/test_ibkr_client.py
@@ -1,0 +1,145 @@
+"""Offline tests for app/brokers/ibkr_client.py — no network.
+
+_get/_post/_delete are monkeypatched per-test so we can assert on the CPAPI
+payloads we build and drive the order-confirmation-reply flow, without a
+real Client Portal Gateway.
+"""
+
+import pytest
+
+from app.brokers.ibkr_client import IBKRTrader
+from app.enums import OrderSide, OrderType
+
+
+@pytest.fixture
+def trader():
+    return IBKRTrader(base_url="https://gw.example:5000/v1/api", account_id="U123")
+
+
+# --------------------------------------------------------------------------- #
+# conid resolution
+# --------------------------------------------------------------------------- #
+
+def test_resolve_conid_matches_stock_section(trader, monkeypatch):
+    def fake_get(path, params=None):
+        assert path == "/iserver/secdef/search"
+        assert params == {"symbol": "AAPL"}
+        return [
+            {"symbol": "AAPL", "conid": 265598, "sections": [{"secType": "STK"}]},
+            {"symbol": "AAPL", "conid": 999, "sections": [{"secType": "OPT"}]},
+        ]
+
+    monkeypatch.setattr(trader, "_get", fake_get)
+    assert trader._resolve_conid("AAPL") == 265598
+    # cached on second call — _get would fail the assert above if hit again
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no cache")))
+    assert trader._resolve_conid("AAPL") == 265598
+
+
+def test_resolve_conid_no_match_returns_none(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: [])
+    assert trader._resolve_conid("ZZZZ") is None
+
+
+# --------------------------------------------------------------------------- #
+# order submission — including the confirm-reply chain
+# --------------------------------------------------------------------------- #
+
+def test_submit_market_order_confirms_replies(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_resolve_conid", lambda symbol: 265598)
+
+    posts = []
+
+    def fake_post(path, payload):
+        posts.append((path, payload))
+        if path == "/iserver/account/U123/orders":
+            assert payload == {
+                "orders": [{
+                    "conid": 265598, "orderType": "MKT", "side": "BUY",
+                    "quantity": 5.0, "tif": "GTC", "acctId": "U123",
+                }]
+            }
+            return [{"id": "reply-1", "message": ["risk warning"]}]
+        if path == "/iserver/reply/reply-1":
+            assert payload == {"confirmed": True}
+            return [{"order_id": "999", "order_status": "submitted"}]
+        raise AssertionError(f"unexpected post to {path}")
+
+    monkeypatch.setattr(trader, "_post", fake_post)
+
+    result = trader.submit_order({
+        "symbol": "AAPL", "side": OrderSide.BUY, "quantity": 5,
+        "order_type": OrderType.MARKET,
+    })
+
+    assert result == {"id": "999", "symbol": "AAPL", "status": "submitted"}
+    assert len(posts) == 2
+
+
+def test_submit_limit_order_sets_price(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_resolve_conid", lambda symbol: 42)
+
+    def fake_post(path, payload):
+        assert payload["orders"][0]["orderType"] == "LMT"
+        assert payload["orders"][0]["price"] == 123.45
+        return [{"order_id": "1", "order_status": "submitted"}]
+
+    monkeypatch.setattr(trader, "_post", fake_post)
+
+    result = trader.submit_order({
+        "symbol": "SPY", "side": OrderSide.SELL, "quantity": 1,
+        "order_type": OrderType.LIMIT, "limit_price": 123.45,
+    })
+    assert result["id"] == "1"
+
+
+def test_submit_order_unresolved_symbol_returns_none(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_resolve_conid", lambda symbol: None)
+    result = trader.submit_order({
+        "symbol": "ZZZZ", "side": OrderSide.BUY, "quantity": 1,
+    })
+    assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# positions / account parsing
+# --------------------------------------------------------------------------- #
+
+def test_positions_skips_zero_qty_and_computes_pl_pct(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: [
+        {"ticker": "AAPL", "position": 10, "avgCost": 100, "mktValue": 1100, "unrealizedPnl": 100},
+        {"ticker": "MSFT", "position": 0, "avgCost": 200, "mktValue": 0, "unrealizedPnl": 0},
+    ])
+    positions = trader.positions()
+    assert len(positions) == 1
+    assert positions[0]["symbol"] == "AAPL"
+    assert positions[0]["unrealized_pl_pct"] == pytest.approx(0.1)
+
+
+def test_account_reads_summary_amounts(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: {
+        "netliquidation": {"amount": 50000},
+        "totalcashvalue": {"amount": 10000},
+        "buyingpower": {"amount": 20000},
+    })
+    account = trader.account()
+    assert account == {
+        "equity": 50000.0, "cash": 10000.0,
+        "buying_power": 20000.0, "portfolio_value": 50000.0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# funding — no retail API exists, must fail loudly rather than pretend
+# --------------------------------------------------------------------------- #
+
+def test_deposit_and_withdraw_are_not_implemented(trader):
+    with pytest.raises(NotImplementedError):
+        trader.deposit(100)
+    with pytest.raises(NotImplementedError):
+        trader.withdraw(100)

--- a/tests/test_ibkr_client.py
+++ b/tests/test_ibkr_client.py
@@ -17,6 +17,46 @@ def trader():
 
 
 # --------------------------------------------------------------------------- #
+# transport — tickle is centralized in _get/_post/_delete, not sprinkled at
+# each call site, so every real CPAPI request (including ones made deep
+# inside submit_order's conid resolution / reply confirmation) gets one.
+# --------------------------------------------------------------------------- #
+
+def test_get_tickles_before_the_real_request(trader, monkeypatch):
+    calls = []
+    monkeypatch.setattr(trader, "_tickle", lambda: calls.append("tickle"))
+
+    class FakeResponse:
+        content = b"{}"
+        def raise_for_status(self):
+            pass
+        def json(self):
+            calls.append("request")
+            return {}
+
+    monkeypatch.setattr("app.brokers.ibkr_client.requests.get", lambda *a, **k: FakeResponse())
+    trader._get("/some/path")
+    assert calls == ["tickle", "request"]
+
+
+def test_tickle_itself_does_not_recurse(trader, monkeypatch):
+    """_tickle() must not call itself via _post's default tickle=True."""
+    posts = []
+
+    def fake_requests_post(url, json=None, verify=None, timeout=None):
+        posts.append(json)
+        class FakeResponse:
+            content = b""
+            def raise_for_status(self):
+                pass
+        return FakeResponse()
+
+    monkeypatch.setattr("app.brokers.ibkr_client.requests.post", fake_requests_post)
+    trader._tickle()
+    assert len(posts) == 1  # exactly one /tickle POST, no recursive re-tickle
+
+
+# --------------------------------------------------------------------------- #
 # conid resolution
 # --------------------------------------------------------------------------- #
 
@@ -104,6 +144,72 @@ def test_submit_order_unresolved_symbol_returns_none(trader, monkeypatch):
     assert result is None
 
 
+def test_submit_stop_order_uses_stp_and_price_field(trader, monkeypatch):
+    """CPAPI's STP type carries the stop price in `price`, not `auxPrice`."""
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_resolve_conid", lambda symbol: 42)
+
+    def fake_post(path, payload):
+        order = payload["orders"][0]
+        assert order["orderType"] == "STP"
+        assert order["price"] == 99.5
+        assert "auxPrice" not in order
+        return [{"order_id": "2", "order_status": "submitted"}]
+
+    monkeypatch.setattr(trader, "_post", fake_post)
+    result = trader.submit_order({
+        "symbol": "SPY", "side": OrderSide.SELL, "quantity": 1,
+        "order_type": OrderType.STOP, "stop_price": 99.5,
+    })
+    assert result["id"] == "2"
+
+
+def test_submit_stop_limit_order_uses_stp_lmt_price_and_aux(trader, monkeypatch):
+    """STP_LMT carries the limit price in `price` and the stop in `auxPrice`."""
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_resolve_conid", lambda symbol: 42)
+
+    def fake_post(path, payload):
+        order = payload["orders"][0]
+        assert order["orderType"] == "STP_LMT"
+        assert order["price"] == 100.0
+        assert order["auxPrice"] == 99.5
+        return [{"order_id": "3", "order_status": "submitted"}]
+
+    monkeypatch.setattr(trader, "_post", fake_post)
+    result = trader.submit_order({
+        "symbol": "SPY", "side": OrderSide.SELL, "quantity": 1,
+        "order_type": OrderType.STOP_LIMIT, "limit_price": 100.0, "stop_price": 99.5,
+    })
+    assert result["id"] == "3"
+
+
+# --------------------------------------------------------------------------- #
+# open order decoding — must invert the STP/STP_LMT price-field mapping above
+# --------------------------------------------------------------------------- #
+
+def test_open_orders_decodes_stp_stop_price_from_price_field(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: {"orders": [
+        {"orderId": "1", "ticker": "SPY", "side": "SELL", "totalSize": 1,
+         "orderType": "STP", "price": "99.5", "status": "PreSubmitted"},
+    ]})
+    orders = trader.open_orders()
+    assert orders[0]["type"] == OrderType.STOP
+    assert orders[0]["limit_price"] is None
+    assert orders[0]["stop_price"] == 99.5
+
+
+def test_open_orders_decodes_stp_lmt_limit_and_stop(trader, monkeypatch):
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: {"orders": [
+        {"orderId": "2", "ticker": "SPY", "side": "SELL", "totalSize": 1,
+         "orderType": "STP_LMT", "price": "100", "auxPrice": "99.5", "status": "PreSubmitted"},
+    ]})
+    orders = trader.open_orders()
+    assert orders[0]["type"] == OrderType.STOP_LIMIT
+    assert orders[0]["limit_price"] == 100.0
+    assert orders[0]["stop_price"] == 99.5
+
+
 # --------------------------------------------------------------------------- #
 # positions / account parsing
 # --------------------------------------------------------------------------- #
@@ -118,6 +224,74 @@ def test_positions_skips_zero_qty_and_computes_pl_pct(trader, monkeypatch):
     assert len(positions) == 1
     assert positions[0]["symbol"] == "AAPL"
     assert positions[0]["unrealized_pl_pct"] == pytest.approx(0.1)
+
+
+def test_positions_short_position_pl_pct_uses_positive_denominator(trader, monkeypatch):
+    """qty * avg_cost is negative for a short — dividing by the raw (negative)
+    cost basis would flip the sign of a profitable short's pl_pct."""
+    monkeypatch.setattr(trader, "_tickle", lambda: None)
+    monkeypatch.setattr(trader, "_get", lambda *a, **k: [
+        {"ticker": "TSLA", "position": -10, "avgCost": 100, "mktValue": -900, "unrealizedPnl": 100},
+    ])
+    positions = trader.positions()
+    assert positions[0]["side"] == "short"
+    assert positions[0]["unrealized_pl_pct"] == pytest.approx(0.1)
+
+
+def test_positions_fetches_every_page(trader, monkeypatch):
+    """CPAPI caps each page at 100 entries — a full first page means keep going."""
+    page0 = [
+        {"ticker": f"SYM{i}", "position": 1, "avgCost": 10, "mktValue": 10, "unrealizedPnl": 0}
+        for i in range(100)
+    ]
+    page1 = [
+        {"ticker": "LAST", "position": 1, "avgCost": 10, "mktValue": 10, "unrealizedPnl": 0},
+    ]
+    calls = []
+
+    def fake_get(path, params=None):
+        calls.append(path)
+        if path == "/portfolio/accounts":
+            return []
+        if path.endswith("/positions/0"):
+            return page0
+        if path.endswith("/positions/1"):
+            return page1
+        raise AssertionError(f"unexpected page request: {path}")
+
+    monkeypatch.setattr(trader, "_get", fake_get)
+    positions = trader.positions()
+    assert len(positions) == 101
+    assert positions[-1]["symbol"] == "LAST"
+    assert calls == [
+        "/portfolio/accounts",
+        "/portfolio/U123/positions/0",
+        "/portfolio/U123/positions/1",
+    ]
+
+
+def test_account_and_positions_init_portfolio_context_once(trader, monkeypatch):
+    """CPAPI requires /portfolio/accounts before any /portfolio/{id}/* call —
+    it should fire once, before the first account-specific request, and be
+    cached across subsequent calls within the same trader instance."""
+    calls = []
+
+    def fake_get(path, params=None):
+        calls.append(path)
+        if path == "/portfolio/accounts":
+            return [{"accountId": "U123"}]
+        if path.endswith("/summary"):
+            return {"netliquidation": {"amount": 1}}
+        if path.endswith("/positions/0"):
+            return []
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr(trader, "_get", fake_get)
+    trader.account()
+    trader.positions()
+
+    assert calls[0] == "/portfolio/accounts"
+    assert calls.count("/portfolio/accounts") == 1
 
 
 def test_account_reads_summary_amounts(trader, monkeypatch):

--- a/tests/test_transfer_api.py
+++ b/tests/test_transfer_api.py
@@ -1,0 +1,157 @@
+"""Offline tests for app/api/transfer.py — dry-run/armed gating and the
+withdraw-then-deposit orchestration, with fake brokers standing in for
+Robinhood/IBKR (no real ACH calls).
+"""
+
+import pytest
+
+from app import create_app
+from app.config import Config
+import app.api.transfer as transfer_mod
+
+
+class FakeBroker:
+    def __init__(self, deposit_result=None, withdraw_result=None,
+                 deposit_error=None, withdraw_error=None, supports=("deposit", "withdraw")):
+        self._deposit_result = deposit_result or {"id": "dep-1"}
+        self._withdraw_result = withdraw_result or {"id": "wd-1"}
+        self._deposit_error = deposit_error
+        self._withdraw_error = withdraw_error
+        self._supports = supports
+
+    def deposit(self, amount):
+        if "deposit" not in self._supports:
+            # Mirrors IBKRTrader.deposit(): the method exists but the
+            # broker has no retail funding API, so it fails loudly.
+            raise NotImplementedError("no funding API for this broker")
+        if self._deposit_error:
+            raise self._deposit_error
+        return self._deposit_result
+
+    def withdraw(self, amount):
+        if "withdraw" not in self._supports:
+            raise NotImplementedError("no funding API for this broker")
+        if self._withdraw_error:
+            raise self._withdraw_error
+        return self._withdraw_result
+
+
+@pytest.fixture
+def app():
+    class TestConfig(Config):
+        TESTING = True
+        TRANSFERS_DRY_RUN = True
+
+    application = create_app(TestConfig)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def fake_brokers(monkeypatch):
+    brokers = {"robinhood": FakeBroker(), "ibkr": FakeBroker(supports=())}
+
+    def fake_get_broker(name):
+        return brokers[name]
+
+    monkeypatch.setattr(transfer_mod, "get_broker", fake_get_broker)
+    return brokers
+
+
+# --------------------------------------------------------------------------- #
+# dry-run / armed gating
+# --------------------------------------------------------------------------- #
+
+def test_transfer_defaults_to_dry_run(client, fake_brokers):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 500,
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "simulated"
+    assert body["dry_run"] is True
+
+
+def test_transfer_live_without_armed_is_rejected(client, fake_brokers):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 500,
+        "dry_run": False,
+    })
+    assert resp.status_code == 400
+    assert "armed" in resp.get_json()["error"]
+
+
+def test_transfer_requires_different_brokers(client, fake_brokers):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "robinhood", "amount": 500,
+    })
+    assert resp.status_code == 400
+
+
+def test_transfer_rejects_non_positive_amount(client, fake_brokers):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 0,
+    })
+    assert resp.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# orchestration: withdraw then deposit, and the "not rolled back" case
+# --------------------------------------------------------------------------- #
+
+def test_transfer_armed_calls_withdraw_then_deposit(client, monkeypatch):
+    robinhood = FakeBroker(withdraw_result={"id": "wd-42"})
+    ibkr = FakeBroker(deposit_result={"id": "dep-42"})
+    monkeypatch.setattr(transfer_mod, "get_broker",
+                         lambda name: {"robinhood": robinhood, "ibkr": ibkr}[name])
+
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 250,
+        "dry_run": False, "armed": True,
+    })
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["withdraw_result"]["id"] == "wd-42"
+    assert body["deposit_result"]["id"] == "dep-42"
+
+
+def test_transfer_deposit_leg_failure_is_reported_not_hidden(client, monkeypatch):
+    robinhood = FakeBroker(withdraw_result={"id": "wd-99"})
+    ibkr = FakeBroker(supports=())  # no deposit support -> NotImplementedError path
+
+    def fake_get_broker(name):
+        return {"robinhood": robinhood, "ibkr": ibkr}[name]
+
+    monkeypatch.setattr(transfer_mod, "get_broker", fake_get_broker)
+
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 250,
+        "dry_run": False, "armed": True,
+    })
+    assert resp.status_code == 501
+    body = resp.get_json()
+    assert body["leg"] == "deposit"
+    assert body["withdraw_result"]["id"] == "wd-99"
+    assert "rolled back" in body["warning"]
+
+
+# --------------------------------------------------------------------------- #
+# single-leg endpoints
+# --------------------------------------------------------------------------- #
+
+def test_single_leg_deposit_dry_run(client, fake_brokers):
+    resp = client.post("/api/transfer/deposit/robinhood", json={"amount": 100})
+    assert resp.status_code == 200
+    assert resp.get_json()["dry_run"] is True
+
+
+def test_single_leg_deposit_unsupported_broker_returns_501(client, fake_brokers):
+    resp = client.post("/api/transfer/deposit/ibkr", json={
+        "amount": 100, "dry_run": False, "armed": True,
+    })
+    assert resp.status_code == 501
+    assert "no funding API" in resp.get_json()["error"]

--- a/tests/test_transfer_api.py
+++ b/tests/test_transfer_api.py
@@ -99,6 +99,33 @@ def test_transfer_rejects_non_positive_amount(client, fake_brokers):
     assert resp.status_code == 400
 
 
+@pytest.mark.parametrize("armed_value", ["false", "0", "no", 1, 0])
+def test_transfer_live_requires_literal_true_for_armed(client, fake_brokers, armed_value):
+    """A JSON string "false" is truthy in Python — armed must reject anything
+    that isn't the literal boolean true, not just anything falsy-looking."""
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 500,
+        "dry_run": False, "armed": armed_value,
+    })
+    assert resp.status_code == 400
+    assert "armed" in resp.get_json()["error"]
+
+
+@pytest.mark.parametrize("amount", [1.999, 0.001, True, float("nan"), float("inf")])
+def test_transfer_rejects_amounts_that_would_change_on_serialization(client, fake_brokers, amount):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": amount,
+    })
+    assert resp.status_code == 400
+
+
+def test_transfer_accepts_two_decimal_amount(client, fake_brokers):
+    resp = client.post("/api/transfer", json={
+        "from_broker": "robinhood", "to_broker": "ibkr", "amount": 99.99,
+    })
+    assert resp.status_code == 200
+
+
 # --------------------------------------------------------------------------- #
 # orchestration: withdraw then deposit, and the "not rolled back" case
 # --------------------------------------------------------------------------- #
@@ -106,6 +133,11 @@ def test_transfer_rejects_non_positive_amount(client, fake_brokers):
 def test_transfer_armed_calls_withdraw_then_deposit(client, monkeypatch):
     robinhood = FakeBroker(withdraw_result={"id": "wd-42"})
     ibkr = FakeBroker(deposit_result={"id": "dep-42"})
+    call_order = []
+    monkeypatch.setattr(robinhood, "withdraw",
+                         lambda amount: call_order.append("withdraw") or {"id": "wd-42"})
+    monkeypatch.setattr(ibkr, "deposit",
+                         lambda amount: call_order.append("deposit") or {"id": "dep-42"})
     monkeypatch.setattr(transfer_mod, "get_broker",
                          lambda name: {"robinhood": robinhood, "ibkr": ibkr}[name])
 
@@ -117,6 +149,7 @@ def test_transfer_armed_calls_withdraw_then_deposit(client, monkeypatch):
     body = resp.get_json()
     assert body["withdraw_result"]["id"] == "wd-42"
     assert body["deposit_result"]["id"] == "dep-42"
+    assert call_order == ["withdraw", "deposit"]
 
 
 def test_transfer_deposit_leg_failure_is_reported_not_hidden(client, monkeypatch):


### PR DESCRIPTION
## Summary

- Adds `IBKRTrader` (`app/brokers/ibkr_client.py`) implementing the existing `BrokerClient` interface via IBKR's **Client Portal Web API** (REST, reachable through a Tailscale/GCP-hosted gateway — per discussion, not TWS/`ib_insync`). Account/positions/open-orders reads, market/limit/stop/stop-limit order submission (auto-confirming CPAPI's order-reply chain), and cancel. Because it's registered in `get_broker()`, it comes "for free" through the existing broker-agnostic routes: `/api/account/ibkr`, `/api/positions/ibkr`, `/api/orders/ibkr`, `/api/trade/{order,buy,sell,cancel,cancel-all}/ibkr`.
- Adds ACH `deposit()`/`withdraw()` to `RobinhoodTrader`, calling Robinhood's ACH transfer endpoint (not wrapped by `robin_stocks`) through the same box-vended session `submit_order()` already uses — no new login path, so this stays inside the auth-service boundary in CLAUDE.md.
- Adds `app/api/transfer.py`:
  - `POST /api/transfer/deposit/<broker>` / `.../withdraw/<broker>` — single-leg ACH against that broker's own linked bank account.
  - `POST /api/transfer` — withdraws from `from_broker`, then deposits to `to_broker`. **Not atomic** (no real broker-to-broker transfer API exists) — if the deposit leg fails after a successful withdrawal, the response reports it explicitly (`leg: "deposit"`, a `warning` with the withdrawal id) instead of pretending to roll back.
  - Both real-money paths require `TRANSFERS_DRY_RUN=false` **and** an explicit `armed: true` in the request body.
- `IBKRTrader.deposit()`/`withdraw()` intentionally raise `NotImplementedError` — IBKR's Client Portal Web API has no retail funding endpoint, so this fails loudly (501) rather than faking success.
- New config: `IBKR_BASE_URL`, `IBKR_ACCOUNT_ID`, `IBKR_VERIFY_SSL`, `RH_ACH_RELATIONSHIP_ID`, `TRANSFERS_DRY_RUN` (all documented in `.env.example` and `CLAUDE.md`).

## Test plan

- [x] `pytest tests/test_ibkr_client.py tests/test_transfer_api.py -q` — 16 new tests covering conid resolution/caching, market/limit order payloads, the CPAPI confirm-reply loop, position/account parsing, the `NotImplementedError` funding paths, and the transfer API's dry-run/armed gating + two-leg orchestration (including the "deposit leg fails after withdrawal succeeds" case).
- [x] Full suite: `pytest tests/ -q` — 104 passed, no regressions.
- [ ] Manual smoke test against a real `clientportal.gw` instance once the Tailscale/GCP gateway box is up (not available in this sandbox).
- [ ] Manual smoke test of a real (small, dry-run-off) Robinhood ACH deposit/withdraw once `RH_ACH_RELATIONSHIP_ID` is set in the target environment.

## Remaining infra before this can go live

1. **IBKR Client Portal Gateway host** — a persistent `clientportal.gw` process on Tailscale or a GCP box, reachable at `IBKR_BASE_URL`. Still needed:
   - Initial browser-based login + 2FA to establish the brokerage session (CPAPI can't do this headlessly).
   - A plan for the ~24h session expiry — there's no headless re-auth, so either someone re-logs in daily or we add a monitoring signal (similar to Robinhood's device-challenge sleep-until-11am pattern) so the engine visibly stops trading IBKR instead of silently failing calls.
   - Confirmed network path from Render (both `allocation-engine-api` and `allocation-engine-2.0`) to that box — Render doesn't run a Tailscale sidecar natively, so this needs either a Tailscale exit-node/funnel setup or a GCP box with a firewall rule scoped to Render's egress IPs.
2. **Render env vars** — `IBKR_BASE_URL`, `IBKR_ACCOUNT_ID`, `IBKR_VERIFY_SSL` on both services.
3. **`RH_ACH_RELATIONSHIP_ID`** — run `RobinhoodTrader.get_linked_bank_accounts()` once against the real account to get the linked-bank relationship id, then set it in Render/Netlify env vars.
4. **IBKR auth-status visibility** — no `/api/auth/status/ibkr` equivalent exists yet; today a stale CPAPI session just fails loudly on the next call instead of being visible ahead of time like `/api/auth/status/robinhood`.
5. **CI** — nothing runs the test suite on PRs today. The `pylint.yml` workflow GitHub still lists no longer exists on `main`, and the other two workflows (`unload-market-quotes`, `unload-options-chain`) are schedule-only. The 104 passing tests (16 new here) aren't enforced anywhere — recommend a pytest-on-PR workflow.
6. **Real-money verification** — both IBKR order submission and Robinhood ACH transfer are untested against live endpoints (this was built and tested offline only). Needs a controlled manual smoke test once the gateway box + linked-bank id exist.

## Risk calibration — gaps found while doing this work

Existing `app/risk/` + `app/engine.py` risk calibration has some real gaps, one of which this PR reintroduces for a second broker:

- `RiskEventType.POSITION_LIMIT` and `.ORDER_REJECTED` (`app/enums.py`) are defined but never emitted anywhere — a broker rejecting an order (`submit_order()` returning `None`) is just logged today, not raised as a risk event or alerted to Slack.
- `MAX_ORDER_QTY` (`app/engine.py::_execute`) is a flat share-count cap (default 50) applied identically regardless of price — a $50 cap means very different risk on a $5 stock vs. a $2,000 stock.
- `DRIFT_THRESHOLD` (8%) is one hardcoded value for every symbol, no per-symbol volatility adjustment.
- **New in this PR**: `IBKRTrader._confirm_replies()` auto-confirms *every* CPAPI order-reply message, including margin/risk warnings, without inspecting severity — same blind-auto-confirm shape as the existing Robinhood order flow, now duplicated for IBKR.
- `app/api/transfer.py` only validates `amount > 0` — no ceiling relative to account equity/cash beyond the `DRY_RUN`+`armed` gates.

Proposed as a follow-up (touches shared engine logic beyond this broker surface, so scoping it separately rather than folding into this diff):
- Emit `ORDER_REJECTED` on broker rejection and a `POSITION_LIMIT` event from a real concentration check, both routed through the existing `RiskSubject`/Slack observer.
- Move `MAX_ORDER_QTY` to a value-based cap (e.g. % of buying power) instead of flat share count.
- Allow-list which IBKR reply messages get auto-confirmed (e.g. "outside regular trading hours") vs. which ones should hard-stop and alert (margin calls, short-sale warnings).
- Add a `MAX_TRANSFER_AMOUNT` (or % of account cash) ceiling to `app/api/transfer.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Interactive Brokers integration for account, position, order, and cancellation management.
  * Added deposit, withdrawal, and cross-broker transfer API operations.
  * Added Robinhood ACH deposits and withdrawals.
  * Added dry-run defaults and safety confirmation for live transfers.
  * Added clear handling for unsupported funding operations and transfer failures.

* **Documentation**
  * Documented broker connectivity, transfer behavior, safety gates, and order confirmations.

* **Tests**
  * Added coverage for IBKR trading workflows and transfer validation, safety, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->