### PR TITLE
fix: verify the cached Robinhood token with Robinhood, not the clock

### DIFF
--- a/auth-service/session.py
+++ b/auth-service/session.py
@@ -17,6 +17,7 @@ Three timeouts, mirroring the sketch:
 
 import json
 import logging
+import os
 import threading
 import time
 import uuid
@@ -34,6 +35,51 @@ log = logging.getLogger("session")
 CALLER_TIMEOUT = 200
 LOGIN_HTTP_TIMEOUT = 10
 APPROVAL_DEADLINE = 180
+
+# How often the cached token is checked against Robinhood rather than the
+# clock. `expires_at` only says when the token *would* lapse; it says nothing
+# about a server-side revocation. On 2026-08-04 Robinhood revoked the session
+# ~18h before its stated expiry and every consumer 401'd for a day while
+# /auth/status kept reporting authenticated — the clock check can't see that.
+# Verifying costs one GET /user/, so do it periodically, not per vend.
+VERIFY_INTERVAL = int(os.getenv("TOKEN_VERIFY_INTERVAL", "300"))
+
+_verify_lock = threading.Lock()
+# profile_id -> (access_token, monotonic_ts, ok)
+_verified: dict[str, tuple[str, float, bool]] = {}
+
+
+def _verify_cached(profile_id: str, session) -> bool:
+    """Is `session` still good at Robinhood? Throttled per profile+token.
+
+    A negative result is never cached: once a token fails we want the next
+    caller to re-drive auth rather than wait out the interval.
+    """
+    if session is None or not session.access_token:
+        return False
+    now = time.monotonic()
+    with _verify_lock:
+        prev = _verified.get(profile_id)
+        if (prev and prev[0] == session.access_token
+                and prev[2] and now - prev[1] < VERIFY_INTERVAL):
+            return True
+
+    ok = robinhood.check_token_valid(session, verify=True)
+    with _verify_lock:
+        if ok:
+            _verified[profile_id] = (session.access_token, now, True)
+        else:
+            _verified.pop(profile_id, None)
+    if not ok:
+        log.warning("cached token for %s rejected by Robinhood despite "
+                    "expires_at=%s — forcing re-auth",
+                    profile_id, getattr(session, "expires_at", None))
+    return ok
+
+
+def _forget_verification(profile_id: str) -> None:
+    with _verify_lock:
+        _verified.pop(profile_id, None)
 
 _STATE_DIR = Path(config.STATE_DIR)
 _lock = threading.Lock()
@@ -154,8 +200,12 @@ def get_session(profile_id: str = "rh.auth", force: bool = False) -> AuthResult:
     """
     if not force:
         cached = load(profile_id)
-        if robinhood.check_token_valid(cached):
+        # Clock first (cheap), then Robinhood itself (throttled). A token can
+        # be locally unexpired and still revoked server-side.
+        if robinhood.check_token_valid(cached) and _verify_cached(profile_id, cached):
             return AuthResult("OK", session=cached)
+    else:
+        _forget_verification(profile_id)
 
     with _lock:
         task = _inflight.get(profile_id)
@@ -187,13 +237,23 @@ def get_session(profile_id: str = "rh.auth", force: bool = False) -> AuthResult:
         return AuthResult("ERROR", error_code="AUTH_EXCEPTION", detail=str(e))
 
 
-def status(profile_id: str = "rh.auth") -> dict:
-    """Auth status for callers / alerting — never triggers a login."""
+def status(profile_id: str = "rh.auth", verify: bool = True) -> dict:
+    """Auth status for callers / alerting — never triggers a login.
+
+    ``authenticated`` means Robinhood still accepts the token, not merely that
+    the clock hasn't passed ``expires_at``. Reporting the clock is what let a
+    revoked session look healthy for a day. ``token_verified`` distinguishes a
+    confirmed-good token from one we only know is unexpired.
+    """
     session = load(profile_id)
-    valid = robinhood.check_token_valid(session)
+    unexpired = robinhood.check_token_valid(session)
+    verified = _verify_cached(profile_id, session) if (verify and unexpired) else None
     return {
         "profile": profile_id,
-        "authenticated": valid,
+        "authenticated": unexpired if verified is None else verified,
+        "token_unexpired": unexpired,
+        "token_verified": verified,
+        "verify_interval": VERIFY_INTERVAL,
         "expires_at": session.expires_at if session else None,
         "account_number": session.account_number if session else None,
     }

--- a/auth-service/tests/test_session_verify.py
+++ b/auth-service/tests/test_session_verify.py
@@ -1,0 +1,125 @@
+"""A cached token must be checked against Robinhood, not just the clock.
+
+On 2026-08-04 Robinhood revoked the session ~18h before its stated expiry.
+`check_token_valid` defaulted to a local `expires_at` comparison, so
+`get_session` kept vending the dead token and `/auth/status` kept reporting
+`authenticated: true` while every consumer 401'd for a day.
+"""
+
+import os
+import sys
+import time
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import session as sm  # noqa: E402
+from models import AuthResult, Session  # noqa: E402
+
+
+def _session(token="tok-live"):
+    return Session(
+        access_token=token,
+        refresh_token="refresh",
+        token_type="Bearer",
+        expires_at=time.time() + 86_400,   # comfortably unexpired
+        device_token="dev",
+        account_number="5RX91619",
+    )
+
+
+class VerifyCachedTokenTests(unittest.TestCase):
+    def setUp(self):
+        sm._verified.clear()
+        self.addCleanup(sm._verified.clear)
+
+    def test_revoked_but_unexpired_token_is_not_served(self):
+        live = _session()
+        fresh = _session("tok-fresh")
+        with mock.patch.object(sm, "load", return_value=live), \
+             mock.patch.object(sm.robinhood, "check_token_valid",
+                               side_effect=lambda s, **kw: not kw.get("verify")), \
+             mock.patch.object(sm, "_do_auth",
+                               return_value=AuthResult("OK", session=fresh)):
+            result = sm.get_session("rh.auth")
+
+        # Fell through to a real re-auth instead of returning the dead token
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(result.session.access_token, "tok-fresh")
+
+    def test_good_token_is_served_without_reauth(self):
+        live = _session()
+        with mock.patch.object(sm, "load", return_value=live), \
+             mock.patch.object(sm.robinhood, "check_token_valid", return_value=True), \
+             mock.patch.object(sm, "_do_auth") as do_auth:
+            result = sm.get_session("rh.auth")
+
+        self.assertEqual(result.session.access_token, "tok-live")
+        do_auth.assert_not_called()
+
+    def test_verification_is_throttled_not_per_call(self):
+        live = _session()
+        with mock.patch.object(sm.robinhood, "check_token_valid",
+                               return_value=True) as check:
+            for _ in range(5):
+                self.assertTrue(sm._verify_cached("rh.auth", live))
+
+        verified = [c for c in check.call_args_list if c.kwargs.get("verify")]
+        self.assertEqual(len(verified), 1, "should hit RH once, then cache")
+
+    def test_a_failure_is_never_cached(self):
+        live = _session()
+        with mock.patch.object(sm.robinhood, "check_token_valid",
+                               return_value=False) as check:
+            self.assertFalse(sm._verify_cached("rh.auth", live))
+            self.assertFalse(sm._verify_cached("rh.auth", live))
+
+        # Both calls re-checked — a dead token must not be remembered as "known bad"
+        # and skipped; the next caller should still drive re-auth.
+        self.assertEqual(len(check.call_args_list), 2)
+
+    def test_a_rotated_token_is_reverified(self):
+        with mock.patch.object(sm.robinhood, "check_token_valid",
+                               return_value=True) as check:
+            sm._verify_cached("rh.auth", _session("tok-a"))
+            sm._verify_cached("rh.auth", _session("tok-b"))
+
+        self.assertEqual(len(check.call_args_list), 2)
+
+    def test_forced_login_discards_the_verification_cache(self):
+        live = _session()
+        sm._verified["rh.auth"] = (live.access_token, time.monotonic(), True)
+        with mock.patch.object(sm, "_do_auth",
+                               return_value=AuthResult("OK", session=_session("new"))):
+            sm.get_session("rh.auth", force=True)
+        self.assertNotIn("rh.auth", sm._verified)
+
+
+class StatusTests(unittest.TestCase):
+    def setUp(self):
+        sm._verified.clear()
+        self.addCleanup(sm._verified.clear)
+
+    def test_status_reports_revoked_token_as_unauthenticated(self):
+        with mock.patch.object(sm, "load", return_value=_session()), \
+             mock.patch.object(sm.robinhood, "check_token_valid",
+                               side_effect=lambda s, **kw: not kw.get("verify")):
+            out = sm.status("rh.auth")
+
+        self.assertFalse(out["authenticated"])   # the bug: this used to be True
+        self.assertTrue(out["token_unexpired"])
+        self.assertFalse(out["token_verified"])
+
+    def test_status_can_skip_verification(self):
+        with mock.patch.object(sm, "load", return_value=_session()), \
+             mock.patch.object(sm.robinhood, "check_token_valid",
+                               return_value=True) as check:
+            out = sm.status("rh.auth", verify=False)
+
+        self.assertIsNone(out["token_verified"])
+        self.assertFalse(any(c.kwargs.get("verify") for c in check.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**auth-service only** — zero changes under `app/`, per the service-boundary rule. Independent of the positions stack.

## What happened

On 2026-08-04 Robinhood revoked the session ~18h before its stated expiry. Nothing noticed for a day:

```
/auth/status  →  authenticated: true          # from the clock
GET /user/    →  401                          # from Robinhood
expires_at    →  1785967924  (18h in the future)
```

Every consumer 401'd — `/positions/`, `/accounts/`, `/portfolios/`, `/options/positions/` — while the engine reported healthy. The dashboard silently showed an empty book, and the daily stop sweeper's ticker list collapsed from 37 live symbols to `book-only`.

## Root cause

`get_session`'s fast path asked the clock, never Robinhood:

```python
if not force:
    cached = load(profile_id)
    if robinhood.check_token_valid(cached):     # verify=False by default
        return AuthResult("OK", session=cached)
```

```python
def check_token_valid(session, skew=60, verify=False):
    if session.expires_at and session.expires_at - skew <= time.time():
        return False
    if not verify:
        return True                              # ← local comparison only
    r = s.get(f"{BASE}/user/", timeout=10)        # ← the real test, never called
```

The `verify=True` branch was already written. It was simply never reached, so a revocation was structurally invisible.

## The fix

- Fast path runs the `GET /user/` check before serving a cached token; a revoked one falls through to a real re-auth
- **Throttled** — cached per `profile + access_token` for `TOKEN_VERIFY_INTERVAL` (300s, env-tunable). One RH call every few minutes, not one per vend
- A **failure is never cached**, so the next caller re-drives auth rather than waiting out the interval
- `force=True` discards the cache; a rotated token re-verifies
- `/auth/status` reports verified state. `authenticated` no longer means "unexpired", with `token_unexpired` and `token_verified` split out so a confirmed-good token is distinguishable from a merely-unexpired one

## Tests

53 pass (8 new). The key one asserts the exact failure: an unexpired-but-revoked token must not be served, and `status()` must report it as unauthenticated.

## ⚠️ Manual deploy — the box is not auto-deployed

```bash
gcloud compute ssh allocation-engine-auth-service-prod \
  --zone us-central1-c --project route-manager-prod

cd ~/auth-service && git pull && sudo systemctl restart auth-service
curl -s localhost:8080/auth/status
```

Expect `token_verified: true` alongside `authenticated: true`. If `token_verified` is `false`, the session needs `POST /login` — which is exactly the signal this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
