### PR TITLE
feat: sync filled equity orders, not just the open book

### DIFF
--- a/app/background.py
+++ b/app/background.py
@@ -97,6 +97,41 @@ def _option_order_to_event(o: dict) -> OrderEvent:
     )
 
 
+EQUITY_HISTORY_LIMIT = int(os.getenv("EQUITY_HISTORY_LIMIT", "200"))
+
+
+def _equity_order_history(broker, limit: int = EQUITY_HISTORY_LIMIT) -> list[dict]:
+    """Recent filled/completed equity orders, shaped for the Trading DB.
+
+    ``order_history()`` names the average fill price ``price``, but the
+    Trading DB reads ``average_price`` and treats ``price`` only as a
+    limit-price fallback — so a straight passthrough would null out the fill
+    price and P&L would silently fall back to the limit. Copy it across.
+
+    Never raises: a history fetch failing must not cost us the rest of the
+    sync.
+
+    Args:
+        broker: The active BrokerClient.
+        limit: Maximum orders to fetch.
+
+    Returns:
+        Order dicts, or an empty list when the broker can't provide them.
+    """
+    if not hasattr(broker, "order_history"):
+        return []
+    try:
+        orders = broker.order_history(limit=limit) or []
+    except Exception:
+        log.exception("Failed to fetch equity order history")
+        return []
+
+    for o in orders:
+        if o.get("average_price") is None and o.get("price") is not None:
+            o["average_price"] = o["price"]
+    return orders
+
+
 def book_looks_unreadable(positions, options_positions, account) -> bool:
     """True when the broker read looks failed rather than genuinely flat.
 
@@ -515,10 +550,15 @@ def start_engine_thread(app):
                     # the only positions path — the Netlify "engine snapshot"
                     # blob it replaced was gated on is_live and went stale.
                     if (now_mono - last_db_sync) >= db_sync_interval:
+                        # Filled equity orders come from order_history(); the
+                        # open book alone would never grow the record, since
+                        # an order stops being "open" the moment it fills.
+                        recent_orders = _equity_order_history(broker)
                         try:
                             from app.trading_db import post_orders
                             res = post_orders(
                                 open_orders=open_orders,
+                                recent_orders=recent_orders,
                                 recent_option_orders=options_open_orders,
                             )
                             if res:

--- a/tests/test_equity_order_history.py
+++ b/tests/test_equity_order_history.py
@@ -1,0 +1,77 @@
+"""Filled equity orders must reach the Trading DB.
+
+The sync only ever posted `open_orders`, and an order stops being open the
+moment it fills — so `historical_orders` never grew from the engine. It sat
+frozen at 2026-07-02 (a one-off backfill) while option orders, which are sent
+in full, stayed current.
+"""
+
+from unittest import mock
+
+from app.background import _equity_order_history
+
+
+class _Broker:
+    def __init__(self, orders=None, raises=False):
+        self._orders = orders or []
+        self._raises = raises
+        self.limit = None
+
+    def order_history(self, limit=50):
+        self.limit = limit
+        if self._raises:
+            raise RuntimeError("robinhood 401")
+        return self._orders
+
+
+FILLED = {"id": "ord-1", "symbol": "NVDA", "side": "BUY", "quantity": 2.0,
+          "filled_quantity": 2.0, "price": 110.5, "limit_price": 112.0,
+          "type": "limit", "state": "filled",
+          "created_at": "2026-08-04T14:00:00Z",
+          "updated_at": "2026-08-04T14:00:02Z"}
+
+
+def test_average_price_is_carried_across():
+    # The DB reads `average_price`; order_history calls it `price`. Without
+    # this copy, P&L silently falls back to the limit price.
+    out = _equity_order_history(_Broker([dict(FILLED)]))
+    assert out[0]["average_price"] == 110.5
+    assert out[0]["limit_price"] == 112.0
+
+
+def test_an_existing_average_price_is_not_overwritten():
+    order = dict(FILLED, average_price=99.0)
+    assert _equity_order_history(_Broker([order]))[0]["average_price"] == 99.0
+
+
+def test_a_market_order_with_no_price_is_left_alone():
+    order = {k: v for k, v in FILLED.items() if k != "price"}
+    assert "average_price" not in _equity_order_history(_Broker([order]))[0]
+
+
+def test_a_broker_failure_never_breaks_the_sync():
+    assert _equity_order_history(_Broker(raises=True)) == []
+
+
+def test_a_broker_without_history_is_tolerated():
+    assert _equity_order_history(object()) == []
+
+
+def test_limit_is_passed_through():
+    broker = _Broker([])
+    _equity_order_history(broker, limit=25)
+    assert broker.limit == 25
+
+
+def test_history_is_posted_as_recent_orders():
+    from app import trading_db as tdb
+
+    resp = mock.Mock(ok=True, status_code=200, content=b"{}")
+    resp.json.return_value = {"ok": True, "data": {}}
+    with mock.patch.object(tdb.requests, "post", return_value=resp) as p:
+        tdb.post_orders(open_orders=[], recent_orders=[dict(FILLED)])
+        body = p.call_args.kwargs["json"]
+
+    # recent_orders is the key db-orders buckets into stock_orders
+    assert body["recent_orders"][0]["id"] == "ord-1"
+    assert "open_orders" not in body


### PR DESCRIPTION
## What's wrong

`historical_orders` in the Trading DB is frozen at **2026-07-02** — 604 rows that the engine never wrote. Those came from a one-off backfill.

The sync only ever posted the *open* book:

```python
post_orders(
    open_orders=open_orders,                    # ← open only
    recent_option_orders=options_open_orders,
)
```

An equity order stops being "open" the moment it fills, so nothing ever reaches `historical_orders`. Right now `open_orders` is empty, so the equity half of every sync is a no-op. Option orders stayed current only because *all* of them are sent, not just open ones — hence `historical_option_orders` reaching 7/29 while stock orders sat a month behind.

This is separate from the `/db-orders` timeouts (fixed in allocation-manager#99) — batching makes the write land, but there was never anything new in it.

## The fix

Post `recent_orders` from `broker.order_history()`, which already exists on `RobinhoodTrader` and returns the right shape — it simply had no caller in the sync path.

One field needs translating. `order_history()` names the average fill price `price`, but the DB normalizer reads:

```js
limit_price:   toNum(o.limit_price ?? o.price) ?? 0,
average_price: toNum(o.average_price),
```

So a straight passthrough leaves `average_price` null, and `computeStockPnl`'s `average_price ?? limit_price` would silently fall back to the limit — wrong for market orders, where `limit_price` is 0. `_equity_order_history()` copies it across, without clobbering an `average_price` the broker already set.

A history fetch failure is logged and skipped rather than costing the rest of the sync. `EQUITY_HISTORY_LIMIT` (default 200) bounds it.

## Tests

104 pass, 7 new — the `price` → `average_price` copy, not overwriting an existing value, market orders with no price, broker failure, a broker lacking `order_history`, and that the payload lands under `recent_orders` (the key `db-orders` buckets into `stock_orders`).

## Verify after deploy

```bash
curl -s "https://5thstreetcapital.netlify.app/.netlify/functions/db-orders?scope=historical&limit=1000" \
  | python3 -c "import json,sys; o=json.load(sys.stdin)['data']['historical_orders']; print(len(o), max(x['created_at'] for x in o))"
```

`newest` should move off `2026-07-02` within one sync interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trading history now includes recently filled equity orders alongside open and option orders.
  * Orders correctly retain existing average prices while filling missing values from available price data.
  * Synchronization continues safely when order history is unavailable or the broker request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->