### PR TITLE
fix: gate every broker-reaching route behind RH_PROXY_TOKEN

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,6 +26,10 @@ def create_app(config_class=Config):
     from app.api import register_blueprints
     register_blueprints(app)
 
+    # Gate the routes that can reach the broker (see app/security.py)
+    from app.security import install_write_gate
+    install_write_gate(app)
+
     # Engine thread is started by gunicorn's post_fork hook (gunicorn.conf.py)
     # to avoid import-lock deadlocks during create_app().
     log.info("[create_app] ENGINE_ENABLED=%s, DRY_RUN=%s, ENGINE_BROKER=%s",

--- a/app/api/robinhood_proxy.py
+++ b/app/api/robinhood_proxy.py
@@ -2,6 +2,12 @@
 
 - GET/POST /api/robinhood/trailing-stop  — allow-listed direct calls (RH session)
 - POST     /api/robinhood/mcp            — JSON-RPC passthrough to Robinhood MCP
+
+Every route here is gated on ``RH_PROXY_TOKEN`` — including the GETs, since
+reading the order book leaks account activity. These endpoints relay to the
+box using *our* bearer and the caller chooses ``dry_run``, so an ungated route
+lets anyone on the internet trade the account. The gate lives in
+``app/security.py`` so it covers the mutating routes elsewhere too.
 """
 
 from flask import Blueprint, jsonify, request, current_app

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,11 @@ class Config:
     RH_AUTH_SERVICE_REQUEST_TOKEN = os.getenv("RH_AUTH_SERVICE_REQUEST_TOKEN", "")
     AUTH_SERVICE_TIMEOUT = int(os.getenv("AUTH_SERVICE_TIMEOUT", "30"))
 
+    # Callers of /api/robinhood/* must present this token. Those routes relay
+    # to the box using OUR bearer, so without a gate anyone on the internet can
+    # place orders through them. Unset means the routes are closed, not open.
+    RH_PROXY_TOKEN = os.getenv("RH_PROXY_TOKEN", "")
+
     # -- Trailing-stop sweeper (runs in the background engine loop) --
     # Universe beyond current positions; comma-separated symbols.
     STOP_TICKERS = os.getenv("STOP_TICKERS", "")

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,67 @@
+"""Token gate for the routes that can move money.
+
+This service holds live broker credentials (a box-vended Robinhood bearer) and
+attaches them server-side, so any unauthenticated route that reaches the broker
+is an open relay: the caller supplies no credentials of their own and still
+trades the account.
+
+Gated:
+  * every mutating request (POST / PUT / PATCH / DELETE) under /api
+  * all of /api/robinhood/* including GET, since reading the order book leaks
+    account activity
+
+Left open: ordinary GETs (health, status, quotes, positions) — read-only and
+relied on by dashboards.
+
+The gate fails closed. With no ``RH_PROXY_TOKEN`` configured the guarded
+routes return 503; an unset token never means "open to everyone".
+"""
+
+import hmac
+
+from flask import current_app, jsonify, request
+
+WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Guarded regardless of method — these relay to the auth-service box.
+GUARDED_PREFIXES = ("/api/robinhood/",)
+
+
+def _presented_token() -> str:
+    """The caller's token from either accepted header."""
+    header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+    if header.startswith(prefix):
+        return header[len(prefix):]
+    return request.headers.get("X-Api-Key", "")
+
+
+def _needs_token() -> bool:
+    path = request.path or ""
+    if any(path.startswith(p) for p in GUARDED_PREFIXES):
+        return True
+    return path.startswith("/api/") and request.method in WRITE_METHODS
+
+
+def install_write_gate(app) -> None:
+    """Attach the gate to `app`. Safe to call once per application."""
+
+    @app.before_request
+    def _gate():  # noqa: ANN202 — Flask hook
+        if request.method == "OPTIONS" or not _needs_token():
+            return None
+
+        expected = current_app.config.get("RH_PROXY_TOKEN", "")
+        if not expected:
+            return jsonify({
+                "error": "endpoint disabled",
+                "detail": "RH_PROXY_TOKEN is unset; routes that can reach the "
+                          "broker stay closed until it is set",
+            }), 503
+        if not hmac.compare_digest(_presented_token(), expected):
+            return jsonify({
+                "error": "unauthorized",
+                "detail": "send Authorization: Bearer <RH_PROXY_TOKEN> "
+                          "or X-Api-Key",
+            }), 401
+        return None

--- a/app/stop_sweeper.py
+++ b/app/stop_sweeper.py
@@ -44,6 +44,7 @@ log = logging.getLogger("stop_sweeper")
 
 DEFAULT_DB = os.getenv("STOP_DB_PATH", os.path.join(os.path.dirname(__file__), "..", "data", "stops.sqlite3"))
 PROXY_BASE = os.getenv("RH_PROXY_BASE", "https://allocation-engine-api.onrender.com/api/robinhood")
+PROXY_TOKEN = os.getenv("RH_PROXY_TOKEN", "")
 BOX_BASE = os.getenv("AUTH_SERVICE_URL", "")
 BOX_TOKEN = os.getenv("RH_AUTH_SERVICE_REQUEST_TOKEN", "")
 
@@ -136,14 +137,24 @@ def validate_mcp_call(payload):
 # --------------------------------------------------------------------------- #
 
 class ProxyClient:
-    """Talk to RH through the deployed Render proxy (works off-network)."""
+    """Talk to RH through the deployed Render proxy (works off-network).
 
-    def __init__(self, base=PROXY_BASE, timeout=45):
+    The proxy relays to the box with its own bearer, so it is gated on
+    RH_PROXY_TOKEN — set it here too or every call comes back 401.
+    """
+
+    def __init__(self, base=PROXY_BASE, token=PROXY_TOKEN, timeout=45):
+        if not token:
+            raise SystemExit(
+                "RH_PROXY_TOKEN not set — the Render proxy requires it. "
+                "Use --via box to talk to the auth-service directly instead.")
         self.base = base.rstrip("/")
+        self.headers = {"Authorization": f"Bearer {token}"}
         self.timeout = timeout
 
     def get_stops(self):
-        r = requests.get(f"{self.base}/trailing-stop", timeout=self.timeout)
+        r = requests.get(f"{self.base}/trailing-stop",
+                         headers=self.headers, timeout=self.timeout)
         r.raise_for_status()
         return r.json().get("orders", [])
 
@@ -151,7 +162,7 @@ class ProxyClient:
         validate_trailing_stop_payload(payload, live=not dry_run)
         r = requests.post(f"{self.base}/trailing-stop",
                           json={"payload": payload, "dry_run": dry_run},
-                          timeout=self.timeout)
+                          headers=self.headers, timeout=self.timeout)
         r.raise_for_status()
         return r.json()
 
@@ -162,7 +173,7 @@ class ProxyClient:
     def mcp_call(self, payload):
         validate_mcp_call(payload)
         r = requests.post(f"{self.base}/mcp", json={"payload": payload},
-                          timeout=self.timeout)
+                          headers=self.headers, timeout=self.timeout)
         r.raise_for_status()
         return r.json()
 

--- a/render.yaml
+++ b/render.yaml
@@ -28,6 +28,11 @@ services:
         sync: false
       - key: RH_AUTH_SERVICE_REQUEST_TOKEN
         sync: false
+      # Gates every mutating /api/* route and the /api/robinhood/* relay.
+      # Those reach the broker with our own credentials, so they stay closed
+      # until this is set.
+      - key: RH_PROXY_TOKEN
+        sync: false
       # Trading DB write path (orders + positions)
       - key: TRADING_DB_URL
         sync: false
@@ -104,6 +109,11 @@ services:
       - key: AUTH_SERVICE_URL
         sync: false
       - key: RH_AUTH_SERVICE_REQUEST_TOKEN
+        sync: false
+      # Gates every mutating /api/* route and the /api/robinhood/* relay.
+      # Those reach the broker with our own credentials, so they stay closed
+      # until this is set.
+      - key: RH_PROXY_TOKEN
         sync: false
       # Trading DB write path (orders + positions)
       - key: TRADING_DB_URL

--- a/tests/test_robinhood_proxy_auth.py
+++ b/tests/test_robinhood_proxy_auth.py
@@ -1,0 +1,95 @@
+"""Routes that can reach the broker must never be open.
+
+This service attaches a live Robinhood bearer server-side, so an
+unauthenticated route that reaches the broker is an open relay: the caller
+supplies no credentials of their own and still trades the account.
+
+The worst of these needs no flag at all — `/api/trade/cancel-all` has no
+dry_run check anywhere in its handler, so an anonymous request cancels every
+open order, including the protective trailing stops.
+"""
+
+import pytest
+
+from app import create_app
+from app.config import Config
+
+TOKEN = "proxy-secret"
+
+
+def _client(token=TOKEN):
+    class TestConfig(Config):
+        TESTING = True
+        RH_PROXY_TOKEN = token
+
+    return create_app(TestConfig).test_client()
+
+
+# Everything that reaches the broker with our credentials.
+GUARDED = [
+    ("get", "/api/robinhood/trailing-stop"),
+    ("post", "/api/robinhood/trailing-stop"),
+    ("post", "/api/robinhood/mcp"),
+    ("post", "/api/trade/order"),
+    ("post", "/api/trade/buy"),
+    ("post", "/api/trade/sell"),
+    ("post", "/api/trade/cancel"),
+    ("delete", "/api/trade/cancel"),
+    ("post", "/api/trade/cancel-all"),
+    ("delete", "/api/trade/cancel-all"),
+    ("post", "/api/engine/tick"),
+    ("post", "/api/claude/reauth"),
+]
+
+
+@pytest.mark.parametrize("method,path", GUARDED)
+def test_no_credentials_is_rejected(method, path):
+    assert getattr(_client(), method)(path, json={}).status_code == 401
+
+
+@pytest.mark.parametrize("method,path", GUARDED)
+def test_wrong_token_is_rejected(method, path):
+    resp = getattr(_client(), method)(
+        path, json={}, headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.parametrize("method,path", GUARDED)
+def test_unset_token_fails_closed(method, path):
+    # An unconfigured gate must shut the door, not leave it open.
+    resp = getattr(_client(token=""), method)(
+        path, json={}, headers={"Authorization": f"Bearer {TOKEN}"})
+    assert resp.status_code == 503
+
+
+def test_cancel_all_needs_the_token_even_though_it_has_no_dry_run():
+    # There is no dry_run check in this handler at all — the token is the
+    # only thing between an anonymous request and a wiped order book.
+    assert _client().post("/api/trade/cancel-all").status_code == 401
+
+
+def test_a_live_sell_still_needs_the_token():
+    body = {"symbol": "AAPL", "side": "SELL", "quantity": 1000,
+            "order_type": "market", "dry_run": False}
+    assert _client().post("/api/trade/order", json=body).status_code == 401
+
+
+def test_read_only_endpoints_stay_open():
+    # Health and status are read-only and dashboards depend on them.
+    client = _client()
+    for path in ("/api/health", "/api/engine/status"):
+        assert client.get(path).status_code != 401
+
+
+def test_valid_token_passes_the_gate():
+    # Past the gate it reaches the handler, which fails on missing
+    # auth-service config rather than being turned away at the door.
+    resp = _client().get("/api/robinhood/trailing-stop",
+                         headers={"Authorization": f"Bearer {TOKEN}"})
+    assert resp.status_code != 401
+
+
+def test_x_api_key_header_is_accepted():
+    resp = _client().get("/api/robinhood/trailing-stop",
+                         headers={"X-Api-Key": TOKEN})
+    assert resp.status_code != 401


### PR DESCRIPTION
🔴 **Security.** Scope widened after review — this now covers the whole broker-reaching surface, not just `/api/robinhood/*`.

## The exposure

This service attaches a live box-vended Robinhood bearer **server-side**. Any unauthenticated route that reaches the broker is therefore an open relay: the caller supplies no credentials of their own and still trades the account. Verified against prod — an unauthenticated `GET /api/robinhood/trailing-stop` returns `200` with data.

Twelve routes are reachable with no credentials. In severity order:

| Route | What an anonymous caller gets | Needs a flag? |
|---|---|---|
| `POST·DELETE /api/trade/cancel-all` | **Cancels every open order** — including the 25 protective trailing stops | **No.** No `dry_run` check exists in that handler |
| `POST·DELETE /api/trade/cancel` | Cancels any order by id | **No** |
| `POST /api/trade/order`·`buy`·`sell` | Arbitrary symbol / side / quantity / order type, straight to the broker — **no `MAX_ORDER_QTY` cap** (that only applies inside `AllocationEngine`) and **no box guardrails** | `dry_run: false` |
| `POST /api/robinhood/trailing-stop` | A trailing stop; box guardrails constrain the *shape*, not side, size, or intent | `dry_run: false` |
| `GET /api/robinhood/trailing-stop` | Reads the order book | No |
| `POST /api/claude/reauth` | Spawns a subprocess | No |
| `POST /api/engine/tick` | Forces an engine tick | No |

`cancel-all` is the one that stands out: it works **today**, needs no flag, and there is no `dry_run` branch anywhere in its handler.

I did **not** exercise any of the write paths against prod — that would have placed or cancelled real orders.

This wasn't drift. `ProxyClient` is documented as *"works off-network"* and deliberately sent no credentials, so the routes were left open for it.

## Why now

It was inert while the box's Robinhood session was revoked — every relay 401'd. **That session was restored today**, so the window is open as of now.

## The fix

`app/security.py` installs one `before_request` gate:

- every mutating `/api` request (`POST`/`PUT`/`PATCH`/`DELETE`)
- all of `/api/robinhood/*` including `GET`
- ordinary GETs (health, status, quotes, positions) stay open — read-only, and dashboards use them
- **fails closed**: unset `RH_PROXY_TOKEN` → `503`, never "open to everyone"
- `Authorization: Bearer` or `X-Api-Key`, compared with `hmac.compare_digest`
- `ProxyClient` sends the token and exits clearly when it's missing

## ⚠️ Manual step before merge

Set `RH_PROXY_TOKEN` to a fresh random secret on `srv-d6sbe2k50q8c73fgn86g`. Merging without it closes the routes rather than breaking anything unsafe, but the sweeper's proxy path will 503 until it's set. Nothing in the engine loop uses it — that talks to the box directly via `BoxClient`.

```bash
curl -s -o /dev/null -w "%{http_code}\n" \
  https://allocation-engine-api.onrender.com/api/robinhood/trailing-stop
# want 401 (currently 200)
```

## Tests

145 pass. All 12 routes are asserted for missing / wrong / unset token, plus a live `dry_run: false` sell, `cancel-all` with no body, and that read-only routes stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-based authentication for Robinhood proxy requests and API write operations.
  * Requests can authenticate with a bearer token or `X-Api-Key`.
  * Unconfigured authentication fails safely with HTTP 503; invalid or missing credentials receive HTTP 401.
  * Ordinary read-only GET and `OPTIONS` requests remain accessible.
  * Proxy clients automatically include authorization credentials for supported requests.
* **Tests**
  * Added coverage for valid, invalid, missing, and unconfigured authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->