### PR TITLE
fix: enforce a real dollar limit and stop silent order divergence (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ POLL_INTERVAL_SECONDS=30
 DRY_RUN=true
 ENGINE_ENABLED=true
 ENGINE_BROKER=alpaca
+# Per-order limits. The share cap alone bounds no dollar amount (50 shares of a
+# $1,000 stock is a $50k order); set MAX_ORDER_NOTIONAL to cap the dollars.
+# 0 disables the dollar cap. With it set, an order the engine cannot price
+# (market order, no live quote) is skipped rather than submitted unbounded.
+MAX_ORDER_QTY=50
+MAX_ORDER_NOTIONAL=0
 
 # === Order-mutation routes (lookup / replace / cancel) ===
 # Bearer token gating /api/robinhood/orders/* — fail closed: unset => 503.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Broker defaults to `DEFAULT_BROKER` env var. Append `/alpaca` or `/robinhood` to
 | `DRY_RUN` | Log orders without submitting | `true` |
 | `ENGINE_ENABLED` | Run background engine loop | `true` |
 | `ENGINE_BROKER` | Broker for engine reconciliation | `alpaca` |
+| `MAX_ORDER_QTY` | Per-order share cap (orders above it are trimmed) | `50` |
+| `MAX_ORDER_NOTIONAL` | Per-order dollar cap; `0` disables. When set, an order with no limit price and no live quote is skipped rather than submitted unbounded | `0` |
 | `PORT` | Server port | `10000` |
 
 ## Service boundaries

--- a/app/background.py
+++ b/app/background.py
@@ -370,6 +370,7 @@ def start_engine_thread(app):
                             dry_run=config["DRY_RUN"],
                             data_broker=data_broker,
                             max_order_qty=config["MAX_ORDER_QTY"],
+                            max_order_notional=config.get("MAX_ORDER_NOTIONAL"),
                             risk_subject=risk_subject,
                         )
                         _engine_status["last_error"] = None

--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,10 @@ class Config:
     ENGINE_BROKER = os.getenv("ENGINE_BROKER", "robinhood")
     DATA_BROKER = os.getenv("DATA_BROKER", "alpaca")
     MAX_ORDER_QTY = int(os.getenv("MAX_ORDER_QTY", "50"))
+    # Dollar cap per order. A share cap alone bounds nothing in dollars — 50
+    # shares of a $1,000 stock is a $50k order. 0 (the default) disables it, so
+    # an unconfigured deploy keeps the share-cap-only behaviour.
+    MAX_ORDER_NOTIONAL = float(os.getenv("MAX_ORDER_NOTIONAL", "0"))
 
     # -- S3 (order event storage) --
     S3_BUCKET = os.getenv("S3_BUCKET", "")

--- a/app/engine.py
+++ b/app/engine.py
@@ -17,6 +17,116 @@ log = logging.getLogger(__name__)
 DRIFT_THRESHOLD = 0.08  # 8 %
 
 
+def order_qty(order: dict) -> float | None:
+    """Read an order's size from either key name, or None if it has neither.
+
+    The runtime service emits `quantity`, the broker book emits `qty`, and both
+    dict shapes reach the engine. Every size read goes through here so a
+    key-name mismatch degrades to a skip rather than a KeyError mid-batch.
+
+    Args:
+        order: order dict from either source.
+
+    Returns:
+        The size as a float, or None when absent/unparseable.
+    """
+    raw = order.get("quantity")
+    if raw is None:
+        raw = order.get("qty")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def apply_order_limits(
+    order: dict,
+    max_qty: float | None = None,
+    max_notional: float | None = None,
+    price: float | None = None,
+) -> tuple[dict | None, dict | None]:
+    """Clamp one order to the share and dollar limits.
+
+    Both limits are enforced against the *effective* size: the dollar cap uses
+    the order's own `limit_price` when it has one, otherwise `price` (the last
+    quote seen this tick). A market order with no resolvable price cannot be
+    bounded in dollars, so it is skipped rather than submitted unbounded —
+    fail closed, since an unpriced order is exactly the case the dollar cap
+    exists to catch. With `max_notional` unset, that path never triggers and
+    the share cap behaves as it always has.
+
+    Args:
+        order: desired order dict; not mutated.
+        max_qty: maximum shares, or None for no share cap.
+        max_notional: maximum dollar value, or None for no dollar cap.
+        price: reference price used when the order carries no limit price.
+
+    Returns:
+        `(limited_order, adjustment)`. `limited_order` is None when the order
+        must be dropped; `adjustment` is None when the order passed untouched,
+        else a dict with `action` ("capped"/"skipped"), `reason`, and the
+        requested/effective sizes for the reconciliation report.
+    """
+    qty = order_qty(order)
+    symbol = order.get("symbol", "?")
+    if qty is None or qty <= 0:
+        return None, {
+            "symbol": symbol, "side": order.get("side"), "action": "skipped",
+            "reason": "no_quantity", "requested_qty": qty, "effective_qty": 0,
+        }
+
+    ref_price = order.get("limit_price") or price
+    try:
+        ref_price = float(ref_price) if ref_price else None
+    except (TypeError, ValueError):
+        ref_price = None
+
+    effective, reason = qty, None
+
+    if max_notional:
+        if not ref_price or ref_price <= 0:
+            return None, {
+                "symbol": symbol, "side": order.get("side"), "action": "skipped",
+                "reason": "unpriceable_under_notional_limit",
+                "requested_qty": qty, "effective_qty": 0,
+            }
+        allowed = max_notional / ref_price
+        if allowed < effective:
+            effective, reason = allowed, "notional_limit"
+
+    if max_qty is not None and max_qty < effective:
+        effective, reason = float(max_qty), "qty_limit"
+
+    # Round down — rounding up would breach the very limit being enforced.
+    # Fractional sizes stay fractional; whole-share orders stay whole.
+    if float(qty).is_integer():
+        effective = float(int(effective))
+
+    def _normalized(size: float) -> dict:
+        # One size key survives, always `quantity`, so downstream reads and
+        # the broker payload can't disagree about which key holds the size.
+        out = dict(order)
+        out["quantity"] = size
+        out.pop("qty", None)
+        return out
+
+    if reason is None:
+        return _normalized(qty), None
+
+    if effective <= 0:
+        return None, {
+            "symbol": symbol, "side": order.get("side"), "action": "skipped",
+            "reason": f"{reason}_below_one_unit", "requested_qty": qty,
+            "effective_qty": 0, "limit_price": ref_price,
+        }
+
+    return _normalized(effective), {
+        "symbol": symbol, "side": order.get("side"), "action": "capped",
+        "reason": reason, "requested_qty": qty, "effective_qty": effective,
+        "limit_price": ref_price,
+    }
+
+
 class AllocationEngine:
     def __init__(
         self,
@@ -25,6 +135,7 @@ class AllocationEngine:
         dry_run: bool = True,
         data_broker: BrokerClient | None = None,
         max_order_qty: int = 50,
+        max_order_notional: float | None = None,
         risk_subject: RiskSubject | None = None,
     ):
         self.trader = trader          # execution broker (Robinhood)
@@ -32,7 +143,15 @@ class AllocationEngine:
         self.runtime = runtime
         self.dry_run = dry_run
         self.max_order_qty = max_order_qty
+        # None/0 disables the dollar cap, so an unconfigured deploy behaves
+        # exactly as it did before this limit existed.
+        self.max_order_notional = float(max_order_notional or 0) or None
         self._last_snapshot_key: str | None = None
+        self._prices: dict[str, float] = {}
+        self._reported_adjustments: set[tuple] = set()
+        # Last tick's limit/submission outcomes — read by the health endpoint
+        # and the logs so a capped order is never a silent divergence.
+        self.last_execution_report: dict = {}
 
         # Risk event bus — observers attach here
         self.risk_subject = risk_subject or RiskSubject()
@@ -65,6 +184,13 @@ class AllocationEngine:
         market_data = self._fetch_market_data()
         self._log_tick_summary(current_positions, current_orders, market_data)
 
+        # Limits are applied to the *desired* set, before reconciliation, so a
+        # capped order reconciles against its own open order. Capping inside
+        # _execute() left the desired key (100 shares) permanently unmatched by
+        # the open order it produced (50 shares), so every fresh snapshot
+        # resubmitted another capped clone while cancellation stayed disabled.
+        desired_orders, adjustments = self._limit_orders(desired_orders, snapshot_key)
+
         # --- drift check ---
         if market_data and current_positions:
             self._check_drift(current_positions, market_data, snapshot_key)
@@ -78,13 +204,20 @@ class AllocationEngine:
             rebalance_orders, rebalance_cancels = self._rebalancer.drain()
             if rebalance_orders:
                 log.info("Adding %d rebalance order(s) from drift events", len(rebalance_orders))
+                # Drift-triggered orders reach the broker through the same
+                # submit path, so they take the same limits.
+                rebalance_orders, rebalance_adj = self._limit_orders(
+                    rebalance_orders, snapshot_key
+                )
+                adjustments.extend(rebalance_adj)
                 new_orders.extend(rebalance_orders)
             if rebalance_cancels:
                 log.info("Adding %d cancel(s) from shadow depeg events", len(rebalance_cancels))
                 for cancel in rebalance_cancels:
                     stale_order_ids.append(cancel["order_id"])
 
-        self._execute(new_orders, stale_order_ids)
+        self._report_adjustments(adjustments, snapshot_key)
+        self._execute(new_orders, stale_order_ids, adjustments)
 
         # --- Options order reconciliation (dry-run only) ---
         try:
@@ -110,10 +243,89 @@ class AllocationEngine:
                 price = metrics.get("price")
                 if price is not None:
                     self.risk_subject.set_price(symbol, float(price))
+                    # Cached so the dollar limit can price a market order,
+                    # which carries no limit_price of its own.
+                    self._prices[symbol.upper()] = float(price)
             return data
         except Exception:
             log.exception("Failed to fetch market data — skipping drift check")
             return {}
+
+    def _limit_orders(
+        self, orders: list[dict], snapshot_key: str | None,
+    ) -> tuple[list[dict], list[dict]]:
+        """Clamp every order to the share/dollar limits before reconciliation.
+
+        Args:
+            orders: desired orders as received from the runtime service.
+            snapshot_key: snapshot the orders belong to, stamped onto events.
+
+        Returns:
+            `(orders_within_limits, adjustments)` — orders dropped entirely are
+            absent from the first list and recorded in the second.
+        """
+        kept, adjustments = [], []
+        for order in orders:
+            limited, adjustment = apply_order_limits(
+                order,
+                max_qty=self.max_order_qty,
+                max_notional=self.max_order_notional,
+                price=self._prices.get(str(order.get("symbol", "")).upper()),
+            )
+            if adjustment:
+                adjustments.append(adjustment)
+            if limited is not None:
+                kept.append(limited)
+        return kept, adjustments
+
+    def _report_adjustments(
+        self, adjustments: list[dict], snapshot_key: str | None,
+    ) -> None:
+        """Log limit adjustments and publish the newly-appearing ones as events.
+
+        The runtime service asked for a size the engine would not submit; that
+        divergence rides the risk bus so operators (and the runtime service's
+        own reconciliation) see it instead of inferring it from fill sizes.
+
+        A standing over-limit request re-derives the same adjustment on every
+        snapshot, so only adjustments that differ from the previous tick's set
+        raise an event — the alert marks the divergence appearing or changing
+        shape, not its continued existence. Every one is still logged.
+        """
+        current = set()
+        for adjustment in adjustments:
+            requested = adjustment.get("requested_qty") or 0
+            effective = adjustment.get("effective_qty") or 0
+            capped = adjustment["action"] == "capped"
+            message = (
+                f"{adjustment['symbol']} {adjustment.get('side') or '?'} "
+                f"{'capped' if capped else 'skipped'}: requested {requested:g}"
+                + (f" -> {effective:g}" if capped else "")
+                + f" ({adjustment['reason']}; max_order_qty={self.max_order_qty}, "
+                f"max_order_notional={self.max_order_notional})"
+            )
+            log.warning("ORDER LIMIT: %s", message)
+
+            key = (adjustment["symbol"], adjustment.get("side"),
+                   adjustment["action"], adjustment["reason"],
+                   requested, effective)
+            current.add(key)
+            if key in self._reported_adjustments:
+                continue
+
+            # Shortfall as a fraction of the request, so RiskEvent.severity
+            # reads a dropped order as critical and a trim as warning/info.
+            shortfall = (requested - effective) / requested if requested else 1.0
+            self.risk_subject.notify(RiskEvent(
+                event_type=(RiskEventType.ORDER_CAPPED if capped
+                            else RiskEventType.ORDER_SKIPPED),
+                symbol=adjustment["symbol"],
+                drift_pct=shortfall,
+                message=message,
+                snapshot_key=snapshot_key,
+                metadata=dict(adjustment),
+            ))
+        self._reported_adjustments = current
 
     def _log_tick_summary(
         self,
@@ -241,10 +453,13 @@ class AllocationEngine:
         Returns (orders_to_submit, order_ids_to_cancel).
         """
         def _order_key(o: dict) -> tuple:
+            # Both sides go through order_qty so the size is compared as a
+            # float from whichever key the source used — "50" from the broker
+            # book and 50 from the runtime service are the same order.
             return (
                 o.get("symbol"),
                 o.get("side"),
-                o.get("quantity") or o.get("qty"),
+                order_qty(o),
                 o.get("limit_price"),
             )
 
@@ -252,8 +467,7 @@ class AllocationEngine:
 
         current_map: dict[tuple, dict] = {}
         for o in current_orders:
-            key = (o["symbol"], o["side"], o["qty"], o["limit_price"])
-            current_map[key] = o
+            current_map[_order_key(o)] = o
 
         stale_ids = [
             o["id"] for key, o in current_map.items() if key not in desired_keys
@@ -351,24 +565,32 @@ class AllocationEngine:
 
     # -- equity execution ----------------------------------------------------
 
-    def _execute(self, orders: list[dict], cancel_ids: list[str]):
-        """Log stale orders and submit new ones. Cancellation is disabled."""
+    def _execute(
+        self,
+        orders: list[dict],
+        cancel_ids: list[str],
+        adjustments: list[dict] | None = None,
+    ):
+        """Submit new orders and log stale ones. Cancellation is disabled.
+
+        Orders arrive already clamped by `_limit_orders`. A broker failure on
+        one order is logged and the batch continues — one rejected symbol must
+        not strand every order behind it.
+
+        Args:
+            orders: orders to submit, already within the configured limits.
+            cancel_ids: stale broker order ids (logged only — cancel disabled).
+            adjustments: limit adjustments from this tick, for the report.
+
+        Returns:
+            The broker results for successfully submitted orders.
+        """
         if cancel_ids:
             log.info("Found %d stale order(s) — cancellation disabled, skipping: %s",
                      len(cancel_ids), cancel_ids)
 
-        results = []
+        results, failures = [], []
         for order in orders:
-            # Enforce max order quantity
-            qty = order["quantity"]
-            if qty > self.max_order_qty:
-                log.warning(
-                    "Order capped: %s %s qty %g -> %d (max_order_qty=%d)",
-                    order["side"], order["symbol"], qty,
-                    self.max_order_qty, self.max_order_qty,
-                )
-                order["quantity"] = self.max_order_qty
-
             if self.dry_run:
                 otype = order.get("order_type", "market")
                 lp = order.get("limit_price")
@@ -376,8 +598,40 @@ class AllocationEngine:
                 log.info("[DRY RUN] Would submit: %s %s %s %s @ %s",
                          order["side"], order["quantity"],
                          order["symbol"], otype, price_str)
-            else:
-                result = self.trader.submit_order(order)
-                results.append(result)
+                continue
+
+            try:
+                results.append(self.trader.submit_order(order))
+            except Exception as e:  # noqa: BLE001 — one bad order, not the batch
+                symbol = order.get("symbol", "?")
+                log.exception("submit_order failed for %s — continuing batch", symbol)
+                failures.append({"symbol": symbol, "side": order.get("side"),
+                                 "quantity": order_qty(order), "error": str(e)})
+                self.risk_subject.notify(RiskEvent(
+                    event_type=RiskEventType.ORDER_REJECTED,
+                    symbol=symbol,
+                    drift_pct=1.0,
+                    message=f"{symbol} submit_order failed: {e}",
+                    snapshot_key=self._last_snapshot_key,
+                    metadata={"order": {k: order.get(k) for k in
+                                        ("symbol", "side", "quantity", "limit_price")}},
+                ))
+
+        adjustments = adjustments or []
+        self.last_execution_report = {
+            "snapshot_key": self._last_snapshot_key,
+            "dry_run": self.dry_run,
+            "submitted": len(results),
+            "failed": failures,
+            "capped": [a for a in adjustments if a["action"] == "capped"],
+            "skipped": [a for a in adjustments if a["action"] == "skipped"],
+        }
+        if failures or adjustments:
+            log.warning(
+                "Execution report: %d submitted, %d failed, %d capped, %d skipped",
+                self.last_execution_report["submitted"], len(failures),
+                len(self.last_execution_report["capped"]),
+                len(self.last_execution_report["skipped"]),
+            )
 
         return results

--- a/app/enums.py
+++ b/app/enums.py
@@ -51,3 +51,5 @@ class RiskEventType(StrEnum):
     PRICE_DEPEG = "price_depeg"             # live price diverges from cached/stale price
     POSITION_LIMIT = "position_limit"       # position exceeds concentration limit
     ORDER_REJECTED = "order_rejected"       # broker rejected an order
+    ORDER_CAPPED = "order_capped"           # order shrunk by the qty/notional limit
+    ORDER_SKIPPED = "order_skipped"         # order dropped before submission

--- a/tests/test_engine_order_limits.py
+++ b/tests/test_engine_order_limits.py
@@ -1,0 +1,315 @@
+"""Tests for the engine's per-order share/dollar limits and submit resilience.
+
+No network: fake broker and runtime clients stand in. The point of these tests
+is that no order leaves the engine above either limit, that a clamped order
+does not re-fire on every snapshot, and that one broker failure cannot strand
+the rest of the batch.
+"""
+
+import pytest
+
+from app.engine import AllocationEngine, apply_order_limits, order_qty
+from app.enums import RiskEventType
+from app.risk.observer import RiskObserver, RiskSubject
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+
+class FakeRuntime:
+    def __init__(self, orders, snapshot_key="snap-1", prices=None):
+        self._orders = orders
+        self.snapshot_key = snapshot_key
+        self._prices = prices or {}
+
+    def state(self):
+        return {"snapshot_key": self.snapshot_key}
+
+    def orders(self):
+        return {"stock_orders": list(self._orders), "option_orders": []}
+
+    def market_data(self):
+        return {"tickers": {s: {"price": p, "drift_pct": 0.0}
+                            for s, p in self._prices.items()}}
+
+
+class FakeBroker:
+    """Records submissions; `fail_on` symbols raise instead."""
+
+    def __init__(self, open_orders=None, fail_on=()):
+        self._open = open_orders or []
+        self.fail_on = set(fail_on)
+        self.submitted = []
+
+    def open_orders(self):
+        return list(self._open)
+
+    def positions(self):
+        return []
+
+    def submit_order(self, order):
+        if order["symbol"] in self.fail_on:
+            raise RuntimeError(f"broker rejected {order['symbol']}")
+        self.submitted.append(order)
+        return {"id": f"ord-{len(self.submitted)}", "state": "queued"}
+
+
+class RecordingObserver(RiskObserver):
+    def __init__(self):
+        self.events = []
+
+    def update(self, symbol, price):
+        pass
+
+    def on_risk_event(self, event):
+        self.events.append(event)
+
+
+def _engine(runtime, broker, **kwargs):
+    subject = RiskSubject()
+    observer = RecordingObserver()
+    subject.attach(observer)
+    engine = AllocationEngine(trader=broker, runtime=runtime, dry_run=False,
+                              risk_subject=subject, **kwargs)
+    return engine, observer
+
+
+def _order(symbol="AAPL", side="BUY", quantity=100, limit_price=10.0):
+    return {"symbol": symbol, "side": side, "quantity": quantity,
+            "limit_price": limit_price}
+
+
+# --------------------------------------------------------------------------- #
+# order_qty — the quantity/qty key split
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("order,expected", [
+    ({"quantity": 10}, 10.0),
+    ({"qty": 10}, 10.0),
+    ({"qty": "10"}, 10.0),          # broker book stringifies
+    ({"quantity": 0, "qty": 5}, 0.0),  # explicit 0 wins over the alias
+    ({}, None),
+    ({"quantity": None, "qty": None}, None),
+    ({"quantity": "abc"}, None),
+])
+def test_order_qty_reads_either_key(order, expected):
+    assert order_qty(order) == expected
+
+
+def test_execute_does_not_keyerror_on_qty_only_order():
+    """A broker-shaped order (`qty`) must not blow up the batch."""
+    broker = FakeBroker()
+    runtime = FakeRuntime([{"symbol": "AAPL", "side": "BUY", "qty": 5,
+                            "limit_price": 10.0}])
+    engine, _ = _engine(runtime, broker, max_order_qty=50)
+    engine.tick()
+    assert len(broker.submitted) == 1
+    assert broker.submitted[0]["quantity"] == 5
+
+
+# --------------------------------------------------------------------------- #
+# apply_order_limits — the pure clamp
+# --------------------------------------------------------------------------- #
+
+def test_qty_limit_trims_and_reports():
+    limited, adj = apply_order_limits(_order(quantity=100), max_qty=50)
+    assert limited["quantity"] == 50
+    assert adj == {"symbol": "AAPL", "side": "BUY", "action": "capped",
+                   "reason": "qty_limit", "requested_qty": 100.0,
+                   "effective_qty": 50.0, "limit_price": 10.0}
+
+
+def test_notional_limit_binds_before_qty_limit():
+    """50 shares of a $1,000 stock is a $50k order — the bug from issue #55."""
+    limited, adj = apply_order_limits(
+        _order(quantity=100, limit_price=1000.0), max_qty=50, max_notional=10_000)
+    assert limited["quantity"] == 10          # 10 x $1,000 = $10,000
+    assert adj["reason"] == "notional_limit"
+
+
+def test_notional_limit_rounds_down_never_up():
+    limited, _ = apply_order_limits(
+        _order(quantity=100, limit_price=300.0), max_notional=1000)
+    assert limited["quantity"] == 3           # 3.33 -> 3, so $999 <= $1,000
+    assert limited["quantity"] * 300.0 <= 1000
+
+
+def test_order_within_both_limits_passes_untouched():
+    order = _order(quantity=10, limit_price=10.0)
+    limited, adj = apply_order_limits(order, max_qty=50, max_notional=10_000)
+    assert adj is None
+    assert limited == order
+
+
+def test_market_order_prices_off_the_live_quote():
+    order = {"symbol": "AAPL", "side": "BUY", "quantity": 100}
+    limited, adj = apply_order_limits(order, max_notional=1000, price=100.0)
+    assert limited["quantity"] == 10
+    assert adj["reason"] == "notional_limit"
+
+
+def test_unpriceable_order_is_skipped_when_a_dollar_cap_is_set():
+    """Fail closed: no limit price and no quote means no dollar bound."""
+    order = {"symbol": "AAPL", "side": "BUY", "quantity": 100}
+    limited, adj = apply_order_limits(order, max_qty=50, max_notional=1000)
+    assert limited is None
+    assert adj["reason"] == "unpriceable_under_notional_limit"
+
+
+def test_unpriceable_order_passes_when_no_dollar_cap_is_set():
+    """Byte-for-byte prior behaviour when MAX_ORDER_NOTIONAL is unset."""
+    order = {"symbol": "AAPL", "side": "BUY", "quantity": 100}
+    limited, adj = apply_order_limits(order, max_qty=50)
+    assert limited["quantity"] == 50
+    assert adj["action"] == "capped"
+
+
+def test_notional_below_one_share_is_skipped_not_zeroed():
+    limited, adj = apply_order_limits(
+        _order(quantity=10, limit_price=5000.0), max_notional=1000)
+    assert limited is None
+    assert adj["reason"] == "notional_limit_below_one_unit"
+
+
+def test_fractional_order_stays_fractional():
+    limited, _ = apply_order_limits(
+        _order(quantity=2.5, limit_price=100.0), max_notional=100)
+    assert limited["quantity"] == pytest.approx(1.0)
+
+
+def test_missing_quantity_is_skipped():
+    limited, adj = apply_order_limits({"symbol": "AAPL", "side": "BUY"}, max_qty=50)
+    assert limited is None
+    assert adj["reason"] == "no_quantity"
+
+
+def test_limited_order_carries_one_size_key():
+    limited, _ = apply_order_limits(
+        {"symbol": "AAPL", "side": "BUY", "qty": 100, "limit_price": 10.0},
+        max_qty=50)
+    assert limited["quantity"] == 50
+    assert "qty" not in limited
+
+
+def test_limits_do_not_mutate_the_caller_s_order():
+    order = _order(quantity=100)
+    apply_order_limits(order, max_qty=50)
+    assert order["quantity"] == 100
+
+
+# --------------------------------------------------------------------------- #
+# engine integration — reconciliation, events, batch resilience
+# --------------------------------------------------------------------------- #
+
+def test_capped_order_is_not_resubmitted_on_the_next_snapshot():
+    """The capped order must reconcile against the open order it produced.
+
+    Capping inside _execute() left the desired key (100) unmatched by the open
+    order it created (50), so every fresh snapshot submitted another 50.
+    """
+    broker = FakeBroker()
+    runtime = FakeRuntime([_order(quantity=100)])
+    engine, _ = _engine(runtime, broker, max_order_qty=50)
+
+    engine.tick()
+    assert len(broker.submitted) == 1
+    assert broker.submitted[0]["quantity"] == 50
+
+    # The capped order is now live in the broker book; a new snapshot arrives.
+    broker._open = [{"symbol": "AAPL", "side": "BUY", "qty": 50,
+                     "limit_price": 10.0, "id": "ord-1"}]
+    runtime.snapshot_key = "snap-2"
+    engine.tick()
+    assert len(broker.submitted) == 1, "capped order re-fired on the next snapshot"
+
+
+def test_capping_emits_a_risk_event_and_lands_in_the_report():
+    broker = FakeBroker()
+    runtime = FakeRuntime([_order(quantity=100)])
+    engine, observer = _engine(runtime, broker, max_order_qty=50)
+    engine.tick()
+
+    capped = [e for e in observer.events
+              if e.event_type == RiskEventType.ORDER_CAPPED]
+    assert len(capped) == 1
+    assert capped[0].symbol == "AAPL"
+    assert capped[0].snapshot_key == "snap-1"
+    assert capped[0].metadata["requested_qty"] == 100.0
+    assert capped[0].metadata["effective_qty"] == 50.0
+
+    report = engine.last_execution_report
+    assert report["submitted"] == 1
+    assert len(report["capped"]) == 1
+    assert report["skipped"] == []
+
+
+def test_skipped_order_emits_an_event_and_is_never_submitted():
+    broker = FakeBroker()
+    # Market order (no limit price), no quote for the symbol, dollar cap on.
+    runtime = FakeRuntime([{"symbol": "AAPL", "side": "BUY", "quantity": 100}])
+    engine, observer = _engine(runtime, broker, max_order_qty=50,
+                               max_order_notional=10_000)
+    engine.tick()
+
+    assert broker.submitted == []
+    assert [e.event_type for e in observer.events] == [RiskEventType.ORDER_SKIPPED]
+    assert engine.last_execution_report["skipped"][0]["symbol"] == "AAPL"
+
+
+def test_engine_prices_market_orders_from_the_tick_s_market_data():
+    broker = FakeBroker()
+    runtime = FakeRuntime([{"symbol": "AAPL", "side": "BUY", "quantity": 100}],
+                          prices={"AAPL": 100.0})
+    engine, _ = _engine(runtime, broker, max_order_qty=50,
+                        max_order_notional=1000)
+    engine.tick()
+    assert [o["quantity"] for o in broker.submitted] == [10]
+
+
+def test_one_broker_failure_does_not_strand_the_rest_of_the_batch():
+    broker = FakeBroker(fail_on={"AAPL"})
+    runtime = FakeRuntime([_order(symbol="AAPL", quantity=10),
+                           _order(symbol="MSFT", quantity=10),
+                           _order(symbol="NVDA", quantity=10)])
+    engine, observer = _engine(runtime, broker, max_order_qty=50)
+    engine.tick()
+
+    assert [o["symbol"] for o in broker.submitted] == ["MSFT", "NVDA"]
+    rejected = [e for e in observer.events
+                if e.event_type == RiskEventType.ORDER_REJECTED]
+    assert len(rejected) == 1 and rejected[0].symbol == "AAPL"
+    assert engine.last_execution_report["failed"][0]["symbol"] == "AAPL"
+
+
+def test_standing_cap_alerts_once_then_again_when_it_changes_shape():
+    """A steady over-limit request must not re-alert on every snapshot."""
+    broker = FakeBroker()
+    runtime = FakeRuntime([_order(quantity=100)])
+    engine, observer = _engine(runtime, broker, max_order_qty=50)
+
+    engine.tick()
+    runtime.snapshot_key = "snap-2"
+    engine.tick()
+    assert len(observer.events) == 1, "standing cap re-alerted unchanged"
+
+    # The runtime service now asks for a different size — a new divergence.
+    runtime._orders = [_order(quantity=200)]
+    runtime.snapshot_key = "snap-3"
+    engine.tick()
+    assert len(observer.events) == 2
+    assert observer.events[1].metadata["requested_qty"] == 200.0
+
+    # It falls back within the limit, then breaches again — alert again.
+    runtime._orders = [_order(quantity=10)]
+    runtime.snapshot_key = "snap-4"
+    engine.tick()
+    runtime._orders = [_order(quantity=200)]
+    runtime.snapshot_key = "snap-5"
+    engine.tick()
+    assert len(observer.events) == 3
+
+
+def test_dollar_cap_defaults_off():
+    engine, _ = _engine(FakeRuntime([]), FakeBroker())
+    assert engine.max_order_notional is None


### PR DESCRIPTION
Closes #55.

## What was still live

Five of the nine findings in #55 were against `scripts/refresh_pickle.py`
(hardcoded Netlify creds, `pickle.load`, plaintext password `input()`, no
error handling on login/upload, unencrypted session upload). **That file no
longer exists on `main`** — it was removed with the rest of the direct-RH
login flow when the auth-service box took over (`CLAUDE.md:57-61`). I verified
nothing on `main` imports `pickle`, calls `input()` for a secret, or carries
the token.

⚠️ **The leaked Netlify token still needs rotating.** Deleting the file did
not un-leak it — it is in git history and must be treated as compromised.
That is the one item from #55 this PR cannot fix.

The four `app/engine.py` findings (#4, #5, #8, #9) were all still live. This
PR fixes them.

## #4 — "dollar limit" that enforced no dollar limit

`max_order_qty=50` bounds shares, not dollars: 50 shares of a $1,000 stock is
a $50,000 order. Added `MAX_ORDER_NOTIONAL` (config + `.env.example` +
README), enforced against `limit_price`, falling back to the tick's live quote
for market orders. It rounds **down**, never up. `0`/unset disables it, so an
unconfigured deploy behaves exactly as it does today.

If a dollar cap is configured and the order cannot be priced at all (market
order, no quote), the order is **skipped**, not submitted — an unpriceable
order is precisely the case the dollar cap exists to catch.

## #5 — silent order modification (and the resubmission bug behind it)

While fixing the "divergence isn't tracked" complaint I found a live bug it
was hiding. `_execute()` capped the order *after* `_reconcile()` had already
keyed the desired set on the uncapped size. So the desired key (100 shares)
never matched the open order the cap produced (50 shares) — every fresh
snapshot re-submitted another 50-share clone, and since cancellation is
disabled the capped clones accumulated in the book unbounded.

Limits now apply to the desired set **before** reconciliation, so a capped
order reconciles against its own open order. `test_capped_order_is_not_
resubmitted_on_the_next_snapshot` pins this.

On the tracking itself: a capped or skipped order now raises
`ORDER_CAPPED` / `ORDER_SKIPPED` on the risk bus and lands in
`engine.last_execution_report` (`submitted` / `failed` / `capped` /
`skipped`). Only *new or changed* adjustments raise an event — a standing
over-limit request would otherwise re-alert every snapshot, and severity maps
to shortfall, which bypasses the Telegram debounce. Every adjustment is still
logged.

## #8 — `quantity` vs `qty`

`_reconcile` handled both keys; `_execute` did `order["quantity"]`
unconditionally, so a broker-shaped order would have raised `KeyError` and
taken down the batch. All size reads now go through `order_qty()`, which
reads either key and returns `None` rather than raising. Orders leaving the
limiter carry exactly one size key. As a side effect `_reconcile` now compares
sizes as floats, so `"50"` from the broker book and `50` from the runtime
service match instead of forking.

## #9 — `submit_order` halting the batch

Wrapped: the failure is logged, emits `ORDER_REJECTED`, records into the
report, and the remaining orders still go out.

## Structure

The clamp is a pure module-level function, `apply_order_limits(order,
max_qty, max_notional, price) -> (limited_order | None, adjustment | None)`,
so the limit rules are testable without a broker, a runtime service, or a
tick. It does not mutate its input.

## Tests

27 new cases in `tests/test_engine_order_limits.py` covering the clamp
(both limits, rounding direction, sub-one-unit, fractional, unpriceable,
no-mutation), the key split, and engine-level behaviour (no resubmission,
event emission and dedupe, market-order pricing from tick data, batch
survives a broker failure).

`python3 -m pytest tests/ -q` → **109 passed** (82 pre-existing + 27 new).

Note: `python3 -m pytest` from the repo root still fails collection on a
pre-existing basename clash between `auth-service/tests/test_server.py` and
`robinhood-mcp/tests/test_server.py` — untouched here.

## Not in this PR

- Rotating the Netlify token (#55 item 1) — needs a human with the account.
- The pre-existing unused `OrderSide` import in `app/engine.py` (ruff F401) —
  left alone to keep the diff focused.

## Follow-up

Opened #111 — trailing stops are mis-sized for symbols with little price
history. `compute_trail_percents()` trusts σ regardless of sample size, and
because trails are ratios to a portfolio-wide mean, one thin-history σ
mis-sizes every other symbol's stop while the budget invariant still checks
out. Latent until a σ source is wired; worth fixing before that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-order share and dollar limits.
  * Orders exceeding limits are capped or skipped when pricing is unavailable.
  * Limit adjustments and skipped orders appear in risk and execution reports.
  * Rebalancing and reconciliation now respect configured order limits.

* **Bug Fixes**
  * Order submissions continue when an individual broker request fails.
  * Duplicate risk alerts are suppressed.

* **Documentation**
  * Documented the new order-limit settings and their default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->